### PR TITLE
MateriaX 1.36 implementation updates

### DIFF
--- a/documents/Libraries/stdlib/stdlib_sx-glsl_impl.mtlx
+++ b/documents/Libraries/stdlib/stdlib_sx-glsl_impl.mtlx
@@ -551,9 +551,16 @@
   <!-- ======================================================================== -->
 
   <!-- <premult> -->
-  <!-- <unpremult> -->
+  <implementation name="IM_premult_color2_sx_glsl" nodedef="ND_premult_color2" file="stdlib/sx-glsl/mx_premult_color2.glsl" function="mx_premult_color2" language="sx-glsl"/>
+  <implementation name="IM_premult_color3_sx_glsl" nodedef="ND_premult_color3" file="stdlib/sx-glsl/mx_premult_color3.glsl" function="mx_premult_color3" language="sx-glsl"/>
+  <implementation name="IM_premult_color4_sx_glsl" nodedef="ND_premult_color4" file="stdlib/sx-glsl/mx_premult_color4.glsl" function="mx_premult_color4" language="sx-glsl"/>
 
-  <!-- <plus> -->
+  <!-- <unpremult> -->
+  <implementation name="IM_unpremult_color2_sx_glsl" nodedef="ND_unpremult_color2" file="stdlib/sx-glsl/mx_unpremult_color2.glsl" function="mx_unpremult_color2" language="sx-glsl"/>
+  <implementation name="IM_unpremult_color3_sx_glsl" nodedef="ND_unpremult_color3" file="stdlib/sx-glsl/mx_unpremult_color3.glsl" function="mx_unpremult_color3" language="sx-glsl"/>
+  <implementation name="IM_unpremult_color4_sx_glsl" nodedef="ND_unpremult_color4" file="stdlib/sx-glsl/mx_unpremult_color4.glsl" function="mx_unpremult_color4" language="sx-glsl"/>
+
+   <!-- <plus> -->
   <implementation name="IM_plus_float_sx_glsl" nodedef="ND_plus_float" file="stdlib/sx-glsl/mx_plus.inline" language="sx-glsl"/>
   <implementation name="IM_plus_color2_sx_glsl" nodedef="ND_plus_color2" file="stdlib/sx-glsl/mx_plus.inline" language="sx-glsl"/>
   <implementation name="IM_plus_color3_sx_glsl" nodedef="ND_plus_color3" file="stdlib/sx-glsl/mx_plus.inline" language="sx-glsl"/>

--- a/documents/Libraries/stdlib/sx-glsl/mx_premult_color2.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_premult_color2.glsl
@@ -1,0 +1,4 @@
+void mx_premult_color2(vec2 in, out vec2 result)
+{
+    result = vec2(in.r * in.a, in.a);
+}

--- a/documents/Libraries/stdlib/sx-glsl/mx_premult_color3.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_premult_color3.glsl
@@ -1,0 +1,4 @@
+void mx_premult_color3(vec3 in, float alpha, out vec3 result)
+{
+    result = in * alpha;
+}

--- a/documents/Libraries/stdlib/sx-glsl/mx_premult_color4.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_premult_color4.glsl
@@ -1,0 +1,4 @@
+void mx_premult_color4(vec4 in, out vec4 result)
+{
+    result = vec4(in.rgb * in.a, in.a);
+}

--- a/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color2.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color2.glsl
@@ -1,0 +1,4 @@
+void mx_unpremult_color2(vec2 in, out vec2 result)
+{
+    result = vec2(in.r / in.a, in.a);
+}

--- a/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color3.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color3.glsl
@@ -1,0 +1,4 @@
+void mx_unpremult_color3(vec3 in, float alpha, out vec3 result)
+{
+    result = in / alpha;
+}

--- a/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color4.glsl
+++ b/documents/Libraries/stdlib/sx-glsl/mx_unpremult_color4.glsl
@@ -1,0 +1,4 @@
+void mx_unpremult_color4(vec4 in, out vec4 result)
+{
+    result = vec4(in.rgb / in.a, in.a);
+}


### PR DESCRIPTION
* Add premulti/unmult implementations for glsl
* Add some temporary filtering of node types to figure implementations out for.
** filter out lights on purpose for osl
