### PR TITLE
Simplified interface for HwShaderGenerator::bindLightShader(). 

### DIFF
--- a/source/MaterialXShaderGen/HwShaderGenerator.cpp
+++ b/source/MaterialXShaderGen/HwShaderGenerator.cpp
@@ -1,5 +1,8 @@
 #include <MaterialXShaderGen/HwShaderGenerator.h>
 
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Definition.h>
+
 namespace MaterialX
 {
 
@@ -9,12 +12,52 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax)
 {
 }
 
-void HwShaderGenerator::bindLightShader(size_t lightTypeId, SgImplementationPtr impl)
+void HwShaderGenerator::bindLightShader(const NodeDef& nodeDef, size_t lightTypeId)
 {
+    if (nodeDef.getType() != DataType::LIGHT)
+    {
+        throw ExceptionShaderGenError("Error binding light shader. Given nodedef '" + nodeDef.getName() + "' is not of lightshader type");
+    }
+
     if (getBoundLightShader(lightTypeId))
     {
-        throw ExceptionShaderGenError("Light type id '" + std::to_string(lightTypeId) + "' has already been bound");
+        throw ExceptionShaderGenError("Error binding light shader. Light type id '" + std::to_string(lightTypeId) + "' has already been bound");
     }
+
+    SgImplementationPtr impl;
+
+    // Find the implementation in the document (graph or implementation element)
+    vector<InterfaceElementPtr> elements = nodeDef.getDocument()->getMatchingImplementations(nodeDef.getName());
+    for (InterfaceElementPtr element : elements)
+    {
+        if (element->isA<NodeGraph>())
+        {
+            NodeGraphPtr implGraph = element->asA<NodeGraph>();
+            const string& matchingTarget = implGraph->getTarget();
+            if (matchingTarget.empty() || matchingTarget == getTarget())
+            {
+                impl = getImplementation(implGraph);
+                break;
+            }
+        }
+        else
+        {
+            ImplementationPtr implElement = element->asA<Implementation>();
+            const string& matchingTarget = implElement->getTarget();
+            if (implElement->getLanguage() == getLanguage() && (matchingTarget.empty() || matchingTarget == getTarget()))
+            {
+                impl = getImplementation(implElement);
+                break;
+            }
+        }
+    }
+
+    if (!impl)
+    {
+        throw ExceptionShaderGenError("Could not find a matching implementation for node '" + nodeDef.getNodeString() +
+            "' matching language '" + getLanguage() + "' and target '" + getTarget() + "'");
+    }
+    
     _boundLightShaders[lightTypeId] = impl;
 }
 

--- a/source/MaterialXShaderGen/HwShaderGenerator.h
+++ b/source/MaterialXShaderGen/HwShaderGenerator.h
@@ -25,7 +25,7 @@ public:
     /// by the generator. The lightTypeId should be a unique identifier for the light 
     /// type and the same id should be used when setting light parameters on a 
     /// generated surface shader.
-    void bindLightShader(size_t lightTypeId, SgImplementationPtr lightShader);
+    void bindLightShader(const NodeDef& nodeDef, size_t lightTypeId);
 
     /// Return a map of all light shaders that has been bound. The map contains the 
     /// light shader implementations with their bound light type id's.

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -166,13 +166,9 @@ void bindLightShaders(mx::DocumentPtr document, mx::HwShaderGenerator& shadergen
 {
     for (auto lightShader : LIGHT_SHADERS)
     {
-        mx::InterfaceElementPtr implElement = findImplementation(document, lightShader.second, shadergen.getLanguage(), shadergen.getTarget());
-        REQUIRE(implElement != nullptr);
-
-        mx::SgImplementationPtr impl = shadergen.getImplementation(implElement);
-        REQUIRE(impl != nullptr);
-
-        shadergen.bindLightShader(lightShader.first, impl);
+        mx::NodeDefPtr nodeDef = document->getNodeDef(lightShader.second);
+        REQUIRE(nodeDef != nullptr);
+        shadergen.bindLightShader(*nodeDef, lightShader.first);
     }
 }
 


### PR DESCRIPTION
Now using NodeDef of the light shader instead of the SgImplementation which a user had to search for.