### PR TITLE
Generalize ShaderX validation tests

### DIFF
--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -134,7 +134,7 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
     // Example1: Create a material from 'standard_surface' with support for normal mapping
     {
         mx::MaterialPtr material = doc->addMaterial("example1");
-        mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "standard_surface");
+        mx::ShaderRefPtr shaderRef = material->addShaderRef("example1_surface", "standard_surface");
 
         // Create nodes to handle normal mapping and bind it to the shader's normal input
         mx::NodePtr texcoord1 = doc->addNode("texcoord", "texcoord1", "vector2");
@@ -213,7 +213,7 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
 
         // Create a material with the above shader node as the shader ref
         mx::MaterialPtr material = doc->addMaterial("example2");
-        mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "testshader2");
+        mx::ShaderRefPtr shaderRef = material->addShaderRef("example2_surface", "testshader2");
 
         // Bind a couple of shader parameter values
         mx::BindInputPtr diffuse_reflectance_input = shaderRef->addBindInput("diffuse_reflectance", "color3");
@@ -295,7 +295,7 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
 
         // Create a material with the above shader node as the shader ref
         mx::MaterialPtr material = doc->addMaterial("example3");
-        mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "testshader3");
+        mx::ShaderRefPtr shaderRef = material->addShaderRef("example3_surface", "testshader3");
 
         // Bind values setting both reflectivity/edgetint and ior_n/ior_k to represent gold,
         // so both metals should give the same result.
@@ -399,7 +399,7 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
 
         // Create a material with the above shader node as the shader ref
         mx::MaterialPtr material = doc->addMaterial("example4");
-        mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "testshader4");
+        mx::ShaderRefPtr shaderRef = material->addShaderRef("example4_surface", "testshader4");
 
         // Bind a couple of shader parameter values
         mx::BindInputPtr base_input = shaderRef->addBindInput("base", "float");
@@ -421,7 +421,7 @@ void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& m
     // Example5: Create a material directly from 'standard_surface'
     {
         mx::MaterialPtr material = doc->addMaterial("example5");
-        mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "standard_surface");
+        mx::ShaderRefPtr shaderRef = material->addShaderRef("example5_surface", "standard_surface");
 
         // Bind a couple of shader parameter values
         mx::BindInputPtr specular_roughness_input = shaderRef->addBindInput("specular_roughness", "float");
@@ -1743,7 +1743,7 @@ TEST_CASE("Color Spaces", "[shadergen]")
     loadLibraries({ "stdlib", "sxpbrlib" }, searchPath, doc);
 
     mx::MaterialPtr material = doc->addMaterial("color_spaces");
-    mx::ShaderRefPtr shaderRef = material->addShaderRef("surface", "standard_surface");
+    mx::ShaderRefPtr shaderRef = material->addShaderRef("color_spaces_surface", "standard_surface");
 
     // Bind an image texture to the base_color input, with sRGB color space
     mx::NodePtr baseColorTex = doc->addNode("image", "base_color_tex", "color3");

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -30,6 +30,7 @@ extern void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath&
 extern void createLightRig(mx::DocumentPtr doc, mx::HwLightHandler& lightHandler, mx::HwShaderGenerator& shadergen);
 extern void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& materials);
 
+#if 0
 TEST_CASE("GLSL Source", "[shadervalid]")
 {
 #ifdef LOG_TO_FILE
@@ -247,115 +248,36 @@ TEST_CASE("GLSL Source", "[shadervalid]")
         }
     }
 }
-
-TEST_CASE("GLSL Shader", "[shadervalid]")
-{
-#ifdef LOG_TO_FILE
-    std::ofstream logfile("log_shadervalid_glsl_shader.txt");
-    std::ostream& log(logfile);
-#else
-    std::ostream& log(std::cout);
 #endif
 
-    mx::DocumentPtr doc = mx::createDocument();
-
-    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Libraries");
-    loadLibraries({ "stdlib", "sxpbrlib" }, searchPath, doc);
-
-    mx::ShaderGeneratorPtr shaderGenerator = mx::GlslShaderGenerator::create();
-    shaderGenerator->registerSourceCodeSearchPath(searchPath);
-
-    // Create a graph testing some geometric nodes
-    mx::NodeGraphPtr nodeGraph = doc->addNodeGraph("geometry_attributes");
-
-    std::vector<mx::NodePtr> attributeList;
-
-    // normal output test
-    mx::NodePtr normal1 = nodeGraph->addNode("normal", "normal1", "vector3");
-    normal1->setParameterValue("space", std::string("world"));
-    attributeList.push_back(normal1);
-
-    // position output test
-    mx::NodePtr position1 = nodeGraph->addNode("position", "position1", "vector3");
-    position1->setParameterValue("space", std::string("world"));
-    mx::NodePtr constant = nodeGraph->addNode("constant");
-    mx::ParameterPtr v = constant->addParameter("value", "vector3");
-    v->setValueString("0.003921568627451, 0.003921568627451, 0.003921568627451");
-    mx::NodePtr multiply1 = nodeGraph->addNode("multiply", "multiply1", "vector3");
-    multiply1->setConnectedNode("in1", position1);
-    multiply1->setConnectedNode("in2", constant);
-    //attributeList.push_back(multiply1); -- error : Could not find a nodedef for node 'multiply1' ?
-    attributeList.push_back(position1);
-
-    // color output test
-    mx::NodePtr geomcolor1 = nodeGraph->addNode("geomcolor", "geomcolor_set0", "color3");
-    geomcolor1->setParameterValue("index", 0, "integer");
-    attributeList.push_back(geomcolor1);
-
-    // color output set 2 test
-    mx::NodePtr geomcolor2 = nodeGraph->addNode("geomcolor", "geomcolor_set1", "color3");
-    geomcolor2->setParameterValue("index", 1, "integer");
-    attributeList.push_back(geomcolor2);
-
-    // tangent output test
-    mx::NodePtr tangent = nodeGraph->addNode("tangent", "tangent1", "vector3");
-    //tangent->setParameterValue("index", 0, "integer"); -- not supported yet in core
-    attributeList.push_back(tangent);
-
-    // bitangent output test
-    mx::NodePtr bitangent = nodeGraph->addNode("bitangent", "bitangent1", "vector3");
-    //bitangent->setParameterValue("index", 0, "integer"); -- not supported yet in core
-    attributeList.push_back(bitangent);
-
-    // uv output test
-    mx::NodePtr texcoord1 = nodeGraph->addNode("texcoord", "texcoord1", "vector2");
-    texcoord1->setParameterValue("index", 0, "integer");
-    mx::NodePtr swizzle1 = nodeGraph->addNode("swizzle", "uv_set0", "vector3");
-    swizzle1->setConnectedNode("in", texcoord1);
-    swizzle1->setParameterValue("channels", std::string("xy0"));
-    attributeList.push_back(swizzle1);
-
-    // uv set 2 output test
-    mx::NodePtr texcoord2 = nodeGraph->addNode("texcoord", "texcoord2", "vector2");
-    texcoord2->setParameterValue("index", 1, "integer");
-    mx::NodePtr swizzle2 = nodeGraph->addNode("swizzle", "uv_set1", "vector3");
-    swizzle2->setConnectedNode("in", texcoord2);
-    swizzle2->setParameterValue("channels", std::string("xy0"));
-    attributeList.push_back(swizzle2);
-
-    // image.
-    mx::FilePath imagePath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Images/MaterialXLogo.exr");
-    std::string imageName = imagePath.asString();
-    mx::NodePtr image = nodeGraph->addNode("image", "image1", "color3");
-    image->setParameterValue("file", imageName, "filename");
-    attributeList.push_back(image);
-
-    // Connected to output.
-    mx::OutputPtr output1 = nodeGraph->addOutput(mx::EMPTY_STRING, "vector3");
-
-    // Setup lighting
-    mx::HwLightHandlerPtr lightHandler = mx::HwLightHandler::create();
-    mx::HwShaderGenerator& hwGenerator = static_cast<mx::HwShaderGenerator&>(*shaderGenerator);
-    createLightRig(doc, *lightHandler, hwGenerator);
-    // Pre-clamp the number of light sources to the number bound
-    size_t lightSourceCount = lightHandler->getLightSources().size();
-    hwGenerator.setMaxActiveLightSources(lightSourceCount);
-
+//
+// Create a validator with an image and geometry handler
+// If a filename is supplied then a stock geometry of that name will be used if it can be loaded.
+// By default if the file can be loaded it is assumed that rendering is done using a perspective
+// view vs an orthographic view. This flag argument is updated and returned.
+//
+static mx::GlslValidatorPtr createValidator(bool& orthographicView, const std::string& fileName,
+                                            std::ostream& log)
+{
     bool initialized = false;
-    bool orthographicsView = true;
+    orthographicView = true;
     mx::GlslValidatorPtr validator = mx::GlslValidator::create();
     mx::TinyEXRImageHandlerPtr imageHandler = mx::TinyEXRImageHandler::create();
     try
     {
         validator->initialize();
         validator->setImageHandler(imageHandler);
-        validator->setLightHandler(lightHandler);
-        const std::string geometryFile(mx::FilePath::getCurrentPath().asString() + "/documents/Geometry/shaderball.obj");
+        validator->setLightHandler(nullptr);
         mx::GeometryHandlerPtr geometryHandler = validator->getGeometryHandler();
-        geometryHandler->setIdentifier(geometryFile);
+        std::string geometryFile; 
+        if (fileName.length())
+        {
+            geometryFile =  mx::FilePath::getCurrentPath().asString() + "/documents/Geometry/" + fileName;
+            geometryHandler->setIdentifier(geometryFile);
+        }
         if (geometryHandler->getIdentifier() == geometryFile)
         {
-            orthographicsView = false;
+            orthographicView = false;
         }
         initialized = true;
     }
@@ -368,26 +290,47 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
     }
     REQUIRE(initialized);
 
+    return validator;
+}
+
+// Iterator through each node to test by connecting it to a supplied out
+// 1. Create the shader and checks for source generation
+// 2. Writes doc to disk if valid
+// 3. Writes vertex and pixel shaders to disk
+// 4. Validates creation / compilation of shader program
+// 5. Validates that inputs were created properly
+// 6. Validates rendering
+// 7. Saves rendered image to disk
+//
+// Outputs error log if validation fails
+//
+static void runValidation(const std::string& shaderName, std::vector<mx::ElementPtr> elementList,
+                          mx::GlslValidatorPtr validator, mx::ShaderGeneratorPtr shaderGenerator,
+                          bool orthographicView, mx::DocumentPtr doc, std::ostream& log)
+{
     mx::SgOptions options;
 
-    for (auto nodePtr : attributeList)
+    for (auto elemPtr : elementList)
     {
-        log << "------------ Validate with output node as input: " << nodePtr->getName() << std::endl;
-        output1->setConnectedNode(nodePtr);
+        if (!elemPtr)
+        {
+            continue;
+        }
+        log << "------------ Run validation with element: " << elemPtr->getName() << std::endl;
 
-        mx::ShaderPtr shader = shaderGenerator->generate(nodeGraph->getName(), output1, options);
+        mx::ShaderPtr shader = shaderGenerator->generate(shaderName, elemPtr, options);
         mx::HwShaderPtr hwShader = std::dynamic_pointer_cast<mx::HwShader>(shader);
         REQUIRE(hwShader != nullptr);
         REQUIRE(hwShader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
         REQUIRE(hwShader->getSourceCode(mx::HwShader::VERTEX_STAGE).length() > 0);
 
-        mx::writeToXmlFile(doc, nodePtr->getName() + ".mtlx");
+        mx::writeToXmlFile(doc, elemPtr->getName() + ".mtlx");
 
         std::ofstream file;
-        file.open(nodePtr->getName() + ".vert");
+        file.open(elemPtr->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         file.close();
-        file.open(nodePtr->getName() + ".frag");
+        file.open(elemPtr->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
 
@@ -402,8 +345,8 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
             program->printUniforms(log);
             program->printAttributes(log);
 
-            validator->validateRender(orthographicsView);
-            std::string fileName = nodePtr->getName() + ".exr";
+            validator->validateRender(orthographicView);
+            std::string fileName = elemPtr->getName() + ".exr";
             validator->save(fileName);
 
             validated = true;
@@ -414,7 +357,7 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
             {
                 log << e.what() << " " << error << std::endl;
             }
-            
+
             std::string stage = program->getStage(mx::HwShader::VERTEX_STAGE);
             log << ">> Failed vertex stage code:\n";
             log << stage;
@@ -424,6 +367,140 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
         }
         REQUIRE(validated);
     }
+}
+
+TEST_CASE("GLSL geometry", "[shadervalid]")
+{
+#ifdef LOG_TO_FILE
+    std::ofstream logfile("log_shadervalid_glsl_geometry.txt");
+    std::ostream& log(logfile);
+#else
+    std::ostream& log(std::cout);
+#endif
+
+    mx::DocumentPtr doc = mx::createDocument();
+
+    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Libraries");
+    loadLibraries({ "stdlib", "sxpbrlib" }, searchPath, doc);
+
+    // Create a graph testing some geometric nodes
+    mx::NodeGraphPtr nodeGraph = doc->addNodeGraph("geometry_attributes");
+
+    std::vector<mx::ElementPtr> outputList;
+
+    // Normal stream test
+    mx::NodePtr normal1 = nodeGraph->addNode("normal", "normal1", "vector3");
+    normal1->setParameterValue("space", std::string("world"));
+    mx::OutputPtr normal_output = nodeGraph->addOutput("normal_output", "vector3");
+    normal_output->setConnectedNode(normal1);
+    outputList.push_back(normal_output);
+
+    // Position stream test
+    mx::NodePtr position1 = nodeGraph->addNode("position", "position1", "vector3");
+    position1->setParameterValue("space", std::string("world"));
+    mx::OutputPtr position_output = nodeGraph->addOutput("position_output", "vector3");
+    position_output->setConnectedNode(position1);
+    outputList.push_back(position_output);
+
+    // Color stream test
+    mx::NodePtr geomcolor1 = nodeGraph->addNode("geomcolor", "geomcolor_set0", "color3");
+    geomcolor1->setParameterValue("index", 0, "integer");
+    mx::OutputPtr geomcolor1_output = nodeGraph->addOutput("geomcolor1_output", "vector3");
+    geomcolor1_output->setConnectedNode(geomcolor1);
+    outputList.push_back(geomcolor1_output);
+
+    // Second color stream test
+    mx::NodePtr geomcolor2 = nodeGraph->addNode("geomcolor", "geomcolor_set1", "color3");
+    geomcolor2->setParameterValue("index", 1, "integer");
+    mx::OutputPtr geomcolor2_output = nodeGraph->addOutput("geomcolor2_output", "vector3");
+    geomcolor2_output->setConnectedNode(geomcolor2);
+    outputList.push_back(geomcolor2_output);
+
+    // Tangent stream test.
+    mx::NodePtr tangent1 = nodeGraph->addNode("tangent", "tangent1", "vector3");
+    tangent1->setParameterValue("index", 0, "integer");
+    mx::OutputPtr tangent1_output = nodeGraph->addOutput("tangent1_output", "vector3");
+    tangent1_output->setConnectedNode(tangent1);
+    outputList.push_back(tangent1_output);
+
+    // Bitangent stream test
+    mx::NodePtr bitangent1 = nodeGraph->addNode("bitangent", "bitangent1", "vector3");
+    bitangent1->setParameterValue("index", 0, "integer");
+    mx::OutputPtr bitangent1_output = nodeGraph->addOutput("bitangent1_output", "vector3");
+    bitangent1_output->setConnectedNode(bitangent1);
+    outputList.push_back(bitangent1_output);
+
+    // UV stream test
+    mx::NodePtr texcoord1 = nodeGraph->addNode("texcoord", "texcoord1", "vector2");
+    texcoord1->setParameterValue("index", 0, "integer");
+    mx::NodePtr swizzle1 = nodeGraph->addNode("swizzle", "uv_set0", "vector3");
+    swizzle1->setConnectedNode("in", texcoord1);
+    swizzle1->setParameterValue("channels", std::string("xy0"));
+    mx::OutputPtr texcoord1_output = nodeGraph->addOutput("texcoord1_output", "vector3");
+    texcoord1_output->setConnectedNode(swizzle1);
+    outputList.push_back(texcoord1_output);
+
+    // Second UV stream test
+    mx::NodePtr texcoord2 = nodeGraph->addNode("texcoord", "texcoord2", "vector2");
+    texcoord2->setParameterValue("index", 1, "integer");
+    mx::NodePtr swizzle2 = nodeGraph->addNode("swizzle", "uv_set1", "vector3");
+    swizzle2->setConnectedNode("in", texcoord2);
+    swizzle2->setParameterValue("channels", std::string("xy0"));
+    mx::OutputPtr texcoord2_output = nodeGraph->addOutput("texcoord2_output", "vector3");
+    texcoord2_output->setConnectedNode(swizzle2);
+    outputList.push_back(texcoord2_output);
+
+    // Image test
+    mx::FilePath imagePath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Images/MaterialXLogo.exr");
+    std::string imageName = imagePath.asString();
+    mx::NodePtr image1 = nodeGraph->addNode("image", "image1", "color3");
+    image1->setParameterValue("file", imageName, "filename");
+    mx::OutputPtr image_output = nodeGraph->addOutput("image1_output", "vector3");
+    image_output->setConnectedNode(image1);
+    outputList.push_back(image_output);
+
+    // Create a validator
+    bool orthographicView = true;
+    mx::GlslValidatorPtr validator = createValidator(orthographicView, "shaderball.obj", log);
+
+    // Set up shader generator
+    mx::ShaderGeneratorPtr shaderGenerator = mx::GlslShaderGenerator::create();
+    shaderGenerator->registerSourceCodeSearchPath(searchPath);
+
+    // Run validation
+    runValidation(nodeGraph->getName(), outputList, validator, shaderGenerator, orthographicView, doc, log);
+}
+
+TEST_CASE("GLSL shading", "[shadervalid]")
+{
+#ifdef LOG_TO_FILE
+    std::ofstream logfile("log_shadervalid_glsl_shading.txt");
+    std::ostream& log(logfile);
+#else
+    std::ostream& log(std::cout);
+#endif
+    mx::DocumentPtr doc = mx::createDocument();
+
+    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Libraries");
+    loadLibraries({ "stdlib", "sxpbrlib" }, searchPath, doc);
+
+    // Create a validator
+    bool orthographicView = true;
+    mx::GlslValidatorPtr validator = createValidator(orthographicView, "shaderball.obj", log);
+
+    // Create shader generator
+    mx::ShaderGeneratorPtr shaderGenerator = mx::GlslShaderGenerator::create();
+    shaderGenerator->registerSourceCodeSearchPath(searchPath);
+
+    // Set up lighting
+    mx::HwLightHandlerPtr lightHandler = mx::HwLightHandler::create();
+    mx::HwShaderGenerator& hwGenerator = static_cast<mx::HwShaderGenerator&>(*shaderGenerator);
+    createLightRig(doc, *lightHandler, hwGenerator);
+    // Pre-clamp the number of light sources to the number bound
+    size_t lightSourceCount = lightHandler->getLightSources().size();
+    hwGenerator.setMaxActiveLightSources(lightSourceCount);
+
+    mx::SgOptions options;
 
     //
     // Lighting test
@@ -443,68 +520,18 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
               <input name=\"roughness\" type=\"float\" value=\"0.8\" /> \
               <input name=\"normal\" type=\"vector3\" /> \
             </diffusebsdf>  \
-            <output name=\"out\" type=\"surfaceshader\" nodename=\"surface1\" /> \
+            <output name=\"lighting_output\" type=\"surfaceshader\" nodename=\"surface1\" /> \
           </nodegraph> \
         </materialx>";
 
-        log << "------------- Validating lighting shader" << std::endl;
-
         MaterialX::readFromXmlBuffer(doc, lightDoc.c_str());
-        mx::writeToXmlFile(doc, "lighting.mtlx");
-        nodeGraph = doc->getNodeGraph("lighting1");
-        mx::ElementPtr output = nodeGraph->getChild("out");
+        mx::NodeGraphPtr nodeGraph = doc->getNodeGraph("lighting1");
+        mx::OutputPtr output = nodeGraph->getOutput("lighting_output");
 
-        // Test shader generation from nodegraph output
-        mx::ShaderPtr shader = shaderGenerator->generate(nodeGraph->getName(), output, options);
-        mx::HwShaderPtr hwShader = std::dynamic_pointer_cast<mx::HwShader>(shader);
-        REQUIRE(hwShader != nullptr);
-        REQUIRE(hwShader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
-        REQUIRE(hwShader->getSourceCode(mx::HwShader::VERTEX_STAGE).length() > 0);
-
-        std::ofstream file;
-        file.open("lighting1.vert");
-        file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
-        file.close();
-        file.open("lighting1.frag");
-        file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
-        file.close();
-
-        /////////////////////////////////////////////////////
-        bool validated = false;
-        MaterialX::GlslProgramPtr program = nullptr;
-        try
-        {
-            validator->validateCreation(hwShader);
-            validator->validateInputs();
-
-            program = validator->program();
-            program->printUniforms(log);
-            program->printAttributes(log);
-
-            validator->validateRender(orthographicsView);
-            const std::string fileName = "lighting1.exr";
-            validator->save(fileName);
-
-            validated = true;
-        }
-        catch (mx::ExceptionShaderValidationError e)
-        {
-            for (auto error : e.errorLog())
-            {
-                log << e.what() << " " << error << std::endl;
-            }
-
-            if (program)
-            {
-                std::string stage = program->getStage(mx::HwShader::VERTEX_STAGE);
-                log << ">> Failed vertex stage code:\n";
-                log << stage;
-                stage = program->getStage(mx::HwShader::PIXEL_STAGE);
-                log << ">> Failed pixel stage code:\n";
-                log << stage;
-            }
-        }
-        REQUIRE(validated);
+        // Run validation
+        std::vector<mx::ElementPtr> outputList;
+        outputList.push_back(output);
+        runValidation(nodeGraph->getName(), outputList, validator, shaderGenerator, orthographicView, doc, log);
     }
 
     //
@@ -519,6 +546,11 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
             for (mx::ShaderRefPtr shaderRef : material->getShaderRefs())
             {
                 const std::string name = material->getName() + "_" + shaderRef->getName();
+
+                std::vector<mx::ElementPtr> shaderRefList;
+                shaderRefList.push_back(shaderRef);
+                runValidation(name, shaderRefList, validator, shaderGenerator, orthographicView, doc, log);
+#if 0
                 mx::ShaderPtr shader = shaderGenerator->generate(name, shaderRef, options);
                 REQUIRE(shader != nullptr);
                 REQUIRE(shader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
@@ -535,7 +567,7 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
                     program->printUniforms(log);
                     program->printAttributes(log);
 
-                    validator->validateRender(orthographicsView);
+                    validator->validateRender(orthographicView);
                     std::string fileName = name + ".exr";
                     validator->save(fileName);
 
@@ -556,6 +588,7 @@ TEST_CASE("GLSL Shader", "[shadervalid]")
                     log << stage;
                 }
                 REQUIRE(validated);
+#endif
             }
         }
     }

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -30,7 +30,6 @@ extern void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath&
 extern void createLightRig(mx::DocumentPtr doc, mx::HwLightHandler& lightHandler, mx::HwShaderGenerator& shadergen);
 extern void createExampleMaterials(mx::DocumentPtr doc, std::vector<mx::MaterialPtr>& materials);
 
-#if 0
 TEST_CASE("GLSL Source", "[shadervalid]")
 {
 #ifdef LOG_TO_FILE
@@ -248,7 +247,6 @@ TEST_CASE("GLSL Source", "[shadervalid]")
         }
     }
 }
-#endif
 
 //
 // Create a validator with an image and geometry handler
@@ -550,45 +548,6 @@ TEST_CASE("GLSL shading", "[shadervalid]")
                 std::vector<mx::ElementPtr> shaderRefList;
                 shaderRefList.push_back(shaderRef);
                 runValidation(name, shaderRefList, validator, shaderGenerator, orthographicView, doc, log);
-#if 0
-                mx::ShaderPtr shader = shaderGenerator->generate(name, shaderRef, options);
-                REQUIRE(shader != nullptr);
-                REQUIRE(shader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
-                REQUIRE(shader->getSourceCode(mx::HwShader::VERTEX_STAGE).length() > 0);
-
-                // Validate
-                MaterialX::GlslProgramPtr program = validator->program();
-                bool validated = false;
-                try
-                {
-                    validator->validateCreation(shader);
-                    validator->validateInputs();
-
-                    program->printUniforms(log);
-                    program->printAttributes(log);
-
-                    validator->validateRender(orthographicView);
-                    std::string fileName = name + ".exr";
-                    validator->save(fileName);
-
-                    validated = true;
-                }
-                catch (mx::ExceptionShaderValidationError e)
-                {
-                    for (auto error : e.errorLog())
-                    {
-                        log << e.what() << " " << error << std::endl;
-                    }
-
-                    std::string stage = program->getStage(mx::HwShader::VERTEX_STAGE);
-                    log << ">> Failed vertex stage code:\n";
-                    log << stage;
-                    stage = program->getStage(mx::HwShader::PIXEL_STAGE);
-                    log << ">> Failed pixel stage code:\n";
-                    log << stage;
-                }
-                REQUIRE(validated);
-#endif
             }
         }
     }


### PR DESCRIPTION
- Rework validation code to have some re-usable utilities.
- Remap geometry, lighting tests and split into 2.