### PR TITLE
Shadergen syntax class for OgsFx

### DIFF
--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.cpp
@@ -57,8 +57,8 @@ GlslSyntax::GlslSyntax()
         TypeSyntax
         (
             "vec2", 
-            "vec2(0.0)", 
-            "{0.0, 0.0}",
+            "vec2(0.0)",
+            "vec2(0.0)",
             "",
             "out vec2"
         )
@@ -70,8 +70,8 @@ GlslSyntax::GlslSyntax()
         TypeSyntax
         (
             "vec3", 
-            "vec3(0.0)", 
-            "{0.0, 0.0, 0.0}",
+            "vec3(0.0)",
+            "vec3(0.0)",
             "",
             "out vec3"
         )
@@ -84,7 +84,7 @@ GlslSyntax::GlslSyntax()
         (
             "vec4",
             "vec4(0.0)",
-            "{0.0, 0.0, 0.0, 0.0}",
+            "vec4(0.0)",
             "",
             "out vec4"
         )
@@ -97,7 +97,7 @@ GlslSyntax::GlslSyntax()
         (
             "vec2",
             "vec2(0.0)",
-            "{0.0, 0.0}",
+            "vec2(0.0)",
             "",
             "out vec2"
         )
@@ -110,7 +110,7 @@ GlslSyntax::GlslSyntax()
         (
             "vec3",
             "vec3(0.0)",
-            "{0.0, 0.0, 0.0}",
+            "vec3(0.0)",
             "",
             "out vec3"
         )
@@ -123,7 +123,7 @@ GlslSyntax::GlslSyntax()
         (
             "vec4",
             "vec4(0.0)",
-            "{0.0, 0.0, 0.0, 0.0}",
+            "vec4(0.0)",
             "",
             "out vec4"
         )
@@ -268,7 +268,7 @@ GlslSyntax::GlslSyntax()
         DataType::COLOR2,
         ValueConstructSyntax(
             "vec2(", ")", // Value constructor syntax
-            "{", "}",     // Value constructor syntax in a shader param initialization context
+            "vec2(", ")", // Value constructor syntax in a shader param initialization context
             {".r", ".g"}  // Syntax for each vector component
         )
     );
@@ -279,7 +279,7 @@ GlslSyntax::GlslSyntax()
         ValueConstructSyntax
         (
             "vec3(", ")",
-            "{", "}",
+            "vec3(", ")",
             {".r", ".g", ".b"}
     )
     );
@@ -290,7 +290,7 @@ GlslSyntax::GlslSyntax()
         ValueConstructSyntax
         (
             "vec4(", ")",
-            "{", "}",
+            "vec4(", ")",
             {".r", ".g", ".b", ".a"}
     )
     );
@@ -300,7 +300,7 @@ GlslSyntax::GlslSyntax()
         ValueConstructSyntax
         (
             "vec2(", ")",
-            "{", "}",
+            "vec2(", ")",
             { ".x", ".y"}
         )
     );
@@ -311,7 +311,7 @@ GlslSyntax::GlslSyntax()
         ValueConstructSyntax
         (
             "vec3(", ")",
-            "{", "}",
+            "vec3(", ")",
             { ".x", ".y", ".z"}
         )
     );
@@ -322,7 +322,7 @@ GlslSyntax::GlslSyntax()
         ValueConstructSyntax
         (
             "vec4(", ")",
-            "{", "}",
+            "vec4(", ")",
             { ".x", ".y", ".z", ".w"}
         )
     );

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.cpp
@@ -1,5 +1,5 @@
 #include <MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.h>
-#include <MaterialXShaderGen/Syntax.h>
+#include <MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h>
 
 #include <sstream>
 
@@ -86,6 +86,7 @@ const string OgsFxShaderGenerator::TARGET = "ogsfx";
 OgsFxShaderGenerator::OgsFxShaderGenerator()
     : GlslShaderGenerator()
 {
+    _syntax = std::make_shared<OgsFxSyntax>();
 }
 
 ShaderPtr OgsFxShaderGenerator::generate(const string& shaderName, ElementPtr element)

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
@@ -1,0 +1,155 @@
+#include <MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h>
+
+namespace MaterialX
+{
+
+OgsFxSyntax::OgsFxSyntax()
+{
+    //
+    // Override the GLSL syntax for vector/color types there the syntax differ
+    //
+
+    addTypeSyntax
+    (
+        DataType::COLOR2,
+        TypeSyntax
+        (
+            "vec2", 
+            "vec2(0.0)", 
+            "{0.0, 0.0}",
+            "",
+            "out vec2"
+        )
+    );
+
+    addTypeSyntax
+    (
+        DataType::COLOR3,
+        TypeSyntax
+        (
+            "vec3", 
+            "vec3(0.0)", 
+            "{0.0, 0.0, 0.0}",
+            "",
+            "out vec3"
+        )
+    );
+
+    addTypeSyntax
+    (
+        DataType::COLOR4,
+        TypeSyntax
+        (
+            "vec4",
+            "vec4(0.0)",
+            "{0.0, 0.0, 0.0, 0.0}",
+            "",
+            "out vec4"
+        )
+    );
+
+    addTypeSyntax
+    (
+        DataType::VECTOR2,
+        TypeSyntax
+        (
+            "vec2",
+            "vec2(0.0)",
+            "{0.0, 0.0}",
+            "",
+            "out vec2"
+        )
+    );
+
+    addTypeSyntax
+    (
+        DataType::VECTOR3,
+        TypeSyntax
+        (
+            "vec3",
+            "vec3(0.0)",
+            "{0.0, 0.0, 0.0}",
+            "",
+            "out vec3"
+        )
+    );
+
+    addTypeSyntax
+    (
+        DataType::VECTOR4,
+        TypeSyntax
+        (
+            "vec4",
+            "vec4(0.0)",
+            "{0.0, 0.0, 0.0, 0.0}",
+            "",
+            "out vec4"
+        )
+    );
+
+
+    addValueConstructSyntax(
+        DataType::COLOR2,
+        ValueConstructSyntax(
+            "vec2(", ")",
+            "{", "}",
+            {".r", ".g"}
+        )
+    );
+
+    addValueConstructSyntax
+    (
+        DataType::COLOR3,
+        ValueConstructSyntax
+        (
+            "vec3(", ")",
+            "{", "}",
+            {".r", ".g", ".b"}
+    )
+    );
+
+    addValueConstructSyntax
+    (
+        DataType::COLOR4,
+        ValueConstructSyntax
+        (
+            "vec4(", ")",
+            "{", "}",
+            {".r", ".g", ".b", ".a"}
+    )
+    );
+
+    addValueConstructSyntax(
+        DataType::VECTOR2,
+        ValueConstructSyntax
+        (
+            "vec2(", ")",
+            "{", "}",
+            { ".x", ".y"}
+        )
+    );
+
+    addValueConstructSyntax
+    (
+        DataType::VECTOR3,
+        ValueConstructSyntax
+        (
+            "vec3(", ")",
+            "{", "}",
+            { ".x", ".y", ".z"}
+        )
+    );
+
+    addValueConstructSyntax
+    (
+        DataType::VECTOR4,
+        ValueConstructSyntax
+        (
+            "vec4(", ")",
+            "{", "}",
+            { ".x", ".y", ".z", ".w"}
+        )
+    );
+}
+
+}

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h
@@ -1,0 +1,18 @@
+#ifndef MATERIALX_OGSFXSYNTAX_H
+#define MATERIALX_OGSFXSYNTAX_H
+
+#include <MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.h>
+
+namespace MaterialX
+{
+
+/// Syntax class for OgsFx
+class OgsFxSyntax : public GlslSyntax
+{
+public:
+    OgsFxSyntax();
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXShaderGen/Syntax.cpp
+++ b/source/MaterialXShaderGen/Syntax.cpp
@@ -11,14 +11,31 @@ namespace MaterialX
 
     void Syntax::addValueConstructSyntax(const string& type, const ValueConstructSyntax& syntax)
     {
-        _valueConstructSyntax.push_back(syntax);
-        _valueConstructSyntaxByName[type] = _valueConstructSyntax.size() - 1;
+        auto it = _valueConstructSyntaxByName.find(type);
+        if (it != _valueConstructSyntaxByName.end())
+        {
+            _valueConstructSyntax[it->second] = syntax;
+        }
+        else
+        {
+            // Type already exists so override with new value
+            _valueConstructSyntax.push_back(syntax);
+            _valueConstructSyntaxByName[type] = _valueConstructSyntax.size() - 1;
+        }
     }
 
     void Syntax::addTypeSyntax(const string& type, const TypeSyntax& syntax)
     {
-        _typeSyntax.push_back(syntax);
-        _typeSyntaxByName[type] = _typeSyntax.size() - 1;
+        auto it = _typeSyntaxByName.find(type);
+        if (it != _typeSyntaxByName.end())
+        {
+            _typeSyntax[it->second] = syntax;
+        }
+        else
+        {
+            _typeSyntax.push_back(syntax);
+            _typeSyntaxByName[type] = _typeSyntax.size() - 1;
+        }
     }
 
     string Syntax::getValue(const Value& value, bool paramInit) const


### PR DESCRIPTION
Added syntax class for OgsFx to handle a difference between GLSL and OgsFx in how vector uniforms are initialized.