### PR TITLE
New Element::getElementByPath function.

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -106,13 +106,13 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
 
 ElementPtr Element::getElementByNamePath(const std::string& path)
 {
-    std::vector<std::string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
+    const std::vector<std::string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
     ElementPtr currentElement = getSelf();
     if (elementNames.size() == 0)
     {
         return currentElement;
     }
-    for (std::string elementName : elementNames)
+    for (const std::string elementName : elementNames)
     {
         if (!(currentElement = currentElement->getChild(elementName)))
         {

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -104,6 +104,24 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
     return res;
 }
 
+ElementPtr Element::getElementByPath(const std::string& path)
+{
+    std::vector<std::string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
+    ElementPtr currentElement = getSelf();
+    if (elementNames.size() == 0)
+    {
+        return currentElement;
+    }
+    for (std::string elementName : elementNames)
+    {
+        if (!(currentElement = currentElement->getChild(elementName)))
+        {
+            return currentElement;
+        }
+    }
+    return currentElement;
+}
+
 void Element::registerChildElement(ElementPtr child)
 {
     DocumentPtr doc = getDocument();

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -108,10 +108,6 @@ ElementPtr Element::getDescendant(const string& path)
 {
     const vector<string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
     ElementPtr currentElement = getSelf();
-    if (elementNames.empty())
-    {
-        return currentElement;
-    }
     for (const string& elementName : elementNames)
     {
         if (!(currentElement = currentElement->getChild(elementName)))

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -104,7 +104,7 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
     return res;
 }
 
-ElementPtr Element::getElementByPath(const std::string& path)
+ElementPtr Element::getElementByNamePath(const std::string& path)
 {
     std::vector<std::string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
     ElementPtr currentElement = getSelf();
@@ -116,7 +116,7 @@ ElementPtr Element::getElementByPath(const std::string& path)
     {
         if (!(currentElement = currentElement->getChild(elementName)))
         {
-            return currentElement;
+            return ElementPtr();
         }
     }
     return currentElement;

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -112,7 +112,7 @@ ElementPtr Element::getElementByNamePath(const std::string& path)
     {
         return currentElement;
     }
-    for (const std::string elementName : elementNames)
+    for (const std::string& elementName : elementNames)
     {
         if (!(currentElement = currentElement->getChild(elementName)))
         {

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -104,15 +104,15 @@ string Element::getNamePath(ConstElementPtr relativeTo) const
     return res;
 }
 
-ElementPtr Element::getElementByNamePath(const std::string& path)
+ElementPtr Element::getDescendant(const string& path)
 {
-    const std::vector<std::string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
+    const vector<string> elementNames = splitString(path, NAME_PATH_SEPARATOR);
     ElementPtr currentElement = getSelf();
-    if (elementNames.size() == 0)
+    if (elementNames.empty())
     {
         return currentElement;
     }
-    for (const std::string& elementName : elementNames)
+    for (const string& elementName : elementNames)
     {
         if (!(currentElement = currentElement->getChild(elementName)))
         {

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -122,7 +122,7 @@ class Element : public std::enable_shared_from_this<Element>
     /// element.
     /// @param path The path to use to find an element relative to the
     ///    current element.
-    ElementPtr getElementByPath(const std::string& path);
+    ElementPtr getElementByNamePath(const std::string& path);
 
     /// @}
     /// @name File Prefix

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -121,8 +121,8 @@ class Element : public std::enable_shared_from_this<Element>
     /// to the current element. If an empty string is provided as the path
     /// then a shared pointer to the current element is returned. If the
     /// path cannot be found then an empty shared pointer is returned.
-    /// @param path The hierarchical path to use to find an element relative
-    ///    to the current element.
+    /// @param path The hierarchical path to use to find a descendant
+    ///    relative to the current element.
     ElementPtr getDescendant(const string& path);
 
     /// @}

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -117,6 +117,13 @@ class Element : public std::enable_shared_from_this<Element>
     ///    the returned path will be relative to this ancestor.
     string getNamePath(ConstElementPtr relativeTo = nullptr) const;
 
+    /// Return the element referred to by the path relative to the current
+    /// element. A path of empty string returns a pointer to the current
+    /// element.
+    /// @param path The path to use to find an element relative to the
+    ///    current element.
+    ElementPtr getElementByPath(const std::string& path);
+
     /// @}
     /// @name File Prefix
     /// @{

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -123,7 +123,7 @@ class Element : public std::enable_shared_from_this<Element>
     /// path cannot be found then an empty shared pointer is returned.
     /// @param path The hierarchical path to use to find an element relative
     ///    to the current element.
-    ElementPtr getElementByNamePath(const std::string& path);
+    ElementPtr getDescendant(const string& path);
 
     /// @}
     /// @name File Prefix

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -117,11 +117,12 @@ class Element : public std::enable_shared_from_this<Element>
     ///    the returned path will be relative to this ancestor.
     string getNamePath(ConstElementPtr relativeTo = nullptr) const;
 
-    /// Return the element referred to by the path relative to the current
-    /// element. A path of empty string returns a pointer to the current
-    /// element.
-    /// @param path The path to use to find an element relative to the
-    ///    current element.
+    /// Return the element referred to by the hierarchical path relative
+    /// to the current element. If an empty string is provided as the path
+    /// then a shared pointer to the current element is returned. If the
+    /// path cannot be found then an empty shared pointer is returned.
+    /// @param path The hierarchical path to use to find an element relative
+    ///    to the current element.
     ElementPtr getElementByNamePath(const std::string& path);
 
     /// @}

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -117,7 +117,7 @@ class Element : public std::enable_shared_from_this<Element>
     ///    the returned path will be relative to this ancestor.
     string getNamePath(ConstElementPtr relativeTo = nullptr) const;
 
-    /// Return the element referred to by the hierarchical path relative
+    /// Return the descendant referred to by the hierarchical path relative
     /// to the current element. If an empty string is provided as the path
     /// then a shared pointer to the current element is returned. If the
     /// path cannot be found then an empty shared pointer is returned.

--- a/source/MaterialXTest/Document.cpp
+++ b/source/MaterialXTest/Document.cpp
@@ -32,6 +32,13 @@ TEST_CASE("Document", "[document]")
     REQUIRE(constant->getNamePath() == "nodegraph1/node1");
     REQUIRE(constant->getNamePath(nodeGraph) == "node1");
 
+    // Test getting elements by path
+    REQUIRE(doc->getElementByPath("") == doc);
+    REQUIRE(doc->getElementByPath("nodegraph1") == nodeGraph);
+    REQUIRE(doc->getElementByPath("nodegraph1/node1") == constant);
+    REQUIRE(nodeGraph->getElementByPath("") == nodeGraph);
+    REQUIRE(nodeGraph->getElementByPath("node1") == constant);
+
     // Create a simple shader interface.
     mx::NodeDefPtr shader = doc->addNodeDef("", "surfaceshader", "simpleSrf");
     mx::InputPtr diffColor = shader->addInput("diffColor", "color3");

--- a/source/MaterialXTest/Document.cpp
+++ b/source/MaterialXTest/Document.cpp
@@ -33,11 +33,14 @@ TEST_CASE("Document", "[document]")
     REQUIRE(constant->getNamePath(nodeGraph) == "node1");
 
     // Test getting elements by path
-    REQUIRE(doc->getElementByPath("") == doc);
-    REQUIRE(doc->getElementByPath("nodegraph1") == nodeGraph);
-    REQUIRE(doc->getElementByPath("nodegraph1/node1") == constant);
-    REQUIRE(nodeGraph->getElementByPath("") == nodeGraph);
-    REQUIRE(nodeGraph->getElementByPath("node1") == constant);
+    REQUIRE(doc->getElementByNamePath("") == doc);
+    REQUIRE(doc->getElementByNamePath("nodegraph1") == nodeGraph);
+    REQUIRE(doc->getElementByNamePath("nodegraph1/node1") == constant);
+    REQUIRE(doc->getElementByNamePath("missingElement") == mx::ElementPtr());
+    REQUIRE(doc->getElementByNamePath("nodegraph1/missingNode") == mx::ElementPtr());
+    REQUIRE(nodeGraph->getElementByNamePath("") == nodeGraph);
+    REQUIRE(nodeGraph->getElementByNamePath("node1") == constant);
+    REQUIRE(nodeGraph->getElementByNamePath("missingNode") == mx::ElementPtr());
 
     // Create a simple shader interface.
     mx::NodeDefPtr shader = doc->addNodeDef("", "surfaceshader", "simpleSrf");

--- a/source/MaterialXTest/Document.cpp
+++ b/source/MaterialXTest/Document.cpp
@@ -33,14 +33,14 @@ TEST_CASE("Document", "[document]")
     REQUIRE(constant->getNamePath(nodeGraph) == "node1");
 
     // Test getting elements by path
-    REQUIRE(doc->getElementByNamePath("") == doc);
-    REQUIRE(doc->getElementByNamePath("nodegraph1") == nodeGraph);
-    REQUIRE(doc->getElementByNamePath("nodegraph1/node1") == constant);
-    REQUIRE(doc->getElementByNamePath("missingElement") == mx::ElementPtr());
-    REQUIRE(doc->getElementByNamePath("nodegraph1/missingNode") == mx::ElementPtr());
-    REQUIRE(nodeGraph->getElementByNamePath("") == nodeGraph);
-    REQUIRE(nodeGraph->getElementByNamePath("node1") == constant);
-    REQUIRE(nodeGraph->getElementByNamePath("missingNode") == mx::ElementPtr());
+    REQUIRE(doc->getDescendant("") == doc);
+    REQUIRE(doc->getDescendant("nodegraph1") == nodeGraph);
+    REQUIRE(doc->getDescendant("nodegraph1/node1") == constant);
+    REQUIRE(doc->getDescendant("missingElement") == mx::ElementPtr());
+    REQUIRE(doc->getDescendant("nodegraph1/missingNode") == mx::ElementPtr());
+    REQUIRE(nodeGraph->getDescendant("") == nodeGraph);
+    REQUIRE(nodeGraph->getDescendant("node1") == constant);
+    REQUIRE(nodeGraph->getDescendant("missingNode") == mx::ElementPtr());
 
     // Create a simple shader interface.
     mx::NodeDefPtr shader = doc->addNodeDef("", "surfaceshader", "simpleSrf");


### PR DESCRIPTION
As pointed out by Bernard, perhaps the function should be renamed from getElementByPath to something else. Bernard recommended getChildByPath or just extending getChild, my only concern with this is that the result could be a descendant that is more than one level deep, so technically not a child, but a descendant. Thoughts appreciated.