### PR TITLE
Remove hard-coded gamma for IBL and image lookup.

### DIFF
--- a/documents/Libraries/stdlib/sx-glsl/mx_image_color2.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_image_color2.glsl
@@ -5,7 +5,6 @@ void mx_image_color2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 tex
     {
         vdirection(texcoord, texcoord);
         result = texture(tex_sampler, texcoord).rg;
-        result = pow(result, vec2(2.2));
     }
     else
     {

--- a/documents/Libraries/stdlib/sx-glsl/mx_image_color3.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_image_color3.glsl
@@ -5,7 +5,6 @@ void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 tex
     {
         vdirection(texcoord, texcoord);
         result = texture(tex_sampler, texcoord).rgb;
-        result = pow(result, vec3(2.2));
     }
     else
     {

--- a/documents/Libraries/stdlib/sx-glsl/mx_image_color4.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_image_color4.glsl
@@ -5,7 +5,6 @@ void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 tex
     {
         vdirection(texcoord, texcoord);
         result = texture(tex_sampler, texcoord);
-        result.rgb = pow(result.rgb, vec3(2.2));
     }
     else
     {

--- a/documents/Libraries/sxpbrlib/sx-glsl/lib/sx_lighting.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/lib/sx_lighting.glsl
@@ -44,9 +44,5 @@ vec3 sx_environment_specular(vec3 normal, vec3 view, float roughness)
 vec3 sx_environment_irradiance(vec3 normal)
 {
     vec3 result = sx_latlong_map_lookup(normal, u_envMatrix, u_envIrradiance);
-
-    // TODO: remove when we have HDR irradiance maps
-    result = pow(result, vec3(2.2));
-
     return result;
 }


### PR DESCRIPTION
Was using a hard-coded 2.2 gamma lookup. Remove this for now as this adversely affects image display.
Add in proper CM lookup later.
