### PR TITLE
Add fallback if no input on nodedef for interfacename

### DIFF
--- a/source/MaterialXShaderGen/SgNode.cpp
+++ b/source/MaterialXShaderGen/SgNode.cpp
@@ -722,6 +722,14 @@ SgNode* SgNodeGraph::addNode(const Node& node, ShaderGenerator& shadergen)
             SgInputSocket* inputSocket = getInputSocket(interfaceName);
             if (!inputSocket)
             {
+                inputSocket = addInputSocket(interfaceName, elem->getType());
+                if (!elem->getValueString().empty())
+                {
+                    inputSocket->value = elem->getValue();
+                }
+            }
+            if (!inputSocket)
+            {
                 throw ExceptionShaderGenError("Interface name '" + interfaceName + "' doesn't match an existing input on nodegraph '" + getName() + "'");
             }
             SgInput* input = newNode->getInput(elem->getName());

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -435,6 +435,8 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
 
         materials.push_back(material);
     }
+
+    mx::writeToXmlFile(doc, "example_materials.mtlx");
 }
 
 float cosAngle(float degrees)


### PR DESCRIPTION
- Handle if there an <interfacename> on a node is specified without it being specified on the nodedef.  
- Add output of generated materials to mtlx file for ShaderGen test.
