### PR TITLE
Add rules for building Artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,15 +28,14 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
-  - 7z a MaterialX-v$(appveyor_build_version).zip %APPVEYOR_BUILD_FOLDER%\installed
+  - 7z a MaterialX_ADSK.zip C:\Projects\MaterialX\build\installed
 
 artifacts:
-- path: MaterialX-v$(appveyor_build_version).zip
-  name: MaterialXCore
+- path: MaterialX_ADSK.zip
+  name: MaterialX_ADSK
 
 deploy:
 - provider: GitHub
-  release: MaterialX-v$(appveyor_build_version)
   prerelease: true
   auth_token:
     secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,3 +26,16 @@ build_script:
   - cmake --build . --target install --config %CONFIGURATION%
   - ctest --output-on-failure --build-config %CONFIGURATION%
   - cmake -E chdir ../python/MaterialXTest python main.py
+
+after_build:
+
+artifacts:
+- path: installed
+  name: MaterialX
+
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh
+  on:
+    branch: adsk_update

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: "{build}"
+version: 1.36."{build}"
 os: Visual Studio 2017
 clone_folder: C:\Projects\MaterialX
 
@@ -28,14 +28,15 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
+  - 7z a MaterialXCore.zip %APPVEYOR_BUILD_FOLDER%\install
 
 artifacts:
-- path: installed
-  name: MaterialX
+- path: MaterialXCore.zip
+  name: MaterialXCore
 
 deploy:
 - provider: GitHub
+  release: MaterialX-v$(appveyor_build_version)
+  prerelease: true
   auth_token:
     secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh
-  on:
-    branch: adsk_update

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,10 +28,10 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
-  - 7z a MaterialXCore.zip %APPVEYOR_BUILD_FOLDER%\install
+  - 7z a MaterialX-v$(appveyor_build_version).zip %APPVEYOR_BUILD_FOLDER%\installed
 
 artifacts:
-- path: MaterialXCore.zip
+- path: MaterialX-v$(appveyor_build_version).zip
   name: MaterialXCore
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,10 +15,10 @@ environment:
 
 configuration:
   - Release
-    
+
 install:
   - set PATH=%PYTHON%;%PATH%
-  
+
 build_script:
   - mkdir build
   - cd build
@@ -28,10 +28,11 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
-  - 7z a C:\Projects\MaterialX\MaterialX_ADSK.zip C:\Projects\MaterialX\build\installed
+  - cd C:\Projects\MaterialX\build\installed
+  - 7z a C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip *.*
 
 artifacts:
-- path: MaterialX_ADSK.zip
+- path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip
   name: MaterialX_ADSK
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,18 +36,31 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
-  - cd C:\Projects\MaterialX\build\installed
-  - 7z a -r C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip .
+    # Go to install directory and zip it up.  Currently marked as pre-release
+    - cd C:\Projects\MaterialX\build\installed
+    - 7z a -r C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip .
 
 artifacts:
-- path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip
-  name: MaterialX_ADSK
+    # Set artifact to be created zip.  Currently marked as pre-release
+    - path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip
+      name: MaterialX_ADSK
 
 deploy:
-- provider: GitHub
-  prerelease: true
-  on:
-    VS_PLATFORM: x64
-    # branch: adsk_update_shadergen
-  auth_token:
-    secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh
+    # Deploy on main working branch
+    - provider: GitHub
+      prerelease: true
+      on:
+        VS_PLATFORM: x64
+        # Choose branch
+        branch: adsk_update_shadergen
+      auth_token:
+        secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh
+
+    # Deploy on tags
+    - provider: GitHub
+      prerelease: true
+      on:
+        VS_PLATFORM: x64
+        appveyor_repo_tag: true
+      auth_token:
+        secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,12 +6,20 @@ environment:
   matrix:
     - CMAKE_PLATFORM: "Visual Studio 14 2015"
       PYTHON: C:\Python26
+      VS_PLATFORM: x86
+      VS_COMPILER: vs2015
     - CMAKE_PLATFORM: "Visual Studio 14 2015 Win64"
       PYTHON: C:\Python27-x64
+      VS_PLATFORM: x64
+      VS_COMPILER: vs2015
     - CMAKE_PLATFORM: "Visual Studio 15 2017"
       PYTHON: C:\Python35
+      VS_PLATFORM: x86
+      VS_COMPILER: vs2017
     - CMAKE_PLATFORM: "Visual Studio 15 2017 Win64"
       PYTHON: C:\Python36-x64
+      platform: x64
+      vscompiler: vs2017
 
 configuration:
   - Release
@@ -29,16 +37,16 @@ build_script:
 
 after_build:
   - cd C:\Projects\MaterialX\build\installed
-  - 7z a -r C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip .
+  - 7z a -r C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip .
 
 artifacts:
-- path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip
+- path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%VS_PLATFORM%-%VS_COMPILER%-%APPVEYOR_BUILD_NUMBER%.zip
   name: MaterialX_ADSK
 
 deploy:
 - provider: GitHub
   prerelease: true
   on:
-    platform: x64
+    VS_PLATFORM: x64
   auth_token:
     secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ after_build:
   - 7z a C:\Projects\MaterialX\MaterialX_ADSK.zip C:\Projects\MaterialX\build\installed
 
 artifacts:
-- path: C:\Projects\MaterialX\MaterialX_ADSK.zip
+- path: MaterialX_ADSK.zip
   name: MaterialX_ADSK
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.36."{build}"
+version: 1.36.0.{build}
 os: Visual Studio 2017
 clone_folder: C:\Projects\MaterialX
 
@@ -28,10 +28,10 @@ build_script:
   - cmake -E chdir ../python/MaterialXTest python main.py
 
 after_build:
-  - 7z a MaterialX_ADSK.zip C:\Projects\MaterialX\build\installed
+  - 7z a C:\Projects\MaterialX\MaterialX_ADSK.zip C:\Projects\MaterialX\build\installed
 
 artifacts:
-- path: MaterialX_ADSK.zip
+- path: C:\Projects\MaterialX\MaterialX_ADSK.zip
   name: MaterialX_ADSK
 
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,8 @@ environment:
       VS_COMPILER: vs2017
     - CMAKE_PLATFORM: "Visual Studio 15 2017 Win64"
       PYTHON: C:\Python36-x64
-      platform: x64
-      vscompiler: vs2017
+      VS_PLATFORM: x64
+      VS_COMPILER: vs2017
 
 configuration:
   - Release
@@ -48,5 +48,6 @@ deploy:
   prerelease: true
   on:
     VS_PLATFORM: x64
+    # branch: adsk_update_shadergen
   auth_token:
     secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ build_script:
 
 after_build:
   - cd C:\Projects\MaterialX\build\installed
-  - 7z a C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip *.*
+  - 7z a -r C:\Projects\MaterialX\MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip .
 
 artifacts:
 - path: MaterialX-Windows-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%.zip
@@ -38,5 +38,7 @@ artifacts:
 deploy:
 - provider: GitHub
   prerelease: true
+  on:
+    platform: x64
   auth_token:
     secure: qg4BvNKremS4OMcbGZEjaXrumrQ+8/pJvr3WrNqM1ZQDyzvNpmUEA0ZMRkUJzeOh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
-    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip ${TRAVIS_BUILD_DIR}/installed
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip -i ${TRAVIS_BUILD_DIR}/installed/\*
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,15 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
-    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip ${TRAVIS_BUILD_DIR}/build/installed
+    - cd ${TRAVIS_BUILD_DIR}/build/installed
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip *.*
 
 deploy:
   provider: releases
   api_key:
     secure: c9kZbgxrcgNFmTh/TYn+aL4Yqww122YlGNVWaIcKdLpLlRyyrejlyOhnFF1VTnytU6CQGeH580I6IQ21auV1PCAMoD7anWT5sJa5vGo7pCAMFrEKk4PSSSF8LNWw1lHVMw96exI0JHywGx7t2fOYX0COSJab4XK8cM/0FEoJ2/rQYNVXz1oG+4F5B39Jl4zuBfI+oEeD+Q1B6LRMY52uFn1dpRIujYhihBJ3jMwKFzOB0rS/pbKSczQaa4M/HNUvCEupNLKQmnTiHv72JwXRzGsIsqbFJ7e0n6jz2Cv9eGdbVDT2fyEz7Kq8faRPB34wo4PP1DBJAkzpbvejdNvUCXHe+l0MsHbBDe6avjrR7IK1+nu5rT/HzPIqzidPunwKxABfQguYLOE2CZs4hqpwCULGdQ1GR/Hy9vCy7I6MpTw5K9VMRTyt/7MbnVlN/tDy8095Sh9GkJBZPzig7eyw37ylLibXDkmmWx+HrDLV9bP/re+NYk2bXWSHOEr8jgZyxeNJwli2p2WZaMFgfYS0AVdEoujq2b4jWawepkLm1U3UOK71NZLGVjY8tElo3j5NbB6Qbvyr9NNTQbj4BJadiGCfsp57QA1/G4UPXaWSvGWjHUnHkDyUl6AtglB9iciTc6mxxWGS57aPNCsbE+NRRV4E9abBycTeJd2nrLlej1I=
   file: ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip
+  prerelease: true
   skip_cleanup: true
   on:
     repo: autodesk-forks/MaterialX

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ deploy:
   skip_cleanup: true
   on:
     repo: autodesk-forks/MaterialX
-    branch: adsk_update_artifacts
+    # branch: adsk_update_shadergen
     condition: "$CC = gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
-    - tar -zcf ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.tar.gz -i ${TRAVIS_BUILD_DIR}/installed
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip ${TRAVIS_BUILD_DIR}/build/installed
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,34 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
+    # Go to install directory and zip up to create artifact
     - cd ${TRAVIS_BUILD_DIR}/build/installed
     - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip .
 
 deploy:
-  provider: releases
-  api_key:
-    secure: c9kZbgxrcgNFmTh/TYn+aL4Yqww122YlGNVWaIcKdLpLlRyyrejlyOhnFF1VTnytU6CQGeH580I6IQ21auV1PCAMoD7anWT5sJa5vGo7pCAMFrEKk4PSSSF8LNWw1lHVMw96exI0JHywGx7t2fOYX0COSJab4XK8cM/0FEoJ2/rQYNVXz1oG+4F5B39Jl4zuBfI+oEeD+Q1B6LRMY52uFn1dpRIujYhihBJ3jMwKFzOB0rS/pbKSczQaa4M/HNUvCEupNLKQmnTiHv72JwXRzGsIsqbFJ7e0n6jz2Cv9eGdbVDT2fyEz7Kq8faRPB34wo4PP1DBJAkzpbvejdNvUCXHe+l0MsHbBDe6avjrR7IK1+nu5rT/HzPIqzidPunwKxABfQguYLOE2CZs4hqpwCULGdQ1GR/Hy9vCy7I6MpTw5K9VMRTyt/7MbnVlN/tDy8095Sh9GkJBZPzig7eyw37ylLibXDkmmWx+HrDLV9bP/re+NYk2bXWSHOEr8jgZyxeNJwli2p2WZaMFgfYS0AVdEoujq2b4jWawepkLm1U3UOK71NZLGVjY8tElo3j5NbB6Qbvyr9NNTQbj4BJadiGCfsp57QA1/G4UPXaWSvGWjHUnHkDyUl6AtglB9iciTc6mxxWGS57aPNCsbE+NRRV4E9abBycTeJd2nrLlej1I=
-  file: ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip
-  prerelease: true
-  skip_cleanup: true
-  on:
-    repo: autodesk-forks/MaterialX
-    # Pick a branch to use.
-    branch: adsk_update_artifacts
-    #branch: adsk_update_shadergen
-    condition: "$CC = gcc"
+    # Deploy on main branch. Currently marked as pre-release
+    - provider: releases
+      api_key:
+        secure: c9kZbgxrcgNFmTh/TYn+aL4Yqww122YlGNVWaIcKdLpLlRyyrejlyOhnFF1VTnytU6CQGeH580I6IQ21auV1PCAMoD7anWT5sJa5vGo7pCAMFrEKk4PSSSF8LNWw1lHVMw96exI0JHywGx7t2fOYX0COSJab4XK8cM/0FEoJ2/rQYNVXz1oG+4F5B39Jl4zuBfI+oEeD+Q1B6LRMY52uFn1dpRIujYhihBJ3jMwKFzOB0rS/pbKSczQaa4M/HNUvCEupNLKQmnTiHv72JwXRzGsIsqbFJ7e0n6jz2Cv9eGdbVDT2fyEz7Kq8faRPB34wo4PP1DBJAkzpbvejdNvUCXHe+l0MsHbBDe6avjrR7IK1+nu5rT/HzPIqzidPunwKxABfQguYLOE2CZs4hqpwCULGdQ1GR/Hy9vCy7I6MpTw5K9VMRTyt/7MbnVlN/tDy8095Sh9GkJBZPzig7eyw37ylLibXDkmmWx+HrDLV9bP/re+NYk2bXWSHOEr8jgZyxeNJwli2p2WZaMFgfYS0AVdEoujq2b4jWawepkLm1U3UOK71NZLGVjY8tElo3j5NbB6Qbvyr9NNTQbj4BJadiGCfsp57QA1/G4UPXaWSvGWjHUnHkDyUl6AtglB9iciTc6mxxWGS57aPNCsbE+NRRV4E9abBycTeJd2nrLlej1I=
+      file: ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip
+      prerelease: true
+      skip_cleanup: true
+      on:
+        repo: autodesk-forks/MaterialX
+        # Pick a branch to use.
+        #branch: adsk_update
+        branch: adsk_update_shadergen
+        condition: "$CC = gcc"
+
+    # Deploy on tags. Currently marked as pre-release
+    - provider: releases
+      api_key:
+        secure: c9kZbgxrcgNFmTh/TYn+aL4Yqww122YlGNVWaIcKdLpLlRyyrejlyOhnFF1VTnytU6CQGeH580I6IQ21auV1PCAMoD7anWT5sJa5vGo7pCAMFrEKk4PSSSF8LNWw1lHVMw96exI0JHywGx7t2fOYX0COSJab4XK8cM/0FEoJ2/rQYNVXz1oG+4F5B39Jl4zuBfI+oEeD+Q1B6LRMY52uFn1dpRIujYhihBJ3jMwKFzOB0rS/pbKSczQaa4M/HNUvCEupNLKQmnTiHv72JwXRzGsIsqbFJ7e0n6jz2Cv9eGdbVDT2fyEz7Kq8faRPB34wo4PP1DBJAkzpbvejdNvUCXHe+l0MsHbBDe6avjrR7IK1+nu5rT/HzPIqzidPunwKxABfQguYLOE2CZs4hqpwCULGdQ1GR/Hy9vCy7I6MpTw5K9VMRTyt/7MbnVlN/tDy8095Sh9GkJBZPzig7eyw37ylLibXDkmmWx+HrDLV9bP/re+NYk2bXWSHOEr8jgZyxeNJwli2p2WZaMFgfYS0AVdEoujq2b4jWawepkLm1U3UOK71NZLGVjY8tElo3j5NbB6Qbvyr9NNTQbj4BJadiGCfsp57QA1/G4UPXaWSvGWjHUnHkDyUl6AtglB9iciTc6mxxWGS57aPNCsbE+NRRV4E9abBycTeJd2nrLlej1I=
+      file: ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_TAG}-${TRAVIS_BUILD_NUMBER}.zip
+      prerelease: true
+      skip_cleanup: true
+      on:
+        repo: autodesk-forks/MaterialX
+        all_branches: true
+        tags: true
+        condition: "$CC = gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
-    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip -i ${TRAVIS_BUILD_DIR}/installed/*.*
+    - tar -zcf ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.tar.gz -i ${TRAVIS_BUILD_DIR}/installed
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,7 @@ deploy:
   skip_cleanup: true
   on:
     repo: autodesk-forks/MaterialX
-    # branch: adsk_update_shadergen
+    # Pick a branch to use.
+    branch: adsk_update_artifacts
+    #branch: adsk_update_shadergen
     condition: "$CC = gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,24 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 script:
-  - mkdir build
-  - cd build
-  - cmake -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_INSTALL_PYTHON=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON ..
-  - cmake --build . --target install -- -j4
-  - ctest --output-on-failure
-  - export PYTHONPATH=$PYTHONPATH:$PWD/installed/python
-  - cmake -E chdir ../python/MaterialXTest python main.py
+    - mkdir build
+    - cd build
+    - cmake -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_INSTALL_PYTHON=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON ..
+    - cmake --build . --target install -- -j4
+    - ctest --output-on-failure
+    - export PYTHONPATH=$PYTHONPATH:$PWD/installed/python
+    - cmake -E chdir ../python/MaterialXTest python main.py
+
+before_deploy:
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip ${TRAVIS_BUILD_DIR}/installed
+
+deploy:
+  provider: releases
+  api_key:
+    secure: c9kZbgxrcgNFmTh/TYn+aL4Yqww122YlGNVWaIcKdLpLlRyyrejlyOhnFF1VTnytU6CQGeH580I6IQ21auV1PCAMoD7anWT5sJa5vGo7pCAMFrEKk4PSSSF8LNWw1lHVMw96exI0JHywGx7t2fOYX0COSJab4XK8cM/0FEoJ2/rQYNVXz1oG+4F5B39Jl4zuBfI+oEeD+Q1B6LRMY52uFn1dpRIujYhihBJ3jMwKFzOB0rS/pbKSczQaa4M/HNUvCEupNLKQmnTiHv72JwXRzGsIsqbFJ7e0n6jz2Cv9eGdbVDT2fyEz7Kq8faRPB34wo4PP1DBJAkzpbvejdNvUCXHe+l0MsHbBDe6avjrR7IK1+nu5rT/HzPIqzidPunwKxABfQguYLOE2CZs4hqpwCULGdQ1GR/Hy9vCy7I6MpTw5K9VMRTyt/7MbnVlN/tDy8095Sh9GkJBZPzig7eyw37ylLibXDkmmWx+HrDLV9bP/re+NYk2bXWSHOEr8jgZyxeNJwli2p2WZaMFgfYS0AVdEoujq2b4jWawepkLm1U3UOK71NZLGVjY8tElo3j5NbB6Qbvyr9NNTQbj4BJadiGCfsp57QA1/G4UPXaWSvGWjHUnHkDyUl6AtglB9iciTc6mxxWGS57aPNCsbE+NRRV4E9abBycTeJd2nrLlej1I=
+  file: ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip
+  skip_cleanup: true
+  on:
+    repo: autodesk-forks/MaterialX
+    branch: adsk_update_artifacts
+    condition: "$CC = gcc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
     - cmake -E chdir ../python/MaterialXTest python main.py
 
 before_deploy:
-    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip -i ${TRAVIS_BUILD_DIR}/installed/\*
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip -i ${TRAVIS_BUILD_DIR}/installed/*.*
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
 
 before_deploy:
     - cd ${TRAVIS_BUILD_DIR}/build/installed
-    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip *.*
+    - zip -r ${TRAVIS_BUILD_DIR}/MaterialX-${TRAVIS_OS_NAME}-${TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER}.zip .
 
 deploy:
   provider: releases


### PR DESCRIPTION
- Add build rules for creating artifacts and depolying to github repo for both appveyor and travis.
- For now we are triggered based on a git tag being specified or updates to adsk_update_shadergen
