### PR TITLE
ShaderX: Improvements to OSL surface shading

### DIFF
--- a/documents/Libraries/stdlib/sx-osl/mx_image_color2.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color2.osl
@@ -1,8 +1,17 @@
 void mx_image_color2(string file, string layer, color2 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output color2 out)
 {
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
+
     vdirection(texcoord, texcoord);
     color missingColor = color(default_value.r, default_value.a, 0.0);
     color rgb = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+
     out.r = rgb[0];
     out.a = rgb[1];
+
+    out.r = pow(out.r, 2.2);
 }

--- a/documents/Libraries/stdlib/sx-osl/mx_image_color3.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color3.osl
@@ -1,6 +1,14 @@
 void mx_image_color3(string file, string layer, color default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output color out)
 {
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
+
     vdirection(texcoord, texcoord);
     color missingColor = default_value;
     out = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+
+    out = pow(out, 2.2);
 }

--- a/documents/Libraries/stdlib/sx-osl/mx_image_color4.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color4.osl
@@ -1,7 +1,12 @@
 void mx_image_color4(string file, string layer, color4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output color4 out)
 {
-    vdirection(texcoord, texcoord);
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
 
+    vdirection(texcoord, texcoord);
     color missingColor = default_value.rgb;
     float missingAlpha = default_value.a;
 
@@ -9,5 +14,6 @@ void mx_image_color4(string file, string layer, color4 default_value, vector2 te
     color rgb = texture(file, texcoord.x, texcoord.y, "alpha", alpha, "subimage", layer,
                         "missingcolor", missingColor, "missingalpha", missingAlpha, "wrap", uaddressmode);
 
+    rgb = pow(rgb, 2.2);
     out = color4(rgb, alpha);
 }

--- a/documents/Libraries/stdlib/sx-osl/mx_image_float.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_float.osl
@@ -1,5 +1,11 @@
 void mx_image_float(string file, string layer, float default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output float out)
 {
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
+
     vdirection(texcoord, texcoord);
     color missingColor = color(default_value);
     color rgb = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);

--- a/documents/Libraries/stdlib/sx-osl/mx_image_vector2.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_vector2.osl
@@ -1,5 +1,11 @@
 void mx_image_vector2(string file, string layer, vector2 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output vector2 out)
 {
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
+
     vdirection(texcoord, texcoord);
     color missingColor = color(default_value.x, default_value.y, 0.0);
     color rgb = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);

--- a/documents/Libraries/stdlib/sx-osl/mx_image_vector3.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_vector3.osl
@@ -1,5 +1,11 @@
 void mx_image_vector3(string file, string layer, vector default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output vector out)
 {
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
+
     vdirection(texcoord, texcoord);
     color missingColor = default_value;
     out = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);

--- a/documents/Libraries/stdlib/sx-osl/mx_image_vector4.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_vector4.osl
@@ -1,7 +1,12 @@
 void mx_image_vector4(string file, string layer, vector4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string framerange, int frameoffset, string frameendaction, output vector4 out)
 {
-    vdirection(texcoord, texcoord);
+    if (file == "")
+    {
+        out = default_value;
+        return;
+    }
 
+    vdirection(texcoord, texcoord);
     color missingColor = color(default_value.x, default_value.y, default_value.z);
     float missingAlpha = default_value.w;
 

--- a/documents/Libraries/stdlib/sx-osl/mx_tangent_vector3.inline
+++ b/documents/Libraries/stdlib/sx-osl/mx_tangent_vector3.inline
@@ -1,1 +1,1 @@
-vector(u,v,0)
+transform({{space}}, dPdu)

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_diffusebsdf.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_diffusebsdf.glsl
@@ -1,21 +1,29 @@
 #include "sxpbrlib/sx-glsl/lib/sx_bsdfs.glsl"
 
-void sx_diffusebsdf(vec3 L, vec3 V, vec3 reflectance, float roughness, vec3 normal, out BSDF result)
+void sx_diffusebsdf(vec3 L, vec3 V, float weight, vec3 reflectance, float roughness, vec3 normal, out BSDF result)
 {
-    result = BSDF(0.0);
     float NdotL = dot(L, normal);
-    if (NdotL <= 0.0)
+    if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
+    {
+        result = BSDF(0.0);
         return;
+    }
 
-    result = reflectance * NdotL * M_PI_INV;
+    result = reflectance * weight * NdotL * M_PI_INV;
     if (roughness > 0.0)
     {
         result *= sx_orennayar(L, V, normal, NdotL, roughness);
     }
 }
 
-void sx_diffusebsdf_ibl(vec3 V, vec3 reflectance, float roughness, vec3 normal, out vec3 result)
+void sx_diffusebsdf_ibl(vec3 V, float weight, vec3 reflectance, float roughness, vec3 normal, out vec3 result)
 {
+    if (weight < M_FLOAT_EPS)
+    {
+        result = vec3(0.0);
+        return;
+    }
+
     vec3 Li = sx_environment_irradiance(normal);
-    result = Li * reflectance;
+    result = Li * reflectance * weight;
 }

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_normalmap.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_normalmap.glsl
@@ -1,0 +1,6 @@
+void sx_normalmap(vec3 value, vec3 N, vec3 T, out vec3 result)
+{
+    vec3 v = value * 2.0 - 1.0;
+    vec3 B = normalize(cross(N, T));
+    result = normalize(T * v.x + B * v.y + N * v.z);
+}

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_refractionbsdf.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_refractionbsdf.glsl
@@ -1,10 +1,10 @@
-void sx_refractionbsdf(vec3 L, vec3 V, vec3 transmittance, float ior, float roughness, float anisotropy, vec3 normal, vec3 tangent, int distribution, VDF interior, out BSDF result)
+void sx_refractionbsdf(vec3 L, vec3 V, float weight, vec3 transmittance, float ior, float roughness, float anisotropy, vec3 normal, vec3 tangent, int distribution, VDF interior, out BSDF result)
 {
     // TODO: Attenuate the transmission based on roughness and interior VDF
-    result = transmittance;
+    result = transmittance * weight;
 }
 
-void sx_refractionbsdf_ibl(vec3 V, vec3 transmittance, float ior, float roughness, float anisotropy, vec3 normal, vec3 tangent, int distribution, VDF interior, out vec3 result)
+void sx_refractionbsdf_ibl(vec3 V, float weight, vec3 transmittance, float ior, float roughness, float anisotropy, vec3 normal, vec3 tangent, int distribution, VDF interior, out vec3 result)
 {
     result = vec3(0.0);
 }

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_translucentbsdf.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_translucentbsdf.glsl
@@ -1,13 +1,25 @@
-void sx_translucentbsdf(vec3 L, vec3 V, vec3 transmittance, vec3 normal, out BSDF result)
+void sx_translucentbsdf(vec3 L, vec3 V, float weight, vec3 transmittance, vec3 normal, out BSDF result)
 {
     // Invert normal since we're transmitting light from the other side
-    float cosTheta = max(dot(-normal, L), 0.0);
-    result = transmittance * M_PI_INV * cosTheta;
+    float NdotL = dot(L, -normal);
+    if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
+    {
+        result = BSDF(0.0);
+        return;
+    }
+
+    result = transmittance * weight * NdotL * M_PI_INV;
 }
 
-void sx_translucentbsdf_ibl(vec3 V, vec3 transmittance, vec3 normal, out vec3 result)
+void sx_translucentbsdf_ibl(vec3 V, float weight, vec3 transmittance, vec3 normal, out vec3 result)
 {
+    if (weight < M_FLOAT_EPS)
+    {
+        result = vec3(0.0);
+        return;
+    }
+
     // Invert normal since we're transmitting light from the other side
     vec3 Li = sx_environment_irradiance(-normal);
-    result = Li * transmittance;
+    result = Li * transmittance * weight;
 }

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_transparentbsdf.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_transparentbsdf.glsl
@@ -1,9 +1,9 @@
-void sx_transparentbsdf(vec3 L, vec3 V, vec3 transmittance, out BSDF result)
+void sx_transparentbsdf(vec3 L, vec3 V, float weight, vec3 transmittance, out BSDF result)
 {
-    result = transmittance;
+    result = transmittance * weight;
 }
 
-void sx_transparentbsdf_ibl(vec3 V, vec3 transmittance, out vec3 result)
+void sx_transparentbsdf_ibl(vec3 V, float weight, vec3 transmittance, out vec3 result)
 {
     result = vec3(0.0);
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/lib/sx_fresnel.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/lib/sx_fresnel.osl
@@ -1,6 +1,6 @@
 float sx_fresnel_dielectric(float cosTheta, float ior)
 {
-    if (cosTheta < 0.0)
+    if (cosTheta < 0.0 || ior == 0.0)
         return 1.0;
 
     float g =  ior*ior + cosTheta*cosTheta - 1.0;

--- a/documents/Libraries/sxpbrlib/sx-osl/lib/sx_fresnel.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/lib/sx_fresnel.osl
@@ -1,0 +1,31 @@
+float sx_fresnel_dielectric(float cosTheta, float ior)
+{
+    if (cosTheta < 0.0)
+        return 1.0;
+
+    float g =  ior*ior + cosTheta*cosTheta - 1.0;
+    // Check for total internal reflection
+    if (g < 0.0)
+        return 1.0;
+
+    g = sqrt(g);
+    float gmc = g - cosTheta;
+    float gpc = g + cosTheta;
+    float x = gmc / gpc;
+    float y = (gpc * cosTheta - 1.0) / (gmc * cosTheta + 1.0);
+    return 0.5 * x * x * (1.0 + y * y);
+}
+
+color sx_fresnel_conductor(float cosTheta, vector n, vector k)
+{
+   float c2 = cosTheta*cosTheta;
+   vector n2_k2 = n*n + k*k;
+   vector nc2 = 2.0 * n * cosTheta;
+
+   vector rs_a = n2_k2 + c2;
+   vector rp_a = n2_k2 * c2 + 1.0;
+   vector rs = (rs_a - nc2) / (rs_a + nc2);
+   vector rp = (rp_a - nc2) / (rp_a + nc2);
+
+   return 0.5 * (rs + rp);
+}

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_coatingbsdf.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_coatingbsdf.osl
@@ -1,17 +1,30 @@
+#include "sxpbrlib/sx-osl/lib/sx_fresnel.osl"
+
 void sx_coatingbsdf(color reflectance, float ior, float roughness, float anisotropy, normal N, vector U, string distribution, BSDF base, output BSDF result)
 {
-    float alpha = roughness * roughness;
+    float alpha = clamp(roughness*roughness, M_FLOAT_EPS, 1.0);
+    float alphaX = alpha;
+    float alphaY = alpha;
+    if (anisotropy > 0.0)
+    {
+        float aspect = clamp(anisotropy, 0.0, 0.98);
+        aspect = sqrt(1.0 - aspect);
+        alphaX = min(alpha / aspect, 1.0);
+        alphaY = alpha * aspect;
+    }
+
     float eta = backfacing() ? 1.0 / ior : ior;
 
+    // Calculate fresnel outside the microfacet closure since we need 
+    // to attenuate the base layer according to fresnel
+    //
     // Fresnel should be based on microfacet normal
     // but we have no access to that from here, so just use
     // view direction and surface normal instead
+    //
     float NdotV = fabs(dot(N,-I));
-    float F0 = (eta - 1.0) / (eta + 1.0);
-    F0 *= F0;
-    float F = F0 + (1.0 - F0) * pow(1.0 - NdotV, 5.0);
+    color F = reflectance * sx_fresnel_dielectric(NdotV, eta);
 
-    // Microfacet reflection is using fresnel internally, so here we attenuate the base layer
-    // by the fresnel transmission
-    result = reflectance * microfacet(distribution, N, U, alpha, alpha, eta, false) + base * (1.0 - F);
+    // Set ior to 0.0 to disable the internal dielectric fresnel
+    result = F * microfacet(distribution, N, U, alphaX, alphaY, 0.0, false) + base * (1.0 - F);
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_coatingbsdf.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_coatingbsdf.osl
@@ -1,7 +1,13 @@
 #include "sxpbrlib/sx-osl/lib/sx_fresnel.osl"
 
-void sx_coatingbsdf(color reflectance, float ior, float roughness, float anisotropy, normal N, vector U, string distribution, BSDF base, output BSDF result)
+void sx_coatingbsdf(float weight, color reflectance, float ior, float roughness, float anisotropy, normal N, vector U, string distribution, BSDF base, output BSDF result)
 {
+    if (weight < M_FLOAT_EPS)
+    {
+        result = base;
+        return;
+    }
+
     float alpha = clamp(roughness*roughness, M_FLOAT_EPS, 1.0);
     float alphaX = alpha;
     float alphaY = alpha;
@@ -13,9 +19,7 @@ void sx_coatingbsdf(color reflectance, float ior, float roughness, float anisotr
         alphaY = alpha * aspect;
     }
 
-    float eta = backfacing() ? 1.0 / ior : ior;
-
-    // Calculate fresnel outside the microfacet closure since we need 
+    // Calculate fresnel since we need 
     // to attenuate the base layer according to fresnel
     //
     // Fresnel should be based on microfacet normal
@@ -23,8 +27,9 @@ void sx_coatingbsdf(color reflectance, float ior, float roughness, float anisotr
     // view direction and surface normal instead
     //
     float NdotV = fabs(dot(N,-I));
-    color F = reflectance * sx_fresnel_dielectric(NdotV, eta);
+    float F = sx_fresnel_dielectric(NdotV, ior);
+    F *= weight;
 
-    // Set ior to 0.0 to disable the internal dielectric fresnel
-    result = F * microfacet(distribution, N, U, alphaX, alphaY, 0.0, false) + base * (1.0 - F);
+    result = reflectance * microfacet(distribution, N, U, alphaX, alphaY, ior, false)
+             + base * (1.0 - F);
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_diffusebsdf.inline
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_diffusebsdf.inline
@@ -1,1 +1,1 @@
-{{reflectance}} * oren_nayar({{normal}}, {{roughness}})
+{{reflectance}} * {{weight}} * oren_nayar({{normal}}, {{roughness}})

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_edgetint.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_edgetint.osl
@@ -1,6 +1,6 @@
 #include "sxpbrlib/sx-osl/lib/sx_complexior.osl"
 
-void sx_edgetint(vector ior_n, vector reflectivity, output color result)
+void sx_edgetint(vector ior_n, color reflectivity, output color result)
 {
     result = sx_get_edgetint(ior_n, reflectivity);
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_metalbsdf.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_metalbsdf.osl
@@ -1,5 +1,30 @@
-void sx_metalbsdf(vector ior_n, vector ior_k, float roughness, float anisotropy, normal N, vector U, string distribution, output BSDF result)
+#include "sxpbrlib/sx-osl/lib/sx_complexior.osl"
+#include "sxpbrlib/sx-osl/lib/sx_fresnel.osl"
+
+void sx_metalbsdf(color reflectivity, color edgetint, float roughness, float anisotropy, normal N, vector U, string distribution, output BSDF result)
 {
-    // TODO: Implement this!
-    result = reflectance;
+    float alpha = clamp(roughness*roughness, M_FLOAT_EPS, 1.0);
+    float alphaX = alpha;
+    float alphaY = alpha;
+    if (anisotropy > 0.0)
+    {
+        float aspect = clamp(anisotropy, 0.0, 0.98);
+        aspect = sqrt(1.0 - aspect);
+        alphaX = min(alpha / aspect, 1.0);
+        alphaY = alpha * aspect;
+    }
+
+    // Calculate conductor fresnel
+    //
+    // Fresnel should be based on microfacet normal
+    // but we have no access to that from here, so just use
+    // view direction and surface normal instead
+    //
+    float NdotV = fabs(dot(N,-I));
+    vector ior_n, ior_k;
+    sx_complexior(reflectivity, edgetint, ior_n, ior_k);
+    color F = sx_fresnel_conductor(NdotV, ior_n, ior_k);
+
+    // Set ior to 0.0 to disable the internal dielectric fresnel
+    result = F * microfacet(distribution, N, U, alphaX, alphaY, 0.0, false);
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_metalbsdf.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_metalbsdf.osl
@@ -1,8 +1,14 @@
 #include "sxpbrlib/sx-osl/lib/sx_complexior.osl"
 #include "sxpbrlib/sx-osl/lib/sx_fresnel.osl"
 
-void sx_metalbsdf(color reflectivity, color edgetint, float roughness, float anisotropy, normal N, vector U, string distribution, output BSDF result)
+void sx_metalbsdf(float weight, color reflectivity, color edgetint, float roughness, float anisotropy, normal N, vector U, string distribution, output BSDF result)
 {
+    if (weight < M_FLOAT_EPS)
+    {
+        result = 0;
+        return;
+    }
+
     float alpha = clamp(roughness*roughness, M_FLOAT_EPS, 1.0);
     float alphaX = alpha;
     float alphaY = alpha;
@@ -24,6 +30,7 @@ void sx_metalbsdf(color reflectivity, color edgetint, float roughness, float ani
     vector ior_n, ior_k;
     sx_complexior(reflectivity, edgetint, ior_n, ior_k);
     color F = sx_fresnel_conductor(NdotV, ior_n, ior_k);
+    F *= weight;
 
     // Set ior to 0.0 to disable the internal dielectric fresnel
     result = F * microfacet(distribution, N, U, alphaX, alphaY, 0.0, false);

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_normalmap.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_normalmap.osl
@@ -1,0 +1,7 @@
+void sx_normalmap(vector value, vector N, vector U, output vector result)
+{
+    vector v = value * 2.0 - 1.0;
+    vector T = normalize(U - dot(U, N) * N);
+    vector B = normalize(cross(N, T));
+    result = normalize(T * v[0] + B * v[1] + N * v[2]);
+}

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_refractionbsdf.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_refractionbsdf.osl
@@ -1,5 +1,21 @@
-void sx_refractionbsdf(color transmittance, float ior, float roughness, float anisotropy, normal N, vector U, string distribution, VDF interior, output BSDF result)
+void sx_refractionbsdf(float weight, color transmittance, float ior, float roughness, float anisotropy, vector in_normal, vector in_tangent, string distribution, VDF interior, output BSDF result)
 {
-    float alpha = roughness * roughness;
-    result = transmittance * microfacet(distribution, N, U, alpha, alpha, ior, true) + interior;
+    if (weight < M_FLOAT_EPS)
+    {
+        result = 0;
+        return;
+    }
+
+    float alpha = clamp(roughness*roughness, M_FLOAT_EPS, 1.0);
+    float alphaX = alpha;
+    float alphaY = alpha;
+    if (anisotropy > 0.0)
+    {
+        float aspect = clamp(anisotropy, 0.0, 0.98);
+        aspect = sqrt(1.0 - aspect);
+        alphaX = min(alpha / aspect, 1.0);
+        alphaY = alpha * aspect;
+    }
+
+    result = transmittance * weight * microfacet(distribution, in_normal, in_tangent, alphaX, alphaY, ior, true) + interior;
 }

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_translucentbsdf.inline
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_translucentbsdf.inline
@@ -1,1 +1,1 @@
-{{transmittance}} * translucent({{normal}})
+{{transmittance}} * {{weight}} * translucent({{normal}})

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_transparentbsdf.inline
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_transparentbsdf.inline
@@ -1,1 +1,1 @@
-{{transmittance}} * transparent()
+{{transmittance}} * {{weight}} * transparent()

--- a/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
@@ -15,6 +15,7 @@
   -->
   <nodedef name="ND_diffusebsdf" node="diffusebsdf" type="BSDF" nodecategory="shaderx"
            doc="A BSDF node for pure diffuse reflections.">
+    <input name="weight" type="float" value="1.0"/>
     <input name="reflectance" type="color3" value="0.8, 0.8, 0.8"/>
     <input name="roughness" type="float" value="1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="shadingnormal"/>
@@ -26,6 +27,7 @@
   -->
   <nodedef name="ND_translucentbsdf" node="translucentbsdf" type="BSDF" nodecategory="shaderx"
            doc="A BSDF node for pure diffuse transmission.">
+    <input name="weight" type="float" value="1.0"/>
     <input name="transmittance" type="color3" value="0.8, 0.8, 0.8"/>
     <input name="normal" type="vector3" defaultgeomprop="shadingnormal"/>
   </nodedef>
@@ -36,7 +38,8 @@
   -->
   <nodedef name="ND_transparentbsdf" node="transparentbsdf" type="BSDF" nodecategory="shaderx"
            doc="A BSDF node for straight transmission.">
-    <input name="transmittance" type="color3"/>
+    <input name="weight" type="float" value="1.0"/>
+    <input name="transmittance" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
 
   <!--
@@ -45,6 +48,7 @@
   -->
   <nodedef name="ND_coatingbsdf" node="coatingbsdf" type="BSDF" nodecategory="shaderx"
            doc="A BSDF node for specular to glossy reflection with dielectric fresel.">
+    <input name="weight" type="float" value="1.0"/>
     <input name="reflectance" type="color3" value="1.0, 1.0, 1.0"/>
     <input name="ior" type="float" value="1.52"/>
     <input name="roughness" type="float" value="0.2"/>
@@ -61,6 +65,7 @@
   -->
   <nodedef name="ND_metalbsdf" node="metalbsdf" type="BSDF" nodecategory="shaderx"
            doc="A BSDF node for specular to glossy reflection with conductor fresel.">
+    <input name="weight" type="float" value="1.0"/>
     <input name="reflectivity" type="color3" value="0.944 0.776 0.373"/>
     <input name="edgetint" type="color3" value="0.998 0.981 0.751"/>
     <input name="roughness" type="float" value="0.2"/>
@@ -96,6 +101,7 @@
   -->
   <nodedef name="ND_refractionbsdf" node="refractionbsdf" type="BSDF" nodecategory="shaderx" 
            doc="A BSDF node for specular to glossy transmission.">
+    <input name="weight" type="float" value="1.0"/>
     <input name="transmittance" type="color3" value="1.0, 1.0, 1.0"/>
     <input name="ior" type="float" value="1.52"/>
     <input name="roughness" type="float" value="0.2"/>
@@ -280,7 +286,6 @@
     <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="shadingnormal"/>
     <input name="tangent" type="vector3" defaultgeomprop="tangent"/>
-    <input name="bitangent" type="vector3" defaultgeomprop="bitangent"/>
   </nodedef>
 
   <!--

--- a/documents/Libraries/sxpbrlib/sxpbrlib_ng.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_ng.mtlx
@@ -1,41 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <materialx version="1.36">
-  <!-- <normalmap> -->
-  <nodegraph name="IMP_normalmap" nodedef="ND_normalmap" type="vector3">
-    <multiply name="in_scale" type="vector3">
-      <input name="in1" type="vector3" interfacename="in"/>
-      <input name="in2" type="vector3" value="2.0000, 2.0000, 2.0000" />
-    </multiply>
-    <subtract name="in_subtract" type="vector3">
-      <input name="in1" type="vector3" nodename="in_scale"/>
-      <input name="in2" type="vector3" value="1.0000, 1.0000, 1.0000" />
-    </subtract>
-    <multiply name="tangent_comp" type="vector3">
-      <input name="in1" type="vector3" interfacename="tangent"/>
-      <input name="in2" type="float" nodename="in_subtract" channels="x" />
-    </multiply>
-    <multiply name="bitangent_comp" type="vector3">
-      <input name="in1" type="vector3" interfacename="bitangent"/>
-      <input name="in2" type="float" nodename="in_subtract" channels="y" />
-    </multiply>
-    <multiply name="normal_comp" type="vector3">
-      <input name="in1" type="vector3" interfacename="normal"/>
-      <input name="in2" type="float" nodename="in_subtract" channels="z" />
-    </multiply>
-    <add name="add1" type="vector3">
-      <input name="in1" type="vector3" nodename="tangent_comp"/>
-      <input name="in2" type="vector3" nodename="bitangent_comp"/>
-    </add>
-    <add name="add2" type="vector3">
-      <input name="in1" type="vector3" nodename="normal_comp"/>
-      <input name="in2" type="vector3" nodename="add1"/>
-    </add>
-    <normalize name="normalize1" type="vector3">
-      <input name="in" type="vector3" nodename="add2"/>
-    </normalize>
-    <output name="out" type="vector3" nodename="normalize1"/>
-  </nodegraph>
-
   <!-- <shadingnormal> -->
   <nodegraph name="IMP_shadingnormal__vector3" nodedef="ND_shadingnormal__vector3" type="vector3">
     <normal name="Nw" type="vector3">
@@ -108,17 +72,15 @@
       <parameter name="amount" type="float" value="1.0" />
     </invert>
     <!-- Diffuse component -->
-    <multiply name="multiply1" type="color3">
-      <input name="in1" type="color3" interfacename="base_color" />
-      <input name="in2" type="float" interfacename="base" />
-    </multiply>
     <diffusebsdf name="Diffuse_BSDF" type="BSDF">
-      <input name="reflectance" type="color3" nodename="multiply1" />
+      <input name="weight" type="float" interfacename="base" />
+      <input name="reflectance" type="color3" interfacename="base_color" />
       <input name="roughness" type="float" interfacename="diffuse_roughness" />
       <input name="normal" type="vector3" interfacename="normal" />
     </diffusebsdf>
     <!-- SSS component -->
     <translucentbsdf name="SSS_BSDF" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
       <input name="transmittance" type="color3" interfacename="subsurface_color" />
       <input name="normal" type="vector3" interfacename="normal" />
     </translucentbsdf>
@@ -129,6 +91,7 @@
     </mixbsdf>
     <!-- Transmission component -->
     <refractionbsdf name="Transmission_BSDF" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
       <input name="transmittance" type="color3" interfacename="transmission_color" />
       <input name="ior" type="float" interfacename="specular_IOR" />
       <input name="roughness" type="float" nodename="invert3" />
@@ -144,12 +107,9 @@
       <input name="weight" type="float" interfacename="transmission" />
     </mixbsdf>
     <!-- Specular component -->
-    <multiply name="multiply2" type="color3">
-      <input name="in1" type="color3" interfacename="specular_color" />
-      <input name="in2" type="float" interfacename="specular" />
-    </multiply>
     <coatingbsdf name="Specular_BSDF" type="BSDF">
-      <input name="reflectance" type="color3" nodename="multiply2" />
+      <input name="weight" type="float" interfacename="specular" />
+      <input name="reflectance" type="color3" interfacename="specular_color" />
       <input name="ior" type="float" interfacename="specular_IOR" />
       <input name="roughness" type="float" nodename="invert3" />
       <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
@@ -160,8 +120,9 @@
     </coatingbsdf>
     <!-- Metal component -->
     <metalbsdf name="Metal_BSDF" type="BSDF">
-      <input name="reflectivity" type="color3" nodename="multiply1"/>
-      <input name="edgetint" type="color3" nodename="multiply2"/>
+      <input name="weight" type="float" interfacename="base" />
+      <input name="reflectivity" type="color3" interfacename="base_color"/>
+      <input name="edgetint" type="color3" interfacename="specular_color"/>
       <input name="roughness" type="float" nodename="invert3" />
       <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
       <input name="normal" type="vector3" interfacename="normal" />
@@ -184,7 +145,8 @@
       <input name="weight" type="color3" nodename="coat_attenuation" />
     </scalebsdf>
     <coatingbsdf name="Coat_BSDF" type="BSDF">
-      <input name="reflectance" type="color3" interfacename="coat" channels="xxx" />
+      <input name="weight" type="float" interfacename="coat" />
+      <input name="reflectance" type="color3" value="1.0, 1.0, 1.0" />
       <input name="ior" type="float" interfacename="coat_IOR" />
       <input name="roughness" type="float" interfacename="coat_roughness" />
       <input name="anisotropy" type="float" value="0.0" />

--- a/documents/Libraries/sxpbrlib/sxpbrlib_sx-glsl_impl.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_sx-glsl_impl.mtlx
@@ -61,4 +61,7 @@
   <!-- <edgetint> -->
   <implementation name="IM_edgetint__sx_glsl" nodedef="ND_edgetint" file="sxpbrlib/sx-glsl/sx_edgetint.glsl" function="sx_edgetint" language="sx-glsl"/>
 
+  <!-- <normalmap> -->
+  <implementation name="IM_normalmap__sx_glsl" nodedef="ND_normalmap" file="sxpbrlib/sx-glsl/sx_normalmap.glsl" function="sx_normalmap" language="sx-glsl"/>
+
 </materialx>

--- a/documents/Libraries/sxpbrlib/sxpbrlib_sx-osl_impl.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_sx-osl_impl.mtlx
@@ -49,4 +49,7 @@
   <!-- <edgetint> -->
   <implementation name="IM_edgetint__sx_osl" nodedef="ND_edgetint" file="sxpbrlib/sx-osl/sx_edgetint.osl" function="sx_edgetint" language="sx-osl"/>
 
+  <!-- <normalmap> -->
+  <implementation name="IM_normalmap__sx_osl" nodedef="ND_normalmap" file="sxpbrlib/sx-osl/sx_normalmap.osl" function="sx_normalmap" language="sx-osl"/>
+
 </materialx>

--- a/source/MaterialXShaderGen/ShaderGenerators/Osl/OslShaderGenerator.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Osl/OslShaderGenerator.cpp
@@ -126,6 +126,9 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
     Shader& shader = *shaderPtr;
 
     emitIncludes(shader);
+
+    shader.addLine("#define M_FLOAT_EPS 0.000001", false);
+
     emitTypeDefs(shader);
     emitFunctionDefinitions(shader);
 
@@ -149,13 +152,15 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
 
     shader.beginScope(Shader::Brackets::PARENTHESES);
 
+    shader.addLine("float dummy = 0.0,", false);
+
     // Emit all app data inputs
     const Shader::VariableBlock& appDataBlock = shader.getAppDataBlock();
     for (const Shader::Variable* input : appDataBlock.variableOrder)
     {
         const string& type = _syntax->getTypeName(input->type);
         const string value = _syntax->getTypeDefault(input->type, true);
-        shader.addLine(type + " " + input->name + " = " + value + " [[ int lockgeom=0 ]],");
+        shader.addLine(type + " " + input->name + " = " + value + " [[ int lockgeom=0 ]],", false);
     }
 
     // Emit all public inputs

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -227,7 +227,8 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
         materials.push_back(material);
     }
 
-    // Example3: Create a metal surface shader by a graph
+    // Example3: Create a metal surface shader by a graph, using both the complex and
+    // the artistic refraction index description, to test that they give equal results.
     {
         // Create a nodedef interface for the surface shader
         mx::NodeDefPtr nodeDef = doc->addNodeDef("ND_testshader3", "surfaceshader", "testshader3");
@@ -395,10 +396,21 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
         mx::MaterialPtr material = doc->addMaterial("example4");
         mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "testshader4");
 
-        mx::BindInputPtr bindBase = shaderRef->addBindInput("base", "float");
-        bindBase->setValue(1.0f);
-        mx::BindInputPtr bindBaseColor = shaderRef->addBindInput("base_color", "color3");
-        bindBaseColor->setValue(mx::Color3(0.8f, 0.6f, 0.6f));
+        // Bind a couple of shader parameter values
+        mx::BindInputPtr base_input = shaderRef->addBindInput("base", "float");
+        base_input->setValue(0.8f);
+        mx::BindInputPtr base_color_input = shaderRef->addBindInput("base_color", "color3");
+        base_color_input->setValue(mx::Color3(1.0f, 1.0f, 1.0f));
+        mx::BindInputPtr specular_input = shaderRef->addBindInput("specular", "float");
+        specular_input->setValue(1.0f);
+        mx::BindInputPtr specular_color_input = shaderRef->addBindInput("specular_color", "color3");
+        specular_color_input->setValue(mx::Color3(1.0f, 1.0f, 1.0f));
+        mx::BindInputPtr specular_IOR_input = shaderRef->addBindInput("specular_IOR", "float");
+        specular_IOR_input->setValue(1.52f);
+        mx::BindInputPtr specular_roughness_input = shaderRef->addBindInput("specular_roughness", "float");
+        specular_roughness_input->setValue(0.1f);
+        mx::BindInputPtr coat_IOR_input = shaderRef->addBindInput("coat_IOR", "float");
+        coat_IOR_input->setValue(3.0);
 
         materials.push_back(material);
     }

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -329,6 +329,9 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
             { { "specular_IOR", "float" }, false },
             { { "specular_anisotropy", "float" }, false },
             { { "metalness","float" }, true },
+            { { "transmission", "float" }, true },
+            { { "transmission_color", "color3" }, true },
+            { { "transmission_extra_roughness", "float" }, true },
             { { "subsurface", "float" }, false },
             { { "subsurface_color", "color3" }, false },
             { { "coat", "float" }, true },
@@ -374,19 +377,24 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
             }
         }
 
-        mx::NodePtr spacularNormalTex = shaderGraph->addNode("image", "normalTex", "vector3");
-        spacularNormalTex->setParameterValue("file", std::string(""), "filename");
-        spacularNormalTex->setParameterValue("default", mx::Vector3(0.5f, 0.5f, 1.0f));
-        mx::NodePtr spacularNormalMap = shaderGraph->addNode("normalmap", "normalmap1", "vector3");
-        spacularNormalMap->setConnectedNode("in", spacularNormalTex);
+        nodeDef->addInput("normalmap", "filename");
+        nodeDef->addInput("coat_normalmap", "filename");
+
+        mx::NodePtr specularNormalTex = shaderGraph->addNode("image", "normalTex", "vector3");
+        mx::ParameterPtr specularNormalTexFile = specularNormalTex->addParameter("file", "filename");
+        specularNormalTexFile->setInterfaceName("normalmap");
+        specularNormalTex->setParameterValue("default", mx::Vector3(0.5f, 0.5f, 1.0f));
+        mx::NodePtr specularNormalMap = shaderGraph->addNode("normalmap", "normalmap1", "vector3");
+        specularNormalMap->setConnectedNode("in", specularNormalTex);
 
         mx::NodePtr coatNormalTex = shaderGraph->addNode("image", "coatTex", "vector3");
-        coatNormalTex->setParameterValue("file", std::string(""), "filename");
+        mx::ParameterPtr coatNormalTexFile = coatNormalTex->addParameter("file", "filename");
+        coatNormalTexFile->setInterfaceName("coat_normalmap");
         coatNormalTex->setParameterValue("default", mx::Vector3(0.5f, 0.5f, 1.0f));
         mx::NodePtr coatNormalMap = shaderGraph->addNode("normalmap", "normalmap2", "vector3");
         coatNormalMap->setConnectedNode("in", coatNormalTex);
 
-        standardSurface->setConnectedNode("normal", spacularNormalMap);
+        standardSurface->setConnectedNode("normal", specularNormalMap);
         standardSurface->setConnectedNode("coat_normal", coatNormalMap);
 
         mx::OutputPtr output = shaderGraph->addOutput("out", "surfaceshader");


### PR DESCRIPTION
Improvements to OSL surface shading:
 - Improved implementation for coatingbsdf and metalbsdf
 - Added anisotropy to refractionbsdf
 - Added conductor and dielectric fresnel functions
 - Added optimization for image nodes when no texture file is given
 - Fixed tangent node implementation

BSDF improvements and bugfixes:
 - Fixed bugs with fresnel weighting in coatingbsdf
 - Added a weight parameter to each BSDF. Needed for coating to be able to get correct layering when coat is disabled. (Still indecisive if it's good design to have on all other BSDF nodes, but for now including on all for consistency).
 - Made separate normal map implementation for OSL vs GLSL since OSL needed a different tangent basis
