### PR TITLE
Minor fix to standard surface nodedef naming.

### DIFF
--- a/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
@@ -236,7 +236,7 @@
   <!--
     Node: <standard_surface>
   -->
-  <nodedef name="ND_standard_surface" node="standard_surface" type="surfaceshader" nodecategory="shaderx"
+  <nodedef name="ND_standard_surface__surfaceshader" node="standard_surface" type="surfaceshader" nodecategory="shaderx"
            doc="A surface uber shader based on the Arnold standard surface shader">
       <input name="base" type="float" value="0.8" />
       <input name="base_color" type="color3" value="1, 1, 1" />

--- a/documents/Libraries/sxpbrlib/sxpbrlib_ng.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_ng.mtlx
@@ -42,7 +42,7 @@
   </nodegraph>
 
   <!-- <standard_surface> -->
-  <nodegraph name="IMP_standard_surface" type="" nodedef="ND_standard_surface">
+  <nodegraph name="IMPL_standard_surface__surfaceshader" type="" nodedef="ND_standard_surface__surfaceshader">
     <!-- Roughness influence by coat-->
     <constant name="coat_affect_roughness" type="float">
       <parameter name="value" type="float" value="0.0" />


### PR DESCRIPTION
Make standard surface conform to naming standard by add __\<type\> to the node definition name.
