### PR TITLE
Removed the uniform renaming feature used by OgsFx generator. 

### DIFF
--- a/source/MaterialXShaderGen/Shader.cpp
+++ b/source/MaterialXShaderGen/Shader.cpp
@@ -53,11 +53,6 @@ void Shader::initialize(ElementPtr element, ShaderGenerator& shadergen, const Sg
         // Only for inputs that are connected/used internally
         if (inputSocket->connections.size())
         {
-            // Give the syntax class a chance to rename the uniform
-            string name = inputSocket->name;
-            shadergen.getSyntax()->renamePublicUniform(name, inputSocket->type);
-            _rootGraph->renameInputSocket(inputSocket->name, name);
-
             // Create the uniform
             createUniform(PIXEL_STAGE, PUBLIC_UNIFORMS, inputSocket->type, inputSocket->name, EMPTY_STRING, inputSocket->value);
         }

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
@@ -201,35 +201,4 @@ OgsFxSyntax::OgsFxSyntax()
     );
 }
 
-void OgsFxSyntax::renamePublicUniform(string& name, const string& type) const
-{
-    // In OGS if a color parameter is suffixed with "Color"
-    // it automatically gets a color picker widgets in UI.
-    // So for color parameters we renamed them accordingly 
-    // to use this feature.
-    if (type == DataType::COLOR3)
-    {
-        static const string COLOR_CAMEL = "Color";
-        static const string COLOR_LOWER = "color";
-
-        if (name.size() >= 5)
-        {
-            // Remove any existing "color", "Color", "COLOR" suffix
-            string suffix = name.substr(name.size() - 5, string::npos);
-            std::transform(suffix.begin(), suffix.end(), suffix.begin(), [](const unsigned char c) { return (unsigned char)tolower(c); });
-            if (suffix == COLOR_LOWER)
-            {
-                const size_t n = name.size() - 5;
-                name = name.substr(0, n);
-                if (!name.empty() && name.back() == '_')
-                {
-                    name.pop_back();
-                }
-            }
-        }
-        // Add the right suffix
-        name += COLOR_CAMEL;
-    }
-}
-
 }

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.h
@@ -15,8 +15,6 @@ public:
     OgsFxSyntax();
 
     static SyntaxPtr create() { return std::make_shared<OgsFxSyntax>(); }
-
-    void renamePublicUniform(string& name, const string& type) const override;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXShaderGen/Syntax.cpp
+++ b/source/MaterialXShaderGen/Syntax.cpp
@@ -183,11 +183,6 @@ namespace MaterialX
         }
     }
 
-    void Syntax::renamePublicUniform(string& /*name*/, const string& /*type*/) const
-    {
-        // Don't rename by default
-    }
-
     const string DataType::BOOLEAN = "boolean";
     const string DataType::INTEGER = "integer";
     const string DataType::FLOAT = "float";

--- a/source/MaterialXShaderGen/Syntax.h
+++ b/source/MaterialXShaderGen/Syntax.h
@@ -109,13 +109,6 @@ public:
     /// on the name string if there is a name collision.
     virtual void makeUnique(string& name, UniqueNameMap& uniqueNames) const;
 
-    /// Modify the give name string to make it appropriate as a public shader uniform.
-    /// The shader generator will call this function on all public shader uniforms
-    /// to give the syntax class a chance to modify public names.
-    /// Derived classes can override this method if needed. The default implementation 
-    /// will leave the name unchanged.
-    virtual void renamePublicUniform(string& name, const string& type) const;
-
 protected:
     /// Protected constructor
     Syntax();


### PR DESCRIPTION
Removed the uniform renaming feature used by OgsFx generator. This is not needed anymore by our use cases in Maya. Additionally the same rename functionality can still be done by overriding the Syntax::makeUnique() method for a particular shader generator.