### PR TITLE
Improvements to color management

### DIFF
--- a/documents/Libraries/stdlib/sx-osl/mx_image_color2.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color2.osl
@@ -12,6 +12,4 @@ void mx_image_color2(string file, string layer, color2 default_value, vector2 te
 
     out.r = rgb[0];
     out.a = rgb[1];
-
-    out.r = pow(out.r, 2.2);
 }

--- a/documents/Libraries/stdlib/sx-osl/mx_image_color3.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color3.osl
@@ -9,6 +9,4 @@ void mx_image_color3(string file, string layer, color default_value, vector2 tex
     vdirection(texcoord, texcoord);
     color missingColor = default_value;
     out = texture(file, texcoord.x, texcoord.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
-
-    out = pow(out, 2.2);
 }

--- a/documents/Libraries/stdlib/sx-osl/mx_image_color4.osl
+++ b/documents/Libraries/stdlib/sx-osl/mx_image_color4.osl
@@ -14,6 +14,5 @@ void mx_image_color4(string file, string layer, color4 default_value, vector2 te
     color rgb = texture(file, texcoord.x, texcoord.y, "alpha", alpha, "subimage", layer,
                         "missingcolor", missingColor, "missingalpha", missingAlpha, "wrap", uaddressmode);
 
-    rgb = pow(rgb, 2.2);
     out = color4(rgb, alpha);
 }

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color2.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color2.glsl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color2(vec2 _in, out vec2 result)
+{
+    result = vec2(pow(_in.x, 2.2), _in.y);
+}

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color3.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color3.glsl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color3(vec3 _in, out vec3 result)
+{
+    result = pow(_in, vec3(2.2));
+}

--- a/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color4.glsl
+++ b/documents/Libraries/sxpbrlib/sx-glsl/sx_srgb_linear_color4.glsl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color4(vec4 _in, out vec4 result)
+{
+    result = vec4(pow(_in.xyz, vec3(2.2)), _in.w);
+}

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color2.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color2.osl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color2(color2 in, output color2 result)
+{
+    result = color2(pow(in.r, 2.2), in.a);
+}

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color3.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color3.osl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color3(color in, output color result)
+{
+    result = pow(in, 2.2);
+}

--- a/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color4.osl
+++ b/documents/Libraries/sxpbrlib/sx-osl/sx_srgb_linear_color4.osl
@@ -1,0 +1,4 @@
+void sx_srgb_linear_color4(color4 in, output color4 result)
+{
+    result = color4(pow(in.rgb, 2.2), in.a);
+}

--- a/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_defs.mtlx
@@ -346,4 +346,17 @@
     <input name="invertAlpha" type="boolean" value="false" />
   </nodedef>
 
+  <!--
+    Node: <srgb_linear>
+  -->
+  <nodedef name="ND_srgb_linear__color2" node="srgb_linear" type="color2" nodecategory="shaderx">
+    <input name="in" type="color2" />
+  </nodedef>
+  <nodedef name="ND_srgb_linear__color3" node="srgb_linear" type="color3" nodecategory="shaderx">
+    <input name="in" type="color3" />
+  </nodedef>
+  <nodedef name="ND_srgb_linear__color4" node="srgb_linear" type="color4" nodecategory="shaderx">
+    <input name="in" type="color4" />
+  </nodedef>
+
 </materialx>

--- a/documents/Libraries/sxpbrlib/sxpbrlib_sx-glsl_impl.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_sx-glsl_impl.mtlx
@@ -70,4 +70,9 @@
   <!-- <colorcorrect> -->
   <implementation name="IM_colorcorrect__color3__sx_glsl" nodedef="ND_colorcorrect__color3" file="sxpbrlib/sx-glsl/sx_colorcorrect.glsl" function="sx_colorcorrect" language="sx-glsl"/>
 
+  <!-- <srgb_linear> -->
+  <implementation name="IM_srgb_linear__color2__sx_glsl" nodedef="ND_srgb_linear__color2" file="sxpbrlib/sx-glsl/sx_srgb_linear_color2.glsl" function="sx_srgb_linear_color2" language="sx-glsl"/>
+  <implementation name="IM_srgb_linear__color3__sx_glsl" nodedef="ND_srgb_linear__color3" file="sxpbrlib/sx-glsl/sx_srgb_linear_color3.glsl" function="sx_srgb_linear_color3" language="sx-glsl"/>
+  <implementation name="IM_srgb_linear__color4__sx_glsl" nodedef="ND_srgb_linear__color4" file="sxpbrlib/sx-glsl/sx_srgb_linear_color4.glsl" function="sx_srgb_linear_color4" language="sx-glsl"/>
+
 </materialx>

--- a/documents/Libraries/sxpbrlib/sxpbrlib_sx-osl_impl.mtlx
+++ b/documents/Libraries/sxpbrlib/sxpbrlib_sx-osl_impl.mtlx
@@ -52,4 +52,9 @@
   <!-- <normalmap> -->
   <implementation name="IM_normalmap__sx_osl" nodedef="ND_normalmap" file="sxpbrlib/sx-osl/sx_normalmap.osl" function="sx_normalmap" language="sx-osl"/>
 
+  <!-- <srgb_linear> -->
+  <implementation name="IM_srgb_linear__color2__sx_osl" nodedef="ND_srgb_linear__color2" file="sxpbrlib/sx-osl/sx_srgb_linear_color2.osl" function="sx_srgb_linear_color2" language="sx-osl"/>
+  <implementation name="IM_srgb_linear__color3__sx_osl" nodedef="ND_srgb_linear__color3" file="sxpbrlib/sx-osl/sx_srgb_linear_color3.osl" function="sx_srgb_linear_color3" language="sx-osl"/>
+  <implementation name="IM_srgb_linear__color4__sx_osl" nodedef="ND_srgb_linear__color4" file="sxpbrlib/sx-osl/sx_srgb_linear_color4.osl" function="sx_srgb_linear_color4" language="sx-osl"/>
+
 </materialx>

--- a/source/MaterialXShaderGen/SgNode.h
+++ b/source/MaterialXShaderGen/SgNode.h
@@ -2,6 +2,7 @@
 #define MATERIALX_SGNODE_H
 
 #include <MaterialXCore/Node.h>
+#include <MaterialXCore/Document.h>
 
 #include <MaterialXShaderGen/SgImplementation.h>
 
@@ -233,7 +234,7 @@ using SgOutputSocket = SgInput;
 class SgNodeGraph : public SgNode
 {
 public:
-    SgNodeGraph(const string& name);
+    SgNodeGraph(const string& name, DocumentPtr document);
 
     /// Create a new shadergen graph from an element.
     /// Supported elements are outputs and shaderrefs.
@@ -295,7 +296,10 @@ protected:
     void addUpstreamDependencies(const Element& root, ConstMaterialPtr material, ShaderGenerator& shadergen);
 
     /// Add a default geometric node and connect to the given input.
-    void addDefaultGeomNode(SgInput* input, const string& geomNode, const Document& doc, ShaderGenerator& shadergen);
+    void addDefaultGeomNode(SgInput* input, const string& geomNode, ShaderGenerator& shadergen);
+
+    /// Add a color transform node and connect to the given output.
+    void addColorTransformNode(SgOutput* output, const string& colorTransform, ShaderGenerator& shadergen);
 
     /// Perform all post-build operations on the graph.
     void finalize(ShaderGenerator& shadergen);
@@ -323,8 +327,12 @@ protected:
     /// Break all connections on a node
     static void disconnect(SgNode* node);
 
+    DocumentPtr _document;
     std::unordered_map<string, SgNodePtr> _nodeMap;
     std::vector<SgNode*> _nodeOrder;
+
+    // Temporary storage for nodes that require color transformations
+    std::unordered_map<SgNode*, string> _colorTransformMap;
 };
 
 /// A function argument for node implementation functions.


### PR DESCRIPTION
 - Removed hard coded gamma correction from OSL <image> implementations
 - Added tracking of color space usage for file texture nodes during graph traversal
 - Added support for insertion of color transform nodes in graph finalization
 - Added a simple sRGB color transformation node (just gamma 2.2 for now)
 - Added a new test case for color spaces