### PR TITLE
Fix potential name conflict in type aliases (#127)

### DIFF
--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -25,25 +25,31 @@ extern const string GEOMETRIC_NODE_CATEGORY;
 extern const string ADJUSTMENT_NODE_CATEGORY;
 extern const string CONDITIONAL_NODE_CATEGORY;
 
+class NodeDef;
+class Implementation;
+class TypeDef;
+class Member;
+class ShaderRef;
+
 /// A shared pointer to a NodeDef
-using NodeDefPtr = shared_ptr<class NodeDef>;
+using NodeDefPtr = shared_ptr<NodeDef>;
 /// A shared pointer to a const NodeDef
-using ConstNodeDefPtr = shared_ptr<const class NodeDef>;
+using ConstNodeDefPtr = shared_ptr<const NodeDef>;
 
 /// A shared pointer to an Implementation
-using ImplementationPtr = shared_ptr<class Implementation>;
+using ImplementationPtr = shared_ptr<Implementation>;
 /// A shared pointer to a const Implementation
-using ConstImplementationPtr = shared_ptr<const class Implementation>;
+using ConstImplementationPtr = shared_ptr<const Implementation>;
 
 /// A shared pointer to a TypeDef
-using TypeDefPtr = shared_ptr<class TypeDef>;
+using TypeDefPtr = shared_ptr<TypeDef>;
 /// A shared pointer to a const TypeDef
-using ConstTypeDefPtr = shared_ptr<const class TypeDef>;
+using ConstTypeDefPtr = shared_ptr<const TypeDef>;
 
 /// A shared pointer to a Member
-using MemberPtr = shared_ptr<class Member>;
+using MemberPtr = shared_ptr<Member>;
 /// A shared pointer to a const Member
-using ConstMemberPtr = shared_ptr<const class Member>;
+using ConstMemberPtr = shared_ptr<const Member>;
 
 /// @class NodeDef
 /// A node definition element within a Document.
@@ -59,7 +65,7 @@ class NodeDef : public InterfaceElement
     }
     virtual ~NodeDef() { }
 
-    using ShaderRefPtr = shared_ptr<class ShaderRef>;
+    using ShaderRefPtr = shared_ptr<ShaderRef>;
 
     /// @name Node String
     /// @{

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -18,10 +18,12 @@
 namespace MaterialX
 {
 
+class Document;
+
 /// A shared pointer to a Document
-using DocumentPtr = shared_ptr<class Document>;
+using DocumentPtr = shared_ptr<Document>;
 /// A shared pointer to a const Document
-using ConstDocumentPtr = shared_ptr<const class Document>;
+using ConstDocumentPtr = shared_ptr<const Document>;
 
 /// @class Document
 /// A MaterialX document, which represents the top-level element in the

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -18,23 +18,30 @@
 namespace MaterialX
 {
 
+class Element;
+class TypedElement;
+class ValueElement;
+class StringResolver;
+class Document;
+class Material;
+
 /// A shared pointer to an Element
-using ElementPtr = shared_ptr<class Element>;
+using ElementPtr = shared_ptr<Element>;
 /// A shared pointer to a const Element
-using ConstElementPtr = shared_ptr<const class Element>;
+using ConstElementPtr = shared_ptr<const Element>;
 
 /// A shared pointer to a TypedElement
-using TypedElementPtr = shared_ptr<class TypedElement>;
+using TypedElementPtr = shared_ptr<TypedElement>;
 /// A shared pointer to a const TypedElement
-using ConstTypedElementPtr = shared_ptr<const class TypedElement>;
+using ConstTypedElementPtr = shared_ptr<const TypedElement>;
 
 /// A shared pointer to a ValueElement
-using ValueElementPtr = shared_ptr<class ValueElement>;
+using ValueElementPtr = shared_ptr<ValueElement>;
 /// A shared pointer to a const ValueElement
-using ConstValueElementPtr = shared_ptr<const class ValueElement>;
+using ConstValueElementPtr = shared_ptr<const ValueElement>;
 
 /// A shared pointer to a StringResolver
-using StringResolverPtr = shared_ptr<class StringResolver>;
+using StringResolverPtr = shared_ptr<StringResolver>;
 
 /// A hash map from strings to elements
 using ElementMap = std::unordered_map<string, ElementPtr>;
@@ -61,9 +68,9 @@ class Element : public std::enable_shared_from_this<Element>
     virtual ~Element() { }
 
   protected:
-    using DocumentPtr = shared_ptr<class Document>;
-    using ConstDocumentPtr = shared_ptr<const class Document>;
-    using ConstMaterialPtr = shared_ptr<const class Material>;
+    using DocumentPtr = shared_ptr<Document>;
+    using ConstDocumentPtr = shared_ptr<const Document>;
+    using ConstMaterialPtr = shared_ptr<const Material>;
 
     template <class T> friend class ElementRegistry;
 

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -20,35 +20,42 @@ extern const string UNIVERSAL_GEOM_NAME;
 extern const string UDIM_TOKEN;
 extern const string UV_TILE_TOKEN;
 
+class GeomElement;
+class GeomAttr;
+class GeomInfo;
+class Collection;
+class CollectionAdd;
+class CollectionRemove;
+
 /// A shared pointer to a GeomElement
-using GeomElementPtr = shared_ptr<class GeomElement>;
+using GeomElementPtr = shared_ptr<GeomElement>;
 /// A shared pointer to a const GeomElement
-using ConstGeomElementPtr = shared_ptr<const class GeomElement>;
+using ConstGeomElementPtr = shared_ptr<const GeomElement>;
 
 /// A shared pointer to a GeomAttr
-using GeomAttrPtr = shared_ptr<class GeomAttr>;
+using GeomAttrPtr = shared_ptr<GeomAttr>;
 /// A shared pointer to a const GeomAttr
-using ConstGeomAttrPtr = shared_ptr<const class GeomAttr>;
+using ConstGeomAttrPtr = shared_ptr<const GeomAttr>;
 
 /// A shared pointer to a GeomInfo
-using GeomInfoPtr = shared_ptr<class GeomInfo>;
+using GeomInfoPtr = shared_ptr<GeomInfo>;
 /// A shared pointer to a const GeomInfo
-using ConstGeomInfoPtr = shared_ptr<const class GeomInfo>;
+using ConstGeomInfoPtr = shared_ptr<const GeomInfo>;
 
 /// A shared pointer to a Collection
-using CollectionPtr = shared_ptr<class Collection>;
+using CollectionPtr = shared_ptr<Collection>;
 /// A shared pointer to a const Collection
-using ConstCollectionPtr = shared_ptr<const class Collection>;
+using ConstCollectionPtr = shared_ptr<const Collection>;
 
 /// A shared pointer to a CollectionAdd
-using CollectionAddPtr = shared_ptr<class CollectionAdd>;
+using CollectionAddPtr = shared_ptr<CollectionAdd>;
 /// A shared pointer to a const CollectionAdd
-using ConstCollectionAddPtr = shared_ptr<const class CollectionAdd>;
+using ConstCollectionAddPtr = shared_ptr<const CollectionAdd>;
 
 /// A shared pointer to a CollectionRemove
-using CollectionRemovePtr = shared_ptr<class CollectionRemove>;
+using CollectionRemovePtr = shared_ptr<CollectionRemove>;
 /// A shared pointer to a const CollectionRemove
-using ConstCollectionRemovePtr = shared_ptr<const class CollectionRemove>;
+using ConstCollectionRemovePtr = shared_ptr<const CollectionRemove>;
 
 /// @class GeomElement
 /// The base class for geometric elements, which support bindings to geometries

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -16,30 +16,38 @@
 namespace MaterialX
 {
 
+class Parameter;
+class PortElement;
+class Input;
+class Output;
+class InterfaceElement;
+class Node;
+class NodeDef;
+
 /// A shared pointer to a Parameter
-using ParameterPtr = shared_ptr<class Parameter>;
+using ParameterPtr = shared_ptr<Parameter>;
 /// A shared pointer to a const Parameter
-using ConstParameterPtr = shared_ptr<const class Parameter>;
+using ConstParameterPtr = shared_ptr<const Parameter>;
 
 /// A shared pointer to a PortElement
-using PortElementPtr = shared_ptr<class PortElement>;
+using PortElementPtr = shared_ptr<PortElement>;
 /// A shared pointer to a const PortElement
-using ConstPortElementPtr = shared_ptr<const class PortElement>;
+using ConstPortElementPtr = shared_ptr<const PortElement>;
 
 /// A shared pointer to an Input
-using InputPtr = shared_ptr<class Input>;
+using InputPtr = shared_ptr<Input>;
 /// A shared pointer to a const Input
-using ConstInputPtr = shared_ptr<const class Input>;
+using ConstInputPtr = shared_ptr<const Input>;
 
 /// A shared pointer to an Output
-using OutputPtr = shared_ptr<class Output>;
+using OutputPtr = shared_ptr<Output>;
 /// A shared pointer to a const Output
-using ConstOutputPtr = shared_ptr<const class Output>;
+using ConstOutputPtr = shared_ptr<const Output>;
 
 /// A shared pointer to an InterfaceElement
-using InterfaceElementPtr = shared_ptr<class InterfaceElement>;
+using InterfaceElementPtr = shared_ptr<InterfaceElement>;
 /// A shared pointer to a const InterfaceElement
-using ConstInterfaceElementPtr = shared_ptr<const class InterfaceElement>;
+using ConstInterfaceElementPtr = shared_ptr<const InterfaceElement>;
 
 /// @class Parameter
 /// A parameter element within a Node or NodeDef.
@@ -90,7 +98,7 @@ class PortElement : public ValueElement
     virtual ~PortElement() { }
 
   protected:
-    using NodePtr = shared_ptr<class Node>;
+    using NodePtr = shared_ptr<Node>;
 
   public:
     /// @name Node Name
@@ -284,7 +292,7 @@ class InterfaceElement : public TypedElement
     virtual ~InterfaceElement() { }
 
   protected:
-    using NodeDefPtr = shared_ptr<class NodeDef>;
+    using NodeDefPtr = shared_ptr<NodeDef>;
 
   public:
     /// @name Parameters

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -17,25 +17,30 @@
 namespace MaterialX
 {
 
+class Look;
+class LookInherit;
+class MaterialAssign;
+class Visibility;
+
 /// A shared pointer to a Look
-using LookPtr = shared_ptr<class Look>;
+using LookPtr = shared_ptr<Look>;
 /// A shared pointer to a const Look
-using ConstLookPtr = shared_ptr<const class Look>;
+using ConstLookPtr = shared_ptr<const Look>;
 
 /// A shared pointer to a LookInherit
-using LookInheritPtr = shared_ptr<class LookInherit>;
+using LookInheritPtr = shared_ptr<LookInherit>;
 /// A shared pointer to a const LookInherit
-using ConstLookInheritPtr = shared_ptr<const class LookInherit>;
+using ConstLookInheritPtr = shared_ptr<const LookInherit>;
 
 /// A shared pointer to a MaterialAssign
-using MaterialAssignPtr = shared_ptr<class MaterialAssign>;
+using MaterialAssignPtr = shared_ptr<MaterialAssign>;
 /// A shared pointer to a const MaterialAssign
-using ConstMaterialAssignPtr = shared_ptr<const class MaterialAssign>;
+using ConstMaterialAssignPtr = shared_ptr<const MaterialAssign>;
 
 /// A shared pointer to a Visibility
-using VisibilityPtr = shared_ptr<class Visibility>;
+using VisibilityPtr = shared_ptr<Visibility>;
 /// A shared pointer to a const Visibility
-using ConstVisibilityPtr = shared_ptr<const class Visibility>;
+using ConstVisibilityPtr = shared_ptr<const Visibility>;
 
 /// @class Look
 /// A look element within a Document.

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -17,35 +17,44 @@
 namespace MaterialX
 {
 
+class Material;
+class ShaderRef;
+class BindParam;
+class BindInput;
+class Override;
+class MaterialInherit;
+class MaterialAssign;
+class Collection;
+
 /// A shared pointer to a Material
-using MaterialPtr = shared_ptr<class Material>;
+using MaterialPtr = shared_ptr<Material>;
 /// A shared pointer to a const Material
-using ConstMaterialPtr = shared_ptr<const class Material>;
+using ConstMaterialPtr = shared_ptr<const Material>;
 
 /// A shared pointer to a ShaderRef
-using ShaderRefPtr = shared_ptr<class ShaderRef>;
+using ShaderRefPtr = shared_ptr<ShaderRef>;
 /// A shared pointer to a const ShaderRef
-using ConstShaderRefPtr = shared_ptr<const class ShaderRef>;
+using ConstShaderRefPtr = shared_ptr<const ShaderRef>;
 
 /// A shared pointer to a BindParam
-using BindParamPtr = shared_ptr<class BindParam>;
+using BindParamPtr = shared_ptr<BindParam>;
 /// A shared pointer to a const BindParam
-using ConstBindParamPtr = shared_ptr<const class BindParam>;
+using ConstBindParamPtr = shared_ptr<const BindParam>;
 
 /// A shared pointer to a BindInput
-using BindInputPtr = shared_ptr<class BindInput>;
+using BindInputPtr = shared_ptr<BindInput>;
 /// A shared pointer to a const BindInput
-using ConstBindInputPtr = shared_ptr<const class BindInput>;
+using ConstBindInputPtr = shared_ptr<const BindInput>;
 
 /// A shared pointer to an Override
-using OverridePtr = shared_ptr<class Override>;
+using OverridePtr = shared_ptr<Override>;
 /// A shared pointer to a const Override
-using ConstOverridePtr = shared_ptr<const class Override>;
+using ConstOverridePtr = shared_ptr<const Override>;
 
 /// A shared pointer to a MaterialInherit
-using MaterialInheritPtr = shared_ptr<class MaterialInherit>;
+using MaterialInheritPtr = shared_ptr<MaterialInherit>;
 /// A shared pointer to a const MaterialInherit
-using ConstMaterialInheritPtr = shared_ptr<const class MaterialInherit>;
+using ConstMaterialInheritPtr = shared_ptr<const MaterialInherit>;
 
 /// @class Material
 /// A material element within a Document.
@@ -62,8 +71,8 @@ class Material : public Element
     virtual ~Material() { }
 
   protected:
-    using MaterialAssignPtr = shared_ptr<class MaterialAssign>;
-    using CollectionPtr = shared_ptr<class Collection>;
+    using MaterialAssignPtr = shared_ptr<MaterialAssign>;
+    using CollectionPtr = shared_ptr<Collection>;
 
   public:
     /// @name ShaderRef Elements

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -16,15 +16,18 @@
 namespace MaterialX
 {
 
+class Node;
+class NodeGraph;
+
 /// A shared pointer to a Node
-using NodePtr = shared_ptr<class Node>;
+using NodePtr = shared_ptr<Node>;
 /// A shared pointer to a const Node
-using ConstNodePtr = shared_ptr<const class Node>;
+using ConstNodePtr = shared_ptr<const Node>;
 
 /// A shared pointer to a NodeGraph
-using NodeGraphPtr = shared_ptr<class NodeGraph>;
+using NodeGraphPtr = shared_ptr<NodeGraph>;
 /// A shared pointer to a const NodeGraph
-using ConstNodeGraphPtr = shared_ptr<const class NodeGraph>;
+using ConstNodeGraphPtr = shared_ptr<const NodeGraph>;
 
 /// @class Node
 /// A node element within a NodeGraph.

--- a/source/MaterialXCore/Observer.h
+++ b/source/MaterialXCore/Observer.h
@@ -14,15 +14,18 @@
 namespace MaterialX
 {
 
+class Observer;
+class ObservedDocument;
+
 /// A shared pointer to an Observer
-using ObserverPtr = shared_ptr<class Observer>;
+using ObserverPtr = shared_ptr<Observer>;
 /// A shared pointer to a const Observer
-using ConstObserverPtr = shared_ptr<const class Observer>;
+using ConstObserverPtr = shared_ptr<const Observer>;
 
 /// A shared pointer to an ObservedDocument
-using ObservedDocumentPtr = shared_ptr<class ObservedDocument>;
+using ObservedDocumentPtr = shared_ptr<ObservedDocument>;
 /// A shared pointer to a const ObservedDocument
-using ConstObservedDocumentPtr = shared_ptr<const class ObservedDocument>;
+using ConstObservedDocumentPtr = shared_ptr<const ObservedDocument>;
 
 /// @class Observer
 /// An observer of a MaterialX Document.

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -16,25 +16,30 @@
 namespace MaterialX
 {
 
+class Property;
+class PropertyAssign;
+class PropertySet;
+class PropertySetAssign;
+
 /// A shared pointer to a Property
-using PropertyPtr = shared_ptr<class Property>;
+using PropertyPtr = shared_ptr<Property>;
 /// A shared pointer to a const Property
-using ConstPropertyPtr = shared_ptr<const class Property>;
+using ConstPropertyPtr = shared_ptr<const Property>;
 
 /// A shared pointer to a PropertyAssign
-using PropertyAssignPtr = shared_ptr<class PropertyAssign>;
+using PropertyAssignPtr = shared_ptr<PropertyAssign>;
 /// A shared pointer to a const PropertyAssign
-using ConstPropertyAssignPtr = shared_ptr<const class PropertyAssign>;
+using ConstPropertyAssignPtr = shared_ptr<const PropertyAssign>;
 
 /// A shared pointer to a PropertySet
-using PropertySetPtr = shared_ptr<class PropertySet>;
+using PropertySetPtr = shared_ptr<PropertySet>;
 /// A shared pointer to a const PropertySet
-using ConstPropertySetPtr = shared_ptr<const class PropertySet>;
+using ConstPropertySetPtr = shared_ptr<const PropertySet>;
 
 /// A shared pointer to a PropertySetAssign
-using PropertySetAssignPtr = shared_ptr<class PropertySetAssign>;
+using PropertySetAssignPtr = shared_ptr<PropertySetAssign>;
 /// A shared pointer to a const PropertySetAssign
-using ConstPropertySetAssignPtr = shared_ptr<const class PropertySetAssign>;
+using ConstPropertySetAssignPtr = shared_ptr<const PropertySetAssign>;
 
 /// @class Property
 /// A property element within a PropertySet.

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -14,9 +14,12 @@
 namespace MaterialX
 {
 
-using ElementPtr = shared_ptr<class Element>;
-using ConstElementPtr = shared_ptr<const class Element>;
-using ConstMaterialPtr = shared_ptr<const class Material>;
+class Element;
+class Material;
+
+using ElementPtr = shared_ptr<Element>;
+using ConstElementPtr = shared_ptr<const Element>;
+using ConstMaterialPtr = shared_ptr<const Material>;
 
 /// @class Edge
 /// An edge between two connected Elements, returned during graph traversal.

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -16,8 +16,11 @@ namespace MaterialX
 
 extern const string EMPTY_STRING;
 
-using ElementPtr = shared_ptr<class Element>;
-using NodeGraphPtr = shared_ptr<class NodeGraph>;
+class Element;
+class NodeGraph;
+
+using ElementPtr = shared_ptr<Element>;
+using NodeGraphPtr = shared_ptr<NodeGraph>;
 
 /// Return the version of the MaterialX library as a string.
 string getVersionString();

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -16,10 +16,12 @@
 namespace MaterialX
 {
 
+class Value;
+
 /// A shared pointer to a Value
-using ValuePtr = shared_ptr<class Value>;
+using ValuePtr = shared_ptr<Value>;
 /// A shared pointer to a const Value
-using ConstValuePtr = shared_ptr<const class Value>;
+using ConstValuePtr = shared_ptr<const Value>;
 
 template <class T> class TypedValue;
 


### PR DESCRIPTION
* Add forward declarations for classes used in type aliases.

Without these a client could define e.g. a Material class before including
MaterialXCore/Material.h, which would cause the type alias

  using MaterialPtr = shared_ptr<class Material>;

to be interpreted as aliasing a ptr to the client's Material, rather than
interpreted as aliasing a forward declaration of MaterialX::Material.

* Remove `class` keyword from type aliases.