### PR TITLE
Added TypeDesc class for handling identification and description of data types

### DIFF
--- a/source/MaterialXShaderGen/HwShader.cpp
+++ b/source/MaterialXShaderGen/HwShader.cpp
@@ -18,7 +18,7 @@ HwShader::HwShader(const string& name)
 
     // Create light data uniform block with the required field for light type
     createUniformBlock(PIXEL_STAGE, LIGHT_DATA_BLOCK, "u_lightData");
-    createUniform(PIXEL_STAGE, LIGHT_DATA_BLOCK, DataType::INTEGER, "type");
+    createUniform(PIXEL_STAGE, LIGHT_DATA_BLOCK, Type::INTEGER, "type");
 
     // Create uniforms for environment lighting
     // Note: Generation of the rotation matrix using floating point math can result
@@ -29,10 +29,10 @@ HwShader::HwShader(const string& name)
                                 0, 1, 0, 0,
                                 0, 0, -1, 0,
                                 0, 0, 0, 1);
-    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, DataType::MATRIX4, "u_envMatrix", 
+    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, Type::MATRIX44, "u_envMatrix", 
         EMPTY_STRING, Value::createValue<Matrix44>(yRotationPI));
-    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, DataType::FILENAME, "u_envSpecular");
-    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, DataType::FILENAME, "u_envIrradiance");
+    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, Type::FILENAME, "u_envSpecular");
+    createUniform(PIXEL_STAGE, PRIVATE_UNIFORMS, Type::FILENAME, "u_envIrradiance");
 }
 
 void HwShader::initialize(ElementPtr element, ShaderGenerator& shadergen, const SgOptions& options)
@@ -62,14 +62,14 @@ void HwShader::initialize(ElementPtr element, ShaderGenerator& shadergen, const 
             {
                 for (SgInput* input : node->getInputs())
                 {
-                    if (!input->connection && input->type == DataType::FILENAME)
+                    if (!input->connection && input->type == Type::FILENAME)
                     {
                         // Create the uniform and assing the name of the uniform to
                         // the input so we can reference it during code generation.
                         // Using the filename type will make this uniform into a texture sampler.
                         string name = node->getName() + "_" + input->name;
                         shadergen.getSyntax()->makeUnique(name, uniqueNames);
-                        createUniform(HwShader::PIXEL_STAGE, PUBLIC_UNIFORMS, DataType::FILENAME, name, EMPTY_STRING, input->value);
+                        createUniform(HwShader::PIXEL_STAGE, PUBLIC_UNIFORMS, Type::FILENAME, name, EMPTY_STRING, input->value);
                         input->value = Value::createValue(std::string(name));
                     }
                 }
@@ -95,7 +95,7 @@ void HwShader::initialize(ElementPtr element, ShaderGenerator& shadergen, const 
     }
 }
 
-void HwShader::createVertexData(const string& type, const string& name, const string& semantic)
+void HwShader::createVertexData(const TypeDesc* type, const string& name, const string& semantic)
 {
     if (_vertexData.variableMap.find(name) == _vertexData.variableMap.end())
     {

--- a/source/MaterialXShaderGen/HwShader.h
+++ b/source/MaterialXShaderGen/HwShader.h
@@ -34,7 +34,7 @@ public:
 
     /// Create a new variable for vertex data. This creates an 
     /// output from the vertex stage and and input to the pixel stage.
-    virtual void createVertexData(const string& type, const string& name, const string& semantic = EMPTY_STRING);
+    virtual void createVertexData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING);
 
     /// Return the block of a vertex data variables.
     const VariableBlock& getVertexDataBlock() const { return _vertexData; }

--- a/source/MaterialXShaderGen/HwShaderGenerator.cpp
+++ b/source/MaterialXShaderGen/HwShaderGenerator.cpp
@@ -14,7 +14,7 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax)
 
 void HwShaderGenerator::bindLightShader(const NodeDef& nodeDef, size_t lightTypeId)
 {
-    if (nodeDef.getType() != DataType::LIGHT)
+    if (TypeDesc::get(nodeDef.getType()) != Type::LIGHTSHADER)
     {
         throw ExceptionShaderGenError("Error binding light shader. Given nodedef '" + nodeDef.getName() + "' is not of lightshader type");
     }

--- a/source/MaterialXShaderGen/SgNode.h
+++ b/source/MaterialXShaderGen/SgNode.h
@@ -4,6 +4,7 @@
 #include <MaterialXCore/Node.h>
 #include <MaterialXCore/Document.h>
 
+#include <MaterialXShaderGen/TypeDesc.h>
 #include <MaterialXShaderGen/SgImplementation.h>
 
 #include <set>
@@ -28,8 +29,8 @@ using SgInputSet = std::set<SgInput*>;
 class SgInput
 {
 public:
+    const TypeDesc* type;
     string name;
-    string type;
     SgNode* node;
     ValuePtr value;
     SgOutput* connection;
@@ -42,8 +43,8 @@ public:
 class SgOutput
 {
 public:
+    const TypeDesc* type;
     string name;
-    string type;
     SgNode* node;
     ValuePtr value;
     SgInputSet connections;
@@ -170,8 +171,8 @@ public:
     }
 
     /// Add inputs/outputs
-    SgInput* addInput(const string& name, const string& type);
-    SgOutput* addOutput(const string& name, const string& type);
+    SgInput* addInput(const string& name, const TypeDesc* type);
+    SgOutput* addOutput(const string& name, const TypeDesc* type);
 
     /// Get number of inputs/outputs
     size_t numInputs() const { return _inputOrder.size(); }
@@ -275,8 +276,8 @@ public:
     SgNode* addNode(const Node& node, ShaderGenerator& shadergen);
 
     /// Add input/output sockets
-    SgInputSocket* addInputSocket(const string& name, const string& type);
-    SgOutputSocket* addOutputSocket(const string& name, const string& type);
+    SgInputSocket* addInputSocket(const string& name, const TypeDesc* type);
+    SgOutputSocket* addOutputSocket(const string& name, const TypeDesc* type);
 
     /// Rename input/output sockets
     void renameInputSocket(const string& name, const string& newName);

--- a/source/MaterialXShaderGen/Shader.cpp
+++ b/source/MaterialXShaderGen/Shader.cpp
@@ -270,7 +270,7 @@ void Shader::createUniformBlock(size_t stage, const string& block, const string&
     }
 }
 
-void Shader::createUniform(size_t stage, const string& block, const string& type, const string& name, const string& semantic, ValuePtr value)
+void Shader::createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& semantic, ValuePtr value)
 {
     const Stage& s = _stages[stage];
     auto it = s.uniforms.find(block);
@@ -298,7 +298,7 @@ const Shader::VariableBlock& Shader::getUniformBlock(size_t stage, const string&
     return *it->second;
 }
 
-void Shader::createAppData(const string& type, const string& name, const string& semantic)
+void Shader::createAppData(const TypeDesc* type, const string& name, const string& semantic)
 {
     if (_appData.variableMap.find(name) == _appData.variableMap.end())
     {

--- a/source/MaterialXShaderGen/Shader.h
+++ b/source/MaterialXShaderGen/Shader.h
@@ -50,12 +50,12 @@ public:
 
     struct Variable
     {
-        string type;
+        const TypeDesc* type;
         string name;
         string semantic;
         ValuePtr value;
 
-        Variable(const string& t = EMPTY_STRING, const string& n = EMPTY_STRING, const string& s = EMPTY_STRING, ValuePtr v = nullptr)
+        Variable(const TypeDesc* t = nullptr, const string& n = EMPTY_STRING, const string& s = EMPTY_STRING, ValuePtr v = nullptr)
             : type(t)
             , name(n)
             , semantic(s)
@@ -120,11 +120,11 @@ public:
 
     /// Create a new variable for uniform data in the given block for a stage.
     /// The block must be previously created with createUniformBlock.
-    virtual void createUniform(size_t stage, const string& block, const string& type, const string& name,
+    virtual void createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name,
         const string& semantic = EMPTY_STRING, ValuePtr value = nullptr);
 
     /// Create a new variable for application/geometric data (primvars).
-    virtual void createAppData(const string& type, const string& name, const string& semantic = EMPTY_STRING);
+    virtual void createAppData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING);
 
     /// Return all blocks of uniform variables for a stage.
     const VariableBlockMap& getUniformBlocks(size_t stage) const { return _stages[stage].uniforms; }

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/BitangentGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/BitangentGlsl.cpp
@@ -12,22 +12,22 @@ void BitangentGlsl::createVariables(const SgNode& node, ShaderGenerator& /*shade
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_bitangent");
+    shader.createAppData(Type::VECTOR3, "i_bitangent");
 
     const SgInput* spaceInput = node.getInput(SPACE);
     string space = spaceInput ? spaceInput->value->getValueString() : EMPTY_STRING;
     if (space == WORLD)
     {
-        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_worldInverseTransposeMatrix");
-        shader.createVertexData(DataType::VECTOR3, "bitangentWorld");
+        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_worldInverseTransposeMatrix");
+        shader.createVertexData(Type::VECTOR3, "bitangentWorld");
     }
     else if (space == MODEL)
     {
-        shader.createVertexData(DataType::VECTOR3, "bitangentModel");
+        shader.createVertexData(Type::VECTOR3, "bitangentModel");
     }
     else
     {
-        shader.createVertexData(DataType::VECTOR3, "bitangentObject");
+        shader.createVertexData(Type::VECTOR3, "bitangentObject");
     }
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/FrameGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/FrameGlsl.cpp
@@ -12,7 +12,7 @@ void FrameGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator& /*shade
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::FLOAT, "u_frame");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::FLOAT, "u_frame");
 }
 
 void FrameGlsl::emitFunctionCall(const SgNode& node, const SgNodeContext& /*context*/, ShaderGenerator& shadergen, Shader& shader_)

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/GeomColorGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/GeomColorGlsl.cpp
@@ -15,8 +15,8 @@ void GeomColorGlsl::createVariables(const SgNode& node, ShaderGenerator& /*shade
     const SgInput* indexInput = node.getInput(INDEX);
     const string index = indexInput ? indexInput->value->getValueString() : "0";
 
-    shader.createAppData(DataType::COLOR4, "i_color_" + index);
-    shader.createVertexData(DataType::COLOR4, "color_" + index);
+    shader.createAppData(Type::COLOR4, "i_color_" + index);
+    shader.createVertexData(Type::COLOR4, "color_" + index);
 }
 
 void GeomColorGlsl::emitFunctionCall(const SgNode& node, const SgNodeContext& /*context*/, ShaderGenerator& shadergen, Shader& shader_)
@@ -41,15 +41,15 @@ void GeomColorGlsl::emitFunctionCall(const SgNode& node, const SgNodeContext& /*
 
     BEGIN_SHADER_STAGE(shader, HwShader::PIXEL_STAGE)
         string suffix = "";
-        if (output->type == DataType::FLOAT)
+        if (output->type == Type::FLOAT)
         {
             suffix = ".r";
         }
-        else if (output->type == DataType::COLOR2)
+        else if (output->type == Type::COLOR2)
         {
             suffix = ".rg";
         }
-        else if (output->type == DataType::COLOR3)
+        else if (output->type == Type::COLOR3)
         {
             suffix = ".rgb";
         }

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslShaderGenerator.h
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslShaderGenerator.h
@@ -147,7 +147,7 @@ protected:
     /// Override the compound implementation creator in order to handle light compounds.
     SgImplementationPtr createCompoundImplementation(NodeGraphPtr impl) override;
 
-    static void toVec4(const string& type, string& variable);
+    static void toVec4(const TypeDesc* type, string& variable);
 
     /// Internal string constants
     static const string INCIDENT;

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.cpp
@@ -1,4 +1,5 @@
 #include <MaterialXShaderGen/ShaderGenerators/Glsl/GlslSyntax.h>
+#include <MaterialXShaderGen/TypeDesc.h>
 
 #include <memory>
 
@@ -80,7 +81,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::FLOAT,
+        Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float", 
             "0.0", 
@@ -89,7 +90,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::INTEGER,
+        Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int", 
             "0", 
@@ -98,7 +99,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::BOOLEAN,
+        Type::BOOLEAN,
         std::make_shared<ScalarTypeSyntax>(
             "bool", 
             "false", 
@@ -107,7 +108,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR2,
+        Type::COLOR2,
         std::make_shared<AggregateTypeSyntax>(
             "vec2", 
             "vec2(0.0)", 
@@ -118,7 +119,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR3,
+        Type::COLOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3", 
             "vec3(0.0)", 
@@ -129,7 +130,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR4,
+        Type::COLOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4", 
             "vec4(0.0)", 
@@ -140,7 +141,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR2,
+        Type::VECTOR2,
         std::make_shared<AggregateTypeSyntax>(
             "vec2", 
             "vec2(0.0)", 
@@ -151,7 +152,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR3,
+        Type::VECTOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3", 
             "vec3(0.0)", 
@@ -162,7 +163,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR4,
+        Type::VECTOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4", 
             "vec4(0.0)", 
@@ -173,7 +174,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX3,
+        Type::MATRIX33,
         std::make_shared<AggregateTypeSyntax>(
             "mat3", 
             "mat3(1.0)", 
@@ -182,7 +183,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX4,
+        Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "mat4", 
             "mat4(1.0)", 
@@ -191,13 +192,13 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::STRING,
+        Type::STRING,
         std::make_shared<GlslStringTypeSyntax>()
     );
 
     registerTypeSyntax
     (
-        DataType::FILENAME,
+        Type::FILENAME,
         std::make_shared<ScalarTypeSyntax>(
             "sampler2D", 
             EMPTY_STRING, 
@@ -206,7 +207,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::BSDF,
+        Type::BSDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF", 
             "BSDF(0.0)", 
@@ -216,7 +217,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::EDF,
+        Type::EDF,
         std::make_shared<AggregateTypeSyntax>(
             "EDF", 
             "EDF(0.0)", 
@@ -226,7 +227,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VDF,
+        Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             "VDF", 
             "VDF(vec3(0.0),vec3(0.0))", 
@@ -236,7 +237,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::SURFACE,
+        Type::SURFACESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "surfaceshader", 
             "surfaceshader(vec3(0.0),vec3(0.0))", 
@@ -246,7 +247,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VOLUME,
+        Type::VOLUMESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "volumeshader",
             "volumeshader(VDF(vec3(0.0),vec3(0.0)),EDF(0.0))",
@@ -256,7 +257,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::DISPLACEMENT,
+        Type::DISPLACEMENTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "displacementshader",
             "displacementshader(vec3(0.0),1.0)",
@@ -266,7 +267,7 @@ GlslSyntax::GlslSyntax()
 
     registerTypeSyntax
     (
-        DataType::LIGHT,
+        Type::LIGHTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "lightshader", 
             "lightshader(vec3(0.0),vec3(0.0))", 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightCompoundGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightCompoundGlsl.cpp
@@ -39,11 +39,11 @@ void LightCompoundGlsl::initialize(ElementPtr implementation, ShaderGenerator& s
     size_t index = 0;
     for (InputPtr input : nodeDef->getInputs())
     {
-        _lightUniforms[index++] = Shader::Variable(input->getType(), input->getName());
+        _lightUniforms[index++] = Shader::Variable(TypeDesc::get(input->getType()), input->getName());
     }
     for (ParameterPtr param : nodeDef->getParameters())
     {
-        _lightUniforms[index++] = Shader::Variable(param->getType(), param->getName());
+        _lightUniforms[index++] = Shader::Variable(TypeDesc::get(param->getType()), param->getName());
     }
 }
 
@@ -65,7 +65,7 @@ void LightCompoundGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator&
     }
 
     // Create uniform for number of active light sources
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::INTEGER, "u_numActiveLightSources",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::INTEGER, "u_numActiveLightSources",
         EMPTY_STRING, Value::createValue<int>(0));
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightGlsl.cpp
@@ -22,15 +22,15 @@ void LightGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator& /*shade
     HwShader& shader = static_cast<HwShader&>(shader_);
 
     // Create uniform for intensity, exposure and direction
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, DataType::FLOAT, "intensity",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, Type::FLOAT, "intensity",
         EMPTY_STRING, Value::createValue<float>(1.0f));
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, DataType::FLOAT, "exposure",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, Type::FLOAT, "exposure",
         EMPTY_STRING, Value::createValue<float>(0.0f));
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, DataType::VECTOR3, "direction",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::LIGHT_DATA_BLOCK, Type::VECTOR3, "direction",
         EMPTY_STRING, Value::createValue<Vector3>(Vector3(0.0f,1.0f,0.0f)));
 
     // Create uniform for number of active light sources
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::INTEGER, "u_numActiveLightSources",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::INTEGER, "u_numActiveLightSources",
         EMPTY_STRING, Value::createValue<int>(0));
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightShaderGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/LightShaderGlsl.cpp
@@ -40,11 +40,11 @@ void LightShaderGlsl::initialize(ElementPtr implementation, ShaderGenerator& sha
     size_t index = 0;
     for (InputPtr input : nodeDef->getInputs())
     {
-        _lightUniforms[index++] = Shader::Variable(input->getType(), input->getName(), EMPTY_STRING, input->getValue());
+        _lightUniforms[index++] = Shader::Variable(TypeDesc::get(input->getType()), input->getName(), EMPTY_STRING, input->getValue());
     }
     for (ParameterPtr param : nodeDef->getParameters())
     {
-        _lightUniforms[index++] = Shader::Variable(param->getType(), param->getName(), EMPTY_STRING, param->getValue());
+        _lightUniforms[index++] = Shader::Variable(TypeDesc::get(param->getType()), param->getName(), EMPTY_STRING, param->getValue());
     }
 }
 
@@ -59,7 +59,7 @@ void LightShaderGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator& /
     }
 
     // Create uniform for number of active light sources
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::INTEGER, "u_numActiveLightSources",
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::INTEGER, "u_numActiveLightSources",
         EMPTY_STRING, Value::createValue<int>(0));
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/NormalGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/NormalGlsl.cpp
@@ -12,22 +12,22 @@ void NormalGlsl::createVariables(const SgNode& node, ShaderGenerator& /*shaderge
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_normal");
+    shader.createAppData(Type::VECTOR3, "i_normal");
 
     const SgInput* spaceInput = node.getInput(SPACE);
     string space = spaceInput ? spaceInput->value->getValueString() : EMPTY_STRING;
     if (space == WORLD)
     {
-        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_worldInverseTransposeMatrix");
-        shader.createVertexData(DataType::VECTOR3, "normalWorld");
+        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_worldInverseTransposeMatrix");
+        shader.createVertexData(Type::VECTOR3, "normalWorld");
     }
     else if (space == MODEL)
     {
-        shader.createVertexData(DataType::VECTOR3, "normalModel");
+        shader.createVertexData(Type::VECTOR3, "normalModel");
     }
     else
     {
-        shader.createVertexData(DataType::VECTOR3, "normalObject");
+        shader.createVertexData(Type::VECTOR3, "normalObject");
     }
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.cpp
@@ -73,7 +73,7 @@ OgsFxShader::OgsFxShader(const string& name)
     createUniformBlock(FINAL_FX_STAGE, PUBLIC_UNIFORMS, "pub");
 }
 
-void OgsFxShader::createUniform(size_t stage, const string& block, const string& type, const string& name, const string& semantic, ValuePtr value)
+void OgsFxShader::createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& semantic, ValuePtr value)
 {
     // If no semantic is given check if we have 
     // an OgsFx semantic that should be used
@@ -89,7 +89,7 @@ void OgsFxShader::createUniform(size_t stage, const string& block, const string&
     ParentClass::createUniform(stage, block, type, name, semantic, value);
 }
 
-void OgsFxShader::createAppData(const string& type, const string& name, const string& semantic)
+void OgsFxShader::createAppData(const TypeDesc* type, const string& name, const string& semantic)
 {
     // If no semantic is given check if we have 
     // an OgsFx semantic that should be used
@@ -105,7 +105,7 @@ void OgsFxShader::createAppData(const string& type, const string& name, const st
     ParentClass::createAppData(type, name, semantic);
 }
 
-void OgsFxShader::createVertexData(const string& type, const string& name, const string& semantic)
+void OgsFxShader::createVertexData(const TypeDesc* type, const string& name, const string& semantic)
 {
     // If no semantic is given check if we have 
     // an OgsFx semantic that should be used
@@ -149,9 +149,9 @@ ShaderPtr OgsFxShaderGenerator::generate(const string& shaderName, ElementPtr el
     shader.setActiveStage(OgsFxShader::VERTEX_STAGE);
 
     // Create required variables
-    shader.createAppData(DataType::VECTOR3, "i_position");
-    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_worldMatrix");
-    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_viewProjectionMatrix");
+    shader.createAppData(Type::VECTOR3, "i_position");
+    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_worldMatrix");
+    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_viewProjectionMatrix");
 
     shader.addComment("---------------------------------- Vertex shader ----------------------------------------\n");
     shader.addLine("GLSLShader VS", false);
@@ -374,7 +374,7 @@ ShaderPtr OgsFxShaderGenerator::generate(const string& shaderName, ElementPtr el
 void OgsFxShaderGenerator::emitUniform(const Shader::Variable& uniform, Shader& shader)
 {
     // A file texture input needs special handling on GLSL
-    if (uniform.type == DataType::FILENAME)
+    if (uniform.type == Type::FILENAME)
     {
         std::stringstream str;
         str << "uniform texture2D " << uniform.name << "_texture : SourceTexture;\n";

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.h
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxShaderGenerator.h
@@ -26,9 +26,9 @@ public:
 
     size_t numStages() const override { return NUM_STAGES; }
 
-    void createUniform(size_t stage, const string& block, const string& type, const string& name, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
-    void createAppData(const string& type, const string& name, const string& semantic = EMPTY_STRING) override;
-    void createVertexData(const string& type, const string& name, const string& semantic = EMPTY_STRING) override;
+    void createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
+    void createAppData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
+    void createVertexData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
 };
 
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/OgsFx/OgsFxSyntax.cpp
@@ -58,7 +58,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR2,
+        Type::COLOR2,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec2", 
             "vec2(0.0)", 
@@ -69,7 +69,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR3,
+        Type::COLOR3,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec3", 
             "vec3(0.0)", 
@@ -80,7 +80,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR4,
+        Type::COLOR4,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec4", 
             "vec4(0.0)", 
@@ -91,7 +91,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR2,
+        Type::VECTOR2,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec2", 
             "vec2(0.0)", 
@@ -102,7 +102,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR3,
+        Type::VECTOR3,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec3", 
             "vec3(0.0)", 
@@ -113,7 +113,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR4,
+        Type::VECTOR4,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "vec4", 
             "vec4(0.0)", 
@@ -124,7 +124,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX3,
+        Type::MATRIX33,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "mat3", 
             "mat3(1.0)", 
@@ -133,7 +133,7 @@ OgsFxSyntax::OgsFxSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX4,
+        Type::MATRIX44,
         std::make_shared<OgsFxAggregateTypeSyntax>(
             "mat4", 
             "mat4(1.0)", 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/PositionGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/PositionGlsl.cpp
@@ -12,21 +12,21 @@ void PositionGlsl::createVariables(const SgNode& node, ShaderGenerator& /*shader
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_position");
+    shader.createAppData(Type::VECTOR3, "i_position");
 
     const SgInput* spaceInput = node.getInput(SPACE);
     string space = spaceInput ? spaceInput->value->getValueString() : EMPTY_STRING;
     if (space == WORLD)
     {
-        shader.createVertexData(DataType::VECTOR3, "positionWorld");
+        shader.createVertexData(Type::VECTOR3, "positionWorld");
     }
     else if (space == MODEL)
     {
-        shader.createVertexData(DataType::VECTOR3, "positionModel");
+        shader.createVertexData(Type::VECTOR3, "positionModel");
     }
     else
     {
-        shader.createVertexData(DataType::VECTOR3, "positionObject");
+        shader.createVertexData(Type::VECTOR3, "positionObject");
     }
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/SurfaceGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/SurfaceGlsl.cpp
@@ -32,13 +32,13 @@ void SurfaceGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator& /*sha
     //
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_position");
-    shader.createAppData(DataType::VECTOR3, "i_normal");
-    shader.createVertexData(DataType::VECTOR3, "positionWorld");
-    shader.createVertexData(DataType::VECTOR3, "normalWorld");
-    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_worldInverseTransposeMatrix");
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::VECTOR3, "u_viewPosition");
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::INTEGER, "u_numActiveLightSources",
+    shader.createAppData(Type::VECTOR3, "i_position");
+    shader.createAppData(Type::VECTOR3, "i_normal");
+    shader.createVertexData(Type::VECTOR3, "positionWorld");
+    shader.createVertexData(Type::VECTOR3, "normalWorld");
+    shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_worldInverseTransposeMatrix");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::VECTOR3, "u_viewPosition");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::INTEGER, "u_numActiveLightSources",
         EMPTY_STRING, Value::createValue<int>(0));
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/SurfaceShaderGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/SurfaceShaderGlsl.cpp
@@ -29,10 +29,10 @@ void SurfaceShaderGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator&
     //
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_position");
-    shader.createVertexData(DataType::VECTOR3, "positionWorld");
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::VECTOR3, "u_viewPosition");
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::INTEGER, "u_numActiveLightSources",
+    shader.createAppData(Type::VECTOR3, "i_position");
+    shader.createVertexData(Type::VECTOR3, "positionWorld");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::VECTOR3, "u_viewPosition");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::INTEGER, "u_numActiveLightSources",
         EMPTY_STRING, Value::createValue<int>(0));
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/TangentGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/TangentGlsl.cpp
@@ -12,22 +12,22 @@ void TangentGlsl::createVariables(const SgNode& node, ShaderGenerator& /*shaderg
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_tangent");
+    shader.createAppData(Type::VECTOR3, "i_tangent");
 
     const SgInput* spaceInput = node.getInput(SPACE);
     string space = spaceInput ? spaceInput->value->getValueString() : EMPTY_STRING;
     if (space == WORLD)
     {
-        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::MATRIX4, "u_worldInverseTransposeMatrix");
-        shader.createVertexData(DataType::VECTOR3, "tangentWorld");
+        shader.createUniform(HwShader::VERTEX_STAGE, HwShader::PRIVATE_UNIFORMS, Type::MATRIX44, "u_worldInverseTransposeMatrix");
+        shader.createVertexData(Type::VECTOR3, "tangentWorld");
     }
     else if (space == MODEL)
     {
-        shader.createVertexData(DataType::VECTOR3, "tangentModel");
+        shader.createVertexData(Type::VECTOR3, "tangentModel");
     }
     else
     {
-        shader.createVertexData(DataType::VECTOR3, "tangentObject");
+        shader.createVertexData(Type::VECTOR3, "tangentObject");
     }
 }
 

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/TimeGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/TimeGlsl.cpp
@@ -12,7 +12,7 @@ void TimeGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator& /*shader
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::FLOAT, "u_frame");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::FLOAT, "u_frame");
 }
 
 void TimeGlsl::emitFunctionCall(const SgNode& node, const SgNodeContext& /*context*/, ShaderGenerator& shadergen, Shader& shader_)

--- a/source/MaterialXShaderGen/ShaderGenerators/Glsl/ViewDirectionGlsl.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Glsl/ViewDirectionGlsl.cpp
@@ -12,9 +12,9 @@ void ViewDirectionGlsl::createVariables(const SgNode& /*node*/, ShaderGenerator&
 {
     HwShader& shader = static_cast<HwShader&>(shader_);
 
-    shader.createAppData(DataType::VECTOR3, "i_position");
-    shader.createVertexData(DataType::VECTOR3, "positionWorld");
-    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, DataType::VECTOR3, "u_viewPosition");
+    shader.createAppData(Type::VECTOR3, "i_position");
+    shader.createVertexData(Type::VECTOR3, "positionWorld");
+    shader.createUniform(HwShader::PIXEL_STAGE, HwShader::PRIVATE_UNIFORMS, Type::VECTOR3, "u_viewPosition");
 }
 
 void ViewDirectionGlsl::emitFunctionCall(const SgNode& node, const SgNodeContext& /*context*/, ShaderGenerator& shadergen, Shader& shader_)

--- a/source/MaterialXShaderGen/ShaderGenerators/Osl/OslShaderGenerator.h
+++ b/source/MaterialXShaderGen/ShaderGenerators/Osl/OslShaderGenerator.h
@@ -38,6 +38,8 @@ protected:
 
     /// Emit include headers needed by the generated shader code.
     void emitIncludes(Shader& shader);
+
+    std::unordered_map<const TypeDesc*, std::pair<const TypeDesc*, string>> _shaderOutputTypeRemap;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXShaderGen/ShaderGenerators/Osl/OslSyntax.cpp
+++ b/source/MaterialXShaderGen/ShaderGenerators/Osl/OslSyntax.cpp
@@ -136,7 +136,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::FLOAT,
+        Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float", 
             "0.0", 
@@ -145,7 +145,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::INTEGER,
+        Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int", 
             "0", 
@@ -154,7 +154,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::BOOLEAN,
+        Type::BOOLEAN,
         std::make_shared<ScalarTypeSyntax>(
             "int", 
             "0", 
@@ -164,7 +164,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR2,
+        Type::COLOR2,
         std::make_shared<OslStructTypeSyntax>(
             "color2", 
             "color2(0.0, 0.0)", 
@@ -177,7 +177,7 @@ OslSyntax::OslSyntax()
     (
         // Note: the color type in OSL is a built in type and 
         // should not use the custom OslStructTypeSyntax.
-        DataType::COLOR3,
+        Type::COLOR3,
         std::make_shared<AggregateTypeSyntax>(
             "color", 
             "color(0.0)", 
@@ -188,13 +188,13 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::COLOR4,
+        Type::COLOR4,
         std::make_shared<OslColor4TypeSyntax>()
     );
 
     registerTypeSyntax
     (
-        DataType::VECTOR2,
+        Type::VECTOR2,
         std::make_shared<OslStructTypeSyntax>(
             "vector2", 
             "vector2(0.0, 0.0)", 
@@ -207,7 +207,7 @@ OslSyntax::OslSyntax()
     (
         // Note: the vector type in OSL is a built in type and 
         // should not use the custom OslStructTypeSyntax.
-        DataType::VECTOR3,
+        Type::VECTOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vector", 
             "vector(0.0)", 
@@ -218,7 +218,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VECTOR4,
+        Type::VECTOR4,
         std::make_shared<OslStructTypeSyntax>(
             "vector4", 
             "vector4(0.0, 0.0, 0.0, 0.0)", 
@@ -229,7 +229,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX3,
+        Type::MATRIX33,
         std::make_shared<AggregateTypeSyntax>(
             "matrix", 
             "matrix(1.0)", 
@@ -238,7 +238,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::MATRIX4,
+        Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "matrix", 
             "matrix(1.0)", 
@@ -247,7 +247,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::STRING,
+        Type::STRING,
         std::make_shared<StringTypeSyntax>(
             "string", 
             "\"\"", 
@@ -256,7 +256,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::FILENAME,
+        Type::FILENAME,
         std::make_shared<StringTypeSyntax>(
             "string", 
             "\"\"", 
@@ -265,7 +265,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::BSDF,
+        Type::BSDF,
         std::make_shared<ScalarTypeSyntax>(
             "BSDF", 
             "null_closure", 
@@ -275,7 +275,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::EDF,
+        Type::EDF,
         std::make_shared<ScalarTypeSyntax>(
             "EDF", 
             "null_closure", 
@@ -285,7 +285,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VDF,
+        Type::VDF,
         std::make_shared<ScalarTypeSyntax>(
             "VDF", 
             "null_closure", 
@@ -295,7 +295,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::SURFACE,
+        Type::SURFACESHADER,
         std::make_shared<ScalarTypeSyntax>(
             "surfaceshader", 
             "null_closure", 
@@ -305,7 +305,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::VOLUME,
+        Type::VOLUMESHADER,
         std::make_shared<ScalarTypeSyntax>(
             "volumeshader", 
             "null_closure", 
@@ -315,7 +315,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::DISPLACEMENT, 
+        Type::DISPLACEMENTSHADER,
         std::make_shared<OslStructTypeSyntax>(
             "displacementshader", 
             "{vector(0.0), 0.0}", 
@@ -325,7 +325,7 @@ OslSyntax::OslSyntax()
 
     registerTypeSyntax
     (
-        DataType::LIGHT,
+        Type::LIGHTSHADER,
         std::make_shared<ScalarTypeSyntax>(
             "lightshader", 
             "null_closure", 

--- a/source/MaterialXShaderGen/Syntax.cpp
+++ b/source/MaterialXShaderGen/Syntax.cpp
@@ -1,246 +1,220 @@
 #include <MaterialXShaderGen/Syntax.h>
 #include <MaterialXShaderGen/Shader.h>
 #include <MaterialXCore/Value.h>
-#include <MaterialXCore/Node.h>
 
 namespace MaterialX
 {
-    Syntax::Syntax()
+
+Syntax::Syntax()
+{
+}
+
+void Syntax::registerTypeSyntax(const TypeDesc* type, TypeSyntaxPtr syntax)
+{
+    auto it = _typeSyntaxByType.find(type);
+    if (it != _typeSyntaxByType.end())
     {
+        _typeSyntaxs[it->second] = syntax;
+    }
+    else
+    {
+        _typeSyntaxs.push_back(syntax);
+        _typeSyntaxByType[type] = _typeSyntaxs.size() - 1;
     }
 
-    void Syntax::registerTypeSyntax(const string& type, TypeSyntaxPtr syntax)
+    // Make this type a restricted name
+    registerRestrictedNames({ syntax->getName() });
+}
+
+void Syntax::registerRestrictedNames(const StringSet& names)
+{
+    _restrictedNames.insert(names.begin(), names.end());
+}
+
+/// Returns the type syntax object for a named type.
+/// Throws an exception if a type syntax is not defined for the given type.
+const TypeSyntax& Syntax::getTypeSyntax(const TypeDesc* type) const
+{
+    auto it = _typeSyntaxByType.find(type);
+    if (it == _typeSyntaxByType.end())
     {
-        auto it = _typeSyntaxByName.find(type);
-        if (it != _typeSyntaxByName.end())
+        throw ExceptionShaderGenError("No syntax is defined for the given type '" + type->getName() + "'.");
+    }
+    return *_typeSyntaxs[it->second];
+}
+
+string Syntax::getValue(const TypeDesc* type, const Value& value, bool uniform) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(type);
+    return syntax.getValue(value, uniform);
+}
+
+const string& Syntax::getDefaultValue(const TypeDesc* type, bool uniform) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(type);
+    return syntax.getDefaultValue(uniform);
+}
+
+const string& Syntax::getTypeName(const TypeDesc* type) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(type);
+    return syntax.getName();
+}
+
+string Syntax::getOutputTypeName(const TypeDesc* type) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(type);
+    const string& outputModifier = getOutputQualifier();
+    return outputModifier.size() ? outputModifier + " " + syntax.getName() : syntax.getName();
+}
+
+const string& Syntax::getTypeDefStatement(const TypeDesc* type) const
+{
+    const TypeSyntax& syntax = getTypeSyntax(type);
+    return syntax.getTypeDefStatement();
+}
+
+string Syntax::getSwizzledVariable(const string& srcName, const TypeDesc* srcType, const string& channels, const TypeDesc* dstType) const
+{
+    static const std::unordered_map<char, size_t> s_channelsMapping =
+    {
+        { 'r', 0 },{ 'x', 0 },
+        { 'g', 1 },{ 'y', 1 },
+        { 'b', 2 },{ 'z', 2 },
+        { 'a', 3 },{ 'w', 3 }
+    };
+
+    const TypeSyntax& srcSyntax = getTypeSyntax(srcType);
+    const TypeSyntax& dstSyntax = getTypeSyntax(dstType);
+
+    const vector<string>& srcMembers = srcSyntax.getMembers();
+
+    vector<string> membersSwizzled;
+
+    for (size_t i = 0; i < channels.size(); ++i)
+    {
+        const char ch = channels[i];
+        if (ch == '0' || ch == '1')
         {
-            _typeSyntaxs[it->second] = syntax;
+            membersSwizzled.push_back(string(1,ch));
+            continue;
+        }
+
+        auto it = s_channelsMapping.find(ch);
+        if (it == s_channelsMapping.end())
+        {
+            throw ExceptionShaderGenError("Invalid channel pattern '" + channels + "'.");
+        }
+
+        if (srcMembers.empty())
+        {
+            membersSwizzled.push_back(srcName);
         }
         else
         {
-            _typeSyntaxs.push_back(syntax);
-            _typeSyntaxByName[type] = _typeSyntaxs.size() - 1;
+            if (it->second >= srcMembers.size())
+            {
+                throw ExceptionShaderGenError("Given member in channels pattern is incorrect for type '" + srcType->getName() + "'.");
+            }
+            membersSwizzled.push_back(srcName + srcMembers[it->second]);
         }
-
-        // Make this type a restricted name
-        registerRestrictedNames({ type });
     }
 
-    void Syntax::registerRestrictedNames(const StringSet& names)
-    {
-        _restrictedNames.insert(names.begin(), names.end());
-    }
+    return dstSyntax.getValue(membersSwizzled, false);
+}
 
-    /// Returns the type syntax object for a named type.
-    /// Throws an exception if a type syntax is not defined for the given type.
-    const TypeSyntax& Syntax::getTypeSyntax(const string& type) const
+void Syntax::makeUnique(string& name, UniqueNameMap& uniqueNames) const
+{
+    UniqueNameMap::iterator it = uniqueNames.find(name);
+    if (it != uniqueNames.end())
     {
-        auto it = _typeSyntaxByName.find(type);
-        if (it == _typeSyntaxByName.end())
+        name += std::to_string(++(it->second));
+    }
+    else
+    {
+        if (_restrictedNames.count(name))
         {
-            throw ExceptionShaderGenError("No syntax is defined for the given type '" + type + "'.");
-        }
-        return *_typeSyntaxs[it->second];
-    }
-
-    string Syntax::getValue(const string& type, const Value& value, bool uniform) const
-    {
-        const TypeSyntax& syntax = getTypeSyntax(type);
-        return syntax.getValue(value, uniform);
-    }
-
-    const string& Syntax::getDefaultValue(const string& type, bool uniform) const
-    {
-        const TypeSyntax& syntax = getTypeSyntax(type);
-        return syntax.getDefaultValue(uniform);
-    }
-
-    const string& Syntax::getTypeName(const string& type) const
-    {
-        const TypeSyntax& syntax = getTypeSyntax(type);
-        return syntax.getName();
-    }
-
-    string Syntax::getOutputTypeName(const string& type) const
-    {
-        const TypeSyntax& syntax = getTypeSyntax(type);
-        const string& outputModifier = getOutputQualifier();
-        return outputModifier.size() ? outputModifier + " " + syntax.getName() : syntax.getName();
-    }
-
-    const string& Syntax::getTypeDefStatement(const string& type) const
-    {
-        const TypeSyntax& syntax = getTypeSyntax(type);
-        return syntax.getTypeDefStatement();
-    }
-
-    string Syntax::getSwizzledVariable(const string& srcName, const string& srcType, const string& channels, const string& dstType) const
-    {
-        static const std::unordered_map<char, size_t> s_channelsMapping =
-        {
-            { 'r', 0 },{ 'x', 0 },
-            { 'g', 1 },{ 'y', 1 },
-            { 'b', 2 },{ 'z', 2 },
-            { 'a', 3 },{ 'w', 3 }
-        };
-
-        const TypeSyntax& srcSyntax = getTypeSyntax(srcType);
-        const TypeSyntax& dstSyntax = getTypeSyntax(dstType);
-
-        const vector<string>& srcMembers = srcSyntax.getMembers();
-
-        vector<string> membersSwizzled;
-
-        for (size_t i = 0; i < channels.size(); ++i)
-        {
-            const char ch = channels[i];
-            if (ch == '0' || ch == '1')
-            {
-                membersSwizzled.push_back(string(1,ch));
-                continue;
-            }
-
-            auto it = s_channelsMapping.find(ch);
-            if (it == s_channelsMapping.end())
-            {
-                throw ExceptionShaderGenError("Invalid channel pattern '" + channels + "'.");
-            }
-
-            if (srcMembers.empty())
-            {
-                membersSwizzled.push_back(srcName);
-            }
-            else
-            {
-                if (it->second >= srcMembers.size())
-                {
-                    throw ExceptionShaderGenError("Given member in channels pattern is incorrect for type '" + srcType + "'.");
-                }
-                membersSwizzled.push_back(srcName + srcMembers[it->second]);
-            }
-        }
-
-        return dstSyntax.getValue(membersSwizzled, false);
-    }
-
-    void Syntax::makeUnique(string& name, UniqueNameMap& uniqueNames) const
-    {
-        UniqueNameMap::iterator it = uniqueNames.find(name);
-        if (it != uniqueNames.end())
-        {
-            name += std::to_string(++(it->second));
+            uniqueNames[name] = 1;
+            name += "1";
         }
         else
         {
-            if (_restrictedNames.count(name))
-            {
-                uniqueNames[name] = 1;
-                name += "1";
-            }
-            else
-            {
-                uniqueNames[name] = 0;
-            }
+            uniqueNames[name] = 0;
         }
     }
+}
 
 
-    const vector<string> TypeSyntax::EMPTY_MEMBERS;
+const vector<string> TypeSyntax::EMPTY_MEMBERS;
 
-    TypeSyntax::TypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
-        const string& typeDefStatement, const vector<string>& members)
-        : _name(name)
-        , _defaultValue(defaultValue)
-        , _uniformDefaultValue(uniformDefaultValue)
-        , _typeDefStatement(typeDefStatement)
-        , _members(members)
+TypeSyntax::TypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
+    const string& typeDefStatement, const vector<string>& members)
+    : _name(name)
+    , _defaultValue(defaultValue)
+    , _uniformDefaultValue(uniformDefaultValue)
+    , _typeDefStatement(typeDefStatement)
+    , _members(members)
+{
+}
+
+
+ScalarTypeSyntax::ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, const string& typeDefStatement)
+    : TypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement, EMPTY_MEMBERS)
+{
+}
+
+string ScalarTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
+{
+    return value.getValueString();
+}
+
+string ScalarTypeSyntax::getValue(const vector<string>& values, bool /*uniform*/) const
+{
+    if (values.empty())
     {
+        throw ExceptionShaderGenError("No values given to construct a value");
+    }
+    return values[0];
+}
+
+
+StringTypeSyntax::StringTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, const string& typeDefStatement)
+    : ScalarTypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement)
+{
+}
+
+string StringTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
+{
+    return "\"" + value.getValueString() + "\"";
+}
+
+
+AggregateTypeSyntax::AggregateTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
+    const string& typeDefStatement, const vector<string>& members)
+    : TypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement, members)
+{
+}
+
+string AggregateTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
+{
+    return getName() + "(" + value.getValueString() + ")";
+}
+
+string AggregateTypeSyntax::getValue(const vector<string>& values, bool /*uniform*/) const
+{
+    if (values.empty())
+    {
+        throw ExceptionShaderGenError("No values given to construct a value");
     }
 
-
-    ScalarTypeSyntax::ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, const string& typeDefStatement)
-        : TypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement, EMPTY_MEMBERS)
+    string result = getName() + "(" + values[0];
+    for (size_t i=1; i<values.size(); ++i)
     {
+        result += ", " + values[i];
     }
+    result += ")";
 
-    string ScalarTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
-    {
-        return value.getValueString();
-    }
+    return result;
+}
 
-    string ScalarTypeSyntax::getValue(const vector<string>& values, bool /*uniform*/) const
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct a value");
-        }
-        return values[0];
-    }
-
-
-    StringTypeSyntax::StringTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, const string& typeDefStatement)
-        : ScalarTypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement)
-    {
-    }
-
-    string StringTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
-    {
-        return "\"" + value.getValueString() + "\"";
-    }
-
-
-    AggregateTypeSyntax::AggregateTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
-        const string& typeDefStatement, const vector<string>& members)
-        : TypeSyntax(name, defaultValue, uniformDefaultValue, typeDefStatement, members)
-    {
-    }
-
-    string AggregateTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
-    {
-        return getName() + "(" + value.getValueString() + ")";
-    }
-
-    string AggregateTypeSyntax::getValue(const vector<string>& values, bool /*uniform*/) const
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct a value");
-        }
-
-        string result = getName() + "(" + values[0];
-        for (size_t i=1; i<values.size(); ++i)
-        {
-            result += ", " + values[i];
-        }
-        result += ")";
-
-        return result;
-    }
-
-
-    const string DataType::BOOLEAN = "boolean";
-    const string DataType::INTEGER = "integer";
-    const string DataType::FLOAT = "float";
-    const string DataType::VECTOR2 = "vector2";
-    const string DataType::VECTOR3 = "vector3";
-    const string DataType::VECTOR4 = "vector4";
-    const string DataType::COLOR2 = "color2";
-    const string DataType::COLOR3 = "color3";
-    const string DataType::COLOR4 = "color4";
-    const string DataType::MATRIX3 = "matrix33";
-    const string DataType::MATRIX4 = "matrix44";
-    const string DataType::STRING = "string";
-    const string DataType::FILENAME = "filename";
-    const string DataType::BSDF = "BSDF";
-    const string DataType::EDF = "EDF";
-    const string DataType::VDF = "VDF";
-    const string DataType::SURFACE = "surfaceshader";
-    const string DataType::VOLUME = "volumeshader";
-    const string DataType::DISPLACEMENT = "displacementshader";
-    const string DataType::LIGHT = "lightshader";
-
-    const std::set<string> DataType::SCALARS = { DataType::BOOLEAN, DataType::FLOAT, DataType::INTEGER };
-    const std::set<string> DataType::TUPLES = { DataType::VECTOR2, DataType::COLOR2 };
-    const std::set<string> DataType::TRIPLES = { DataType::VECTOR3, DataType::COLOR3 };
-    const std::set<string> DataType::QUADRUPLES = { DataType::VECTOR4, DataType::COLOR4 };
 }

--- a/source/MaterialXShaderGen/Syntax.h
+++ b/source/MaterialXShaderGen/Syntax.h
@@ -4,13 +4,14 @@
 #include <MaterialXCore/Library.h>
 #include <MaterialXCore/Value.h>
 #include <MaterialXCore/Definition.h>
-#include <MaterialXCore/Node.h>
 
 #include <utility>
 #include <set>
 
 namespace MaterialX
 {
+
+class TypeDesc;
 
 using SyntaxPtr = shared_ptr<class Syntax>;
 using TypeSyntaxPtr = shared_ptr<class TypeSyntax>;
@@ -27,7 +28,7 @@ public:
 
     /// Register syntax handling for a data type.
     /// Required to be set for all supported data types.
-    void registerTypeSyntax(const string& type, TypeSyntaxPtr syntax);
+    void registerTypeSyntax(const TypeDesc* type, TypeSyntaxPtr syntax);
 
     /// Register names that are restricted to use by a code generator when naming 
     /// variables and functions. Keywords, types, built-in functions etc. should be 
@@ -36,29 +37,29 @@ public:
 
     /// Returns the type syntax object for a named type.
     /// Throws an exception if a type syntax is not defined for the given type.
-    const TypeSyntax& getTypeSyntax(const string& type) const;
+    const TypeSyntax& getTypeSyntax(const TypeDesc* type) const;
 
     /// Returns an array of all registered type syntax objects
     const vector<TypeSyntaxPtr>& getTypeSyntaxs() const { return _typeSyntaxs; }
 
     /// Returns the name syntax of the given type
-    const string& getTypeName(const string& type) const;
+    const string& getTypeName(const TypeDesc* type) const;
 
     /// Returns the type name in an output context
-    string getOutputTypeName(const string& type) const;
+    string getOutputTypeName(const TypeDesc* type) const;
 
     /// Returns the custom typedef syntax for the given data type
     /// If not used returns an empty string
-    const string& getTypeDefStatement(const string& type) const;
+    const string& getTypeDefStatement(const TypeDesc* type) const;
 
     /// Returns the default value string for the given type
-    const string& getDefaultValue(const string& type, bool uniform = false) const;
+    const string& getDefaultValue(const TypeDesc* type, bool uniform = false) const;
 
     /// Returns the value string for a given type and value object
-    string getValue(const string& type, const Value& value, bool uniform = false) const;
+    string getValue(const TypeDesc* type, const Value& value, bool uniform = false) const;
 
     /// Get syntax for a swizzled variable
-    string getSwizzledVariable(const string& srcName, const string& srcType, const string& channels, const string& dstType) const;
+    string getSwizzledVariable(const string& srcName, const TypeDesc* srcType, const string& channels, const TypeDesc* dstType) const;
 
     /// Returns a set of names that are restricted to use for this language syntax.
     const StringSet& getRestrictedNames() const { return _restrictedNames; }
@@ -82,7 +83,7 @@ protected:
 
 private:
     vector<TypeSyntaxPtr> _typeSyntaxs;
-    std::unordered_map<string, size_t> _typeSyntaxByName;
+    std::unordered_map<const TypeDesc*, size_t> _typeSyntaxByType;
 
     StringSet _restrictedNames;
 };
@@ -159,43 +160,6 @@ public:
 
     string getValue(const Value& value, bool uniform) const override;
     string getValue(const vector<string>& values, bool uniform) const override;
-};
-
-
-/// Built in data types
-class DataType
-{
-public:
-    static const string BOOLEAN;
-    static const string INTEGER;
-    static const string FLOAT;
-    static const string VECTOR2;
-    static const string VECTOR3;
-    static const string VECTOR4;
-    static const string COLOR2;
-    static const string COLOR3;
-    static const string COLOR4;
-    static const string MATRIX3;
-    static const string MATRIX4;
-    static const string STRING;
-    static const string FILENAME;
-    static const string BSDF;
-    static const string EDF;
-    static const string VDF;
-    static const string SURFACE;
-    static const string VOLUME;
-    static const string DISPLACEMENT;
-    static const string LIGHT;
-
-    static const std::set<string> SCALARS;
-    static const std::set<string> TUPLES;
-    static const std::set<string> TRIPLES;
-    static const std::set<string> QUADRUPLES;
-
-    static bool isScalar(const string& type) { return SCALARS.count(type) > 0; }
-    static bool isTuple(const string& type) { return TUPLES.count(type) > 0; }
-    static bool isTriple(const string& type) { return TRIPLES.count(type) > 0; }
-    static bool isQuadruple(const string& type) { return QUADRUPLES.count(type) > 0; }
 };
 
 } // namespace MaterialX

--- a/source/MaterialXShaderGen/TypeDesc.cpp
+++ b/source/MaterialXShaderGen/TypeDesc.cpp
@@ -55,27 +55,27 @@ namespace Type
 {
     // Register all standard types and save their pointers
     // for quick access and type comparisons later.
-    extern const TypeDesc* NONE               = TypeDesc::registerType("none", TypeDesc::BASETYPE_NONE);
-    extern const TypeDesc* BOOLEAN            = TypeDesc::registerType("boolean", TypeDesc::BASETYPE_BOOLEAN);
-    extern const TypeDesc* INTEGER            = TypeDesc::registerType("integer", TypeDesc::BASETYPE_INTEGER);
-    extern const TypeDesc* FLOAT              = TypeDesc::registerType("float", TypeDesc::BASETYPE_FLOAT);
-    extern const TypeDesc* VECTOR2            = TypeDesc::registerType("vector2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 2);
-    extern const TypeDesc* VECTOR3            = TypeDesc::registerType("vector3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 3);
-    extern const TypeDesc* VECTOR4            = TypeDesc::registerType("vector4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 4);
-    extern const TypeDesc* COLOR2             = TypeDesc::registerType("color2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 2);
-    extern const TypeDesc* COLOR3             = TypeDesc::registerType("color3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 3);
-    extern const TypeDesc* COLOR4             = TypeDesc::registerType("color4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 4);
-    extern const TypeDesc* MATRIX33           = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 9);
-    extern const TypeDesc* MATRIX44           = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 16);
-    extern const TypeDesc* STRING             = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
-    extern const TypeDesc* FILENAME           = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMATIC_FILENAME);
-    extern const TypeDesc* BSDF               = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
-    extern const TypeDesc* EDF                = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
-    extern const TypeDesc* VDF                = TypeDesc::registerType("VDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
-    extern const TypeDesc* SURFACESHADER      = TypeDesc::registerType("surfaceshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
-    extern const TypeDesc* VOLUMESHADER       = TypeDesc::registerType("volumeshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
-    extern const TypeDesc* DISPLACEMENTSHADER = TypeDesc::registerType("displacementshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
-    extern const TypeDesc* LIGHTSHADER        = TypeDesc::registerType("lightshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    const TypeDesc* NONE               = TypeDesc::registerType("none", TypeDesc::BASETYPE_NONE);
+    const TypeDesc* BOOLEAN            = TypeDesc::registerType("boolean", TypeDesc::BASETYPE_BOOLEAN);
+    const TypeDesc* INTEGER            = TypeDesc::registerType("integer", TypeDesc::BASETYPE_INTEGER);
+    const TypeDesc* FLOAT              = TypeDesc::registerType("float", TypeDesc::BASETYPE_FLOAT);
+    const TypeDesc* VECTOR2            = TypeDesc::registerType("vector2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 2);
+    const TypeDesc* VECTOR3            = TypeDesc::registerType("vector3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 3);
+    const TypeDesc* VECTOR4            = TypeDesc::registerType("vector4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 4);
+    const TypeDesc* COLOR2             = TypeDesc::registerType("color2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 2);
+    const TypeDesc* COLOR3             = TypeDesc::registerType("color3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 3);
+    const TypeDesc* COLOR4             = TypeDesc::registerType("color4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 4);
+    const TypeDesc* MATRIX33           = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 9);
+    const TypeDesc* MATRIX44           = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 16);
+    const TypeDesc* STRING             = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
+    const TypeDesc* FILENAME           = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMATIC_FILENAME);
+    const TypeDesc* BSDF               = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    const TypeDesc* EDF                = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    const TypeDesc* VDF                = TypeDesc::registerType("VDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    const TypeDesc* SURFACESHADER      = TypeDesc::registerType("surfaceshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    const TypeDesc* VOLUMESHADER       = TypeDesc::registerType("volumeshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    const TypeDesc* DISPLACEMENTSHADER = TypeDesc::registerType("displacementshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    const TypeDesc* LIGHTSHADER        = TypeDesc::registerType("lightshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
 }
 
 }

--- a/source/MaterialXShaderGen/TypeDesc.cpp
+++ b/source/MaterialXShaderGen/TypeDesc.cpp
@@ -1,0 +1,81 @@
+#include <MaterialXShaderGen/TypeDesc.h>
+#include <MaterialXShaderGen/Shader.h>
+
+namespace MaterialX
+{
+
+namespace
+{
+    using TypeDescPtr = std::shared_ptr<TypeDesc>;
+    using TypeDescMap = std::unordered_map<string, TypeDescPtr>;
+
+    // Internal storage of the type descriptor pointers
+    TypeDescMap& typeMap()
+    {
+        static TypeDescMap map;
+        return map;
+    }
+}
+
+TypeDesc::TypeDesc(const string& name, unsigned char basetype, unsigned char semantic, int size)
+    : _name(name)
+    , _basetype(basetype)
+    , _semantic(semantic)
+    , _size(size)
+{
+}
+
+const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetype, unsigned char semantic, int size)
+{
+    TypeDescMap& map = typeMap();
+    auto it = map.find(name);
+    if (it != map.end())
+    {
+        throw ExceptionShaderGenError("A type with name '" + name + "' is already registered");
+    }
+
+    TypeDescPtr ptr = TypeDescPtr(new TypeDesc(name, basetype, semantic, size));
+    map[name] = ptr;
+
+    return ptr.get();
+}
+
+const TypeDesc* TypeDesc::get(const string& name)
+{
+    const TypeDescMap& map = typeMap();
+    auto it = map.find(name);
+    if (it == map.end())
+    {
+        throw ExceptionShaderGenError("No registered type with name '" + name + "' could be found");
+    }
+    return it->second.get();
+}
+
+namespace Type
+{
+    // Register all standard types and save their pointers
+    // for quick access and type comparisons later.
+    extern const TypeDesc* NONE               = TypeDesc::registerType("none", TypeDesc::BASETYPE_NONE);
+    extern const TypeDesc* BOOLEAN            = TypeDesc::registerType("boolean", TypeDesc::BASETYPE_BOOLEAN);
+    extern const TypeDesc* INTEGER            = TypeDesc::registerType("integer", TypeDesc::BASETYPE_INTEGER);
+    extern const TypeDesc* FLOAT              = TypeDesc::registerType("float", TypeDesc::BASETYPE_FLOAT);
+    extern const TypeDesc* VECTOR2            = TypeDesc::registerType("vector2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 2);
+    extern const TypeDesc* VECTOR3            = TypeDesc::registerType("vector3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 3);
+    extern const TypeDesc* VECTOR4            = TypeDesc::registerType("vector4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_VECTOR, 4);
+    extern const TypeDesc* COLOR2             = TypeDesc::registerType("color2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 2);
+    extern const TypeDesc* COLOR3             = TypeDesc::registerType("color3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 3);
+    extern const TypeDesc* COLOR4             = TypeDesc::registerType("color4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_COLOR, 4);
+    extern const TypeDesc* MATRIX33           = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 9);
+    extern const TypeDesc* MATRIX44           = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMATIC_MATRIX, 16);
+    extern const TypeDesc* STRING             = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
+    extern const TypeDesc* FILENAME           = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMATIC_FILENAME);
+    extern const TypeDesc* BSDF               = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    extern const TypeDesc* EDF                = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    extern const TypeDesc* VDF                = TypeDesc::registerType("VDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_CLOSURE);
+    extern const TypeDesc* SURFACESHADER      = TypeDesc::registerType("surfaceshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    extern const TypeDesc* VOLUMESHADER       = TypeDesc::registerType("volumeshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    extern const TypeDesc* DISPLACEMENTSHADER = TypeDesc::registerType("displacementshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+    extern const TypeDesc* LIGHTSHADER        = TypeDesc::registerType("lightshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMATIC_SHADER);
+}
+
+}

--- a/source/MaterialXShaderGen/TypeDesc.h
+++ b/source/MaterialXShaderGen/TypeDesc.h
@@ -1,0 +1,123 @@
+#ifndef MATERIALX_TYPEDESC_H
+#define MATERIALX_TYPEDESC_H
+
+#include <MaterialXCore/Library.h>
+
+namespace MaterialX
+{
+
+/// @class TypeDesc
+/// A type descriptor for MaterialX data types.
+/// All types needs to have a type descriptor registered in order for shader generators 
+/// to know about the type. A unique type descriptor pointer is the identifier used for
+/// types, and can be used for type comparisons as well as getting more information
+/// about the type. All standard library data types are registered by default and their 
+/// type descriptors can be accessed from the Type namespace, e.g. MaterialX::Type::FLOAT.
+/// If custom types are used they must be registered by calling TypeDesc::registerType().
+/// Descriptors for registered types can be retreived using TypeDesc::get(), see below.
+class TypeDesc
+{
+public:
+    enum BaseType
+    {
+        BASETYPE_NONE,
+        BASETYPE_BOOLEAN,
+        BASETYPE_INTEGER,
+        BASETYPE_FLOAT,
+        BASETYPE_STRING,
+        BASETYPE_STRUCT,
+        BASETYPE_LAST
+    };
+
+    enum Semantic
+    {
+        SEMATIC_NONE,
+        SEMATIC_COLOR,
+        SEMATIC_VECTOR,
+        SEMATIC_MATRIX,
+        SEMATIC_FILENAME,
+        SEMATIC_CLOSURE,
+        SEMATIC_SHADER,
+        SEMATIC_LAST
+    };
+
+    /// Register a type descriptor for a MaterialX data type.
+    /// Throws an exception if a type with the same name is already registered.
+    static const TypeDesc* registerType(const string& name, unsigned char basetype, unsigned char semantic = SEMATIC_NONE, int size = 1);
+    
+    /// Get a type descriptor for given name.
+    /// Throws an exception if no type with that name is found.
+    static const TypeDesc* get(const string& name);
+
+    /// Return the name of the type.
+    const string& getName() const { return _name; }
+
+    /// Return the basetype for the type.
+    unsigned char getBaseType() const { return _basetype; }
+
+    /// Return the semantic for the type.
+    unsigned char getSemantic() const { return _semantic; }
+
+    /// Return the number of elements the type is composed of.
+    /// Will return 1 for scalar types and a size greater than 1 for aggregate type.
+    /// For array types 0 is returned since the number of elements not defined by 
+    /// the type but rather the array variable instance.
+    size_t getSize() const { return _size; }
+
+    /// Return true if the type is a scalar type.
+    bool isScalar() const { return _size == 1; }
+
+    /// Return true if the type is an aggregate type.
+    bool isAggregate() const { return _size > 1; }
+
+    /// Return true if the type is an array type.
+    bool isArray() const { return _size == 0; }
+
+    /// Return true if the type is an aggregate of 2 floats.
+    bool isFloat2() const { return _size == 2 && (_semantic == SEMATIC_COLOR || _semantic == SEMATIC_VECTOR); }
+
+    /// Return true if the type is an aggregate of 3 floats.
+    bool isFloat3() const { return _size == 3 && (_semantic == SEMATIC_COLOR || _semantic == SEMATIC_VECTOR); }
+
+    /// Return true if the type is an aggregate of 4 floats.
+    bool isFloat4() const { return _size == 4 && (_semantic == SEMATIC_COLOR || _semantic == SEMATIC_VECTOR); }
+
+private:
+    TypeDesc(const string& name, unsigned char basetype, unsigned char semantic, int size);
+
+    const string _name;
+    const unsigned char _basetype;
+    const unsigned char _semantic;
+    const int _size;
+};
+
+namespace Type
+{
+    /// Type descriptors for all standard types.
+    /// These are always registered by default.
+    extern const TypeDesc* NONE;
+    extern const TypeDesc* BOOLEAN;
+    extern const TypeDesc* INTEGER;
+    extern const TypeDesc* FLOAT;
+    extern const TypeDesc* VECTOR2;
+    extern const TypeDesc* VECTOR3;
+    extern const TypeDesc* VECTOR4;
+    extern const TypeDesc* COLOR2;
+    extern const TypeDesc* COLOR3;
+    extern const TypeDesc* COLOR4;
+    extern const TypeDesc* MATRIX33;
+    extern const TypeDesc* MATRIX44;
+    extern const TypeDesc* STRING;
+    extern const TypeDesc* FILENAME;
+    extern const TypeDesc* BSDF;
+    extern const TypeDesc* EDF;
+    extern const TypeDesc* VDF;
+    extern const TypeDesc* SURFACESHADER;
+    extern const TypeDesc* VOLUMESHADER;
+    extern const TypeDesc* DISPLACEMENTSHADER;
+    extern const TypeDesc* LIGHTSHADER;
+} // namespace Type
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXShaderGen/TypeDesc.h
+++ b/source/MaterialXShaderGen/TypeDesc.h
@@ -60,8 +60,8 @@ public:
 
     /// Return the number of elements the type is composed of.
     /// Will return 1 for scalar types and a size greater than 1 for aggregate type.
-    /// For array types 0 is returned since the number of elements not defined by 
-    /// the type but rather the array variable instance.
+    /// For array types 0 is returned since the number of elements is undefined
+    /// until an array is instantiated.
     size_t getSize() const { return _size; }
 
     /// Return true if the type is a scalar type.
@@ -95,6 +95,9 @@ namespace Type
 {
     /// Type descriptors for all standard types.
     /// These are always registered by default.
+    /// 
+    /// TODO: Add support for the standard array types.
+    ///
     extern const TypeDesc* NONE;
     extern const TypeDesc* BOOLEAN;
     extern const TypeDesc* INTEGER;

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -688,6 +688,9 @@ TEST_CASE("TypeDesc", "[shadergen]")
 
     // Make sure we can't use a name already take
     REQUIRE_THROWS(mx::TypeDesc::registerType("color3", mx::TypeDesc::BASETYPE_FLOAT));
+
+    // Make sure we can't request an unknown type
+    REQUIRE_THROWS(mx::TypeDesc::get("bar"));
 }
 
 TEST_CASE("Reference Implementation Validity", "[shadergen]")

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -522,44 +522,44 @@ TEST_CASE("OslSyntax", "[shadergen]")
 {
     mx::SyntaxPtr syntax = mx::OslSyntax::create();
 
-    REQUIRE(syntax->getTypeName("float") == "float");
-    REQUIRE(syntax->getTypeName("color3") == "color");
-    REQUIRE(syntax->getTypeName("vector3") == "vector");
+    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "color");
+    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vector");
 
-    REQUIRE(syntax->getTypeName("BSDF") == "BSDF");
-    REQUIRE(syntax->getOutputTypeName("BSDF") == "output BSDF");
+    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "output BSDF");
 
     // Set fixed precision with one digit
     mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
 
     std::string value;
-    value = syntax->getDefaultValue("float");
+    value = syntax->getDefaultValue(mx::Type::FLOAT);
     REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue("color3");
+    value = syntax->getDefaultValue(mx::Type::COLOR3);
     REQUIRE(value == "color(0.0)");
-    value = syntax->getDefaultValue("color3", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
     REQUIRE(value == "color(0.0)");
-    value = syntax->getDefaultValue("color4");
+    value = syntax->getDefaultValue(mx::Type::COLOR4);
     REQUIRE(value == "color4(color(0.0), 0.0)");
-    value = syntax->getDefaultValue("color4", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
     REQUIRE(value == "{color(0.0), 0.0}");
 
     mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
     REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue, true);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
     REQUIRE(value == "42.0");
 
     mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
     REQUIRE(value == "color(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value, true);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
     REQUIRE(value == "color(1.0, 2.0, 3.0)");
 
     mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
     REQUIRE(value == "color4(color(1.0, 2.0, 3.0), 4.0)");
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value, true);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
     REQUIRE(value == "{color(1.0, 2.0, 3.0), 4.0}");
 }
 
@@ -567,44 +567,44 @@ TEST_CASE("GlslSyntax", "[shadergen]")
 {
     mx::SyntaxPtr syntax = mx::GlslSyntax::create();
 
-    REQUIRE(syntax->getTypeName("float") == "float");
-    REQUIRE(syntax->getTypeName("color3") == "vec3");
-    REQUIRE(syntax->getTypeName("vector3") == "vec3");
+    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
+    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
 
-    REQUIRE(syntax->getTypeName("BSDF") == "BSDF");
-    REQUIRE(syntax->getOutputTypeName("BSDF") == "out BSDF");
+    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
 
     // Set fixed precision with one digit
     mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
 
     std::string value;
-    value = syntax->getDefaultValue("float");
+    value = syntax->getDefaultValue(mx::Type::FLOAT);
     REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue("color3");
+    value = syntax->getDefaultValue(mx::Type::COLOR3);
     REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue("color3", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
     REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue("color4");
+    value = syntax->getDefaultValue(mx::Type::COLOR4);
     REQUIRE(value == "vec4(0.0)");
-    value = syntax->getDefaultValue("color4", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
     REQUIRE(value == "vec4(0.0)");
 
     mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
     REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue, true);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
     REQUIRE(value == "42.0");
 
     mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
     REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value, true);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
     REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
 
     mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
     REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value, true);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
     REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
 }
 
@@ -612,44 +612,44 @@ TEST_CASE("OgsFxSyntax", "[shadergen]")
 {
     mx::SyntaxPtr syntax = mx::OgsFxSyntax::create();
 
-    REQUIRE(syntax->getTypeName("float") == "float");
-    REQUIRE(syntax->getTypeName("color3") == "vec3");
-    REQUIRE(syntax->getTypeName("vector3") == "vec3");
+    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
+    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
 
-    REQUIRE(syntax->getTypeName("BSDF") == "BSDF");
-    REQUIRE(syntax->getOutputTypeName("BSDF") == "out BSDF");
+    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
 
     // Set fixed precision with one digit
     mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
 
     std::string value;
-    value = syntax->getDefaultValue("float");
+    value = syntax->getDefaultValue(mx::Type::FLOAT);
     REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue("color3");
+    value = syntax->getDefaultValue(mx::Type::COLOR3);
     REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue("color3", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
     REQUIRE(value == "{0.0, 0.0, 0.0}");
-    value = syntax->getDefaultValue("color4");
+    value = syntax->getDefaultValue(mx::Type::COLOR4);
     REQUIRE(value == "vec4(0.0)");
-    value = syntax->getDefaultValue("color4", true);
+    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
     REQUIRE(value == "{0.0, 0.0, 0.0, 0.0}");
 
     mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
     REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::DataType::FLOAT, *floatValue, true);
+    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
     REQUIRE(value == "42.0");
 
     mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
     REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::DataType::COLOR3, *color3Value, true);
+    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
     REQUIRE(value == "{1.0, 2.0, 3.0}");
 
     mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
     REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
-    value = syntax->getValue(mx::DataType::COLOR4, *color4Value, true);
+    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
     REQUIRE(value == "{1.0, 2.0, 3.0, 4.0}");
 }
 
@@ -997,17 +997,17 @@ TEST_CASE("Swizzling", "[shadergen]")
         const mx::Syntax* syntax = sg.getSyntax();
 
         // Test swizzle syntax
-        std::string var1 = syntax->getSwizzledVariable("foo", "color3", "bgr", "color3");
+        std::string var1 = syntax->getSwizzledVariable("foo", mx::Type::COLOR3, "bgr", mx::Type::COLOR3);
         REQUIRE(var1 == "color(foo[2], foo[1], foo[0])");
-        std::string var2 = syntax->getSwizzledVariable("foo", "vector2", "xy", "color2");
+        std::string var2 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR2, "xy", mx::Type::COLOR2);
         REQUIRE(var2 == "color2(foo.x, foo.y)");
-        std::string var3 = syntax->getSwizzledVariable("foo", "float", "rr01", "color4");
+        std::string var3 = syntax->getSwizzledVariable("foo", mx::Type::FLOAT, "rr01", mx::Type::COLOR4);
         REQUIRE(var3 == "color4(color(foo, foo, 0), 1)");
-        std::string var4 = syntax->getSwizzledVariable("foo", "vector3", "zyx", "vector3");
+        std::string var4 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR3, "zyx", mx::Type::VECTOR3);
         REQUIRE(var4 == "vector(foo[2], foo[1], foo[0])");
-        std::string var5 = syntax->getSwizzledVariable("foo", "vector4", "yy", "vector2");
+        std::string var5 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR4, "yy", mx::Type::VECTOR2);
         REQUIRE(var5 == "vector2(foo.y, foo.y)");
-        std::string var6 = syntax->getSwizzledVariable("foo", "color2", "rrgg", "vector4");
+        std::string var6 = syntax->getSwizzledVariable("foo", mx::Type::COLOR2, "rrgg", mx::Type::VECTOR4);
         REQUIRE(var6 == "vector4(foo.r, foo.r, foo.a, foo.a)");
 
         // Create a simple test graph
@@ -1046,17 +1046,17 @@ TEST_CASE("Swizzling", "[shadergen]")
         const mx::Syntax* syntax = sg.getSyntax();
 
         // Test swizzle syntax
-        std::string var1 = syntax->getSwizzledVariable("foo", "color3", "bgr", "color3");
+        std::string var1 = syntax->getSwizzledVariable("foo", mx::Type::COLOR3, "bgr", mx::Type::COLOR3);
         REQUIRE(var1 == "vec3(foo.z, foo.y, foo.x)");
-        std::string var2 = syntax->getSwizzledVariable("foo", "vector2", "xy", "color2");
+        std::string var2 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR2, "xy", mx::Type::COLOR2);
         REQUIRE(var2 == "vec2(foo.x, foo.y)");
-        std::string var3 = syntax->getSwizzledVariable("foo", "float", "rr01", "color4");
+        std::string var3 = syntax->getSwizzledVariable("foo", mx::Type::FLOAT, "rr01", mx::Type::COLOR4);
         REQUIRE(var3 == "vec4(foo, foo, 0, 1)");
-        std::string var4 = syntax->getSwizzledVariable("foo", "vector3", "zyx", "vector3");
+        std::string var4 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR3, "zyx", mx::Type::VECTOR3);
         REQUIRE(var4 == "vec3(foo.z, foo.y, foo.x)");
-        std::string var5 = syntax->getSwizzledVariable("foo", "vector4", "yy", "vector2");
+        std::string var5 = syntax->getSwizzledVariable("foo", mx::Type::VECTOR4, "yy", mx::Type::VECTOR2);
         REQUIRE(var5 == "vec2(foo.y, foo.y)");
-        std::string var6 = syntax->getSwizzledVariable("foo", "color2", "rrgg", "vector4");
+        std::string var6 = syntax->getSwizzledVariable("foo", mx::Type::COLOR2, "rrgg", mx::Type::VECTOR4);
         REQUIRE(var6 == "vec4(foo.x, foo.x, foo.y, foo.y)");
 
         // Create a simple test graph

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -12,6 +12,7 @@
 #include <MaterialXShaderGen/ShaderGenerators/Osl/Arnold/ArnoldShaderGenerator.h>
 #include <MaterialXShaderGen/ShaderGenerators/Osl/OslSyntax.h>
 #include <MaterialXShaderGen/ShaderGenerators/Common/Swizzle.h>
+#include <MaterialXShaderGen/TypeDesc.h>
 #include <MaterialXShaderGen/Util.h>
 #include <MaterialXShaderGen/HwShader.h>
 #include <MaterialXShaderGen/HwLightHandler.h>
@@ -518,139 +519,175 @@ void createLightRig(mx::DocumentPtr doc, mx::HwLightHandler& lightHandler, mx::H
     lightHandler.bindLightShaders(shadergen);
 }
 
-TEST_CASE("OslSyntax", "[shadergen]")
+TEST_CASE("Syntax", "[shadergen]")
 {
-    mx::SyntaxPtr syntax = mx::OslSyntax::create();
+    {
+        mx::SyntaxPtr syntax = mx::OslSyntax::create();
 
-    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
-    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "color");
-    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vector");
+        REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+        REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "color");
+        REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vector");
 
-    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
-    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "output BSDF");
+        REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+        REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "output BSDF");
 
-    // Set fixed precision with one digit
-    mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
+        // Set fixed precision with one digit
+        mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
 
-    std::string value;
-    value = syntax->getDefaultValue(mx::Type::FLOAT);
-    REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue(mx::Type::COLOR3);
-    REQUIRE(value == "color(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
-    REQUIRE(value == "color(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR4);
-    REQUIRE(value == "color4(color(0.0), 0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
-    REQUIRE(value == "{color(0.0), 0.0}");
+        std::string value;
+        value = syntax->getDefaultValue(mx::Type::FLOAT);
+        REQUIRE(value == "0.0");
+        value = syntax->getDefaultValue(mx::Type::COLOR3);
+        REQUIRE(value == "color(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR3, true);
+        REQUIRE(value == "color(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR4);
+        REQUIRE(value == "color4(color(0.0), 0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR4, true);
+        REQUIRE(value == "{color(0.0), 0.0}");
 
-    mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
-    REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
-    REQUIRE(value == "42.0");
+        mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue);
+        REQUIRE(value == "42.0");
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
+        REQUIRE(value == "42.0");
 
-    mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
-    REQUIRE(value == "color(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
-    REQUIRE(value == "color(1.0, 2.0, 3.0)");
+        mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value);
+        REQUIRE(value == "color(1.0, 2.0, 3.0)");
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
+        REQUIRE(value == "color(1.0, 2.0, 3.0)");
 
-    mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
-    REQUIRE(value == "color4(color(1.0, 2.0, 3.0), 4.0)");
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
-    REQUIRE(value == "{color(1.0, 2.0, 3.0), 4.0}");
+        mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value);
+        REQUIRE(value == "color4(color(1.0, 2.0, 3.0), 4.0)");
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
+        REQUIRE(value == "{color(1.0, 2.0, 3.0), 4.0}");
+    }
+
+    {
+        mx::SyntaxPtr syntax = mx::GlslSyntax::create();
+
+        REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+        REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
+        REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
+
+        REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+        REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
+
+        // Set fixed precision with one digit
+        mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
+
+        std::string value;
+        value = syntax->getDefaultValue(mx::Type::FLOAT);
+        REQUIRE(value == "0.0");
+        value = syntax->getDefaultValue(mx::Type::COLOR3);
+        REQUIRE(value == "vec3(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR3, true);
+        REQUIRE(value == "vec3(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR4);
+        REQUIRE(value == "vec4(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR4, true);
+        REQUIRE(value == "vec4(0.0)");
+
+        mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue);
+        REQUIRE(value == "42.0");
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
+        REQUIRE(value == "42.0");
+
+        mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value);
+        REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
+        REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
+
+        mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value);
+        REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
+        REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
+    }
+
+    {
+        mx::SyntaxPtr syntax = mx::OgsFxSyntax::create();
+
+        REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
+        REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
+        REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
+
+        REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
+        REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
+
+        // Set fixed precision with one digit
+        mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
+
+        std::string value;
+        value = syntax->getDefaultValue(mx::Type::FLOAT);
+        REQUIRE(value == "0.0");
+        value = syntax->getDefaultValue(mx::Type::COLOR3);
+        REQUIRE(value == "vec3(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR3, true);
+        REQUIRE(value == "{0.0, 0.0, 0.0}");
+        value = syntax->getDefaultValue(mx::Type::COLOR4);
+        REQUIRE(value == "vec4(0.0)");
+        value = syntax->getDefaultValue(mx::Type::COLOR4, true);
+        REQUIRE(value == "{0.0, 0.0, 0.0, 0.0}");
+
+        mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue);
+        REQUIRE(value == "42.0");
+        value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
+        REQUIRE(value == "42.0");
+
+        mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value);
+        REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
+        value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
+        REQUIRE(value == "{1.0, 2.0, 3.0}");
+
+        mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value);
+        REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
+        value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
+        REQUIRE(value == "{1.0, 2.0, 3.0, 4.0}");
+    }
 }
 
-TEST_CASE("GlslSyntax", "[shadergen]")
+TEST_CASE("TypeDesc", "[shadergen]")
 {
-    mx::SyntaxPtr syntax = mx::GlslSyntax::create();
+    // Make sure the standard types are registered
+    const mx::TypeDesc* floatType = mx::TypeDesc::get("float");
+    REQUIRE(floatType != nullptr);
+    REQUIRE(floatType->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT);
+    const mx::TypeDesc* integerType = mx::TypeDesc::get("integer");
+    REQUIRE(integerType != nullptr);
+    REQUIRE(integerType->getBaseType() == mx::TypeDesc::BASETYPE_INTEGER);
+    const mx::TypeDesc* booleanType = mx::TypeDesc::get("boolean");
+    REQUIRE(booleanType != nullptr);
+    REQUIRE(booleanType->getBaseType() == mx::TypeDesc::BASETYPE_BOOLEAN);
+    const mx::TypeDesc* color2Type = mx::TypeDesc::get("color2");
+    REQUIRE(color2Type != nullptr);
+    REQUIRE(color2Type->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT);
+    REQUIRE(color2Type->getSemantic() == mx::TypeDesc::SEMATIC_COLOR);
+    REQUIRE(color2Type->isFloat2());
+    const mx::TypeDesc* color3Type = mx::TypeDesc::get("color3");
+    REQUIRE(color3Type != nullptr);
+    REQUIRE(color3Type->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT);
+    REQUIRE(color3Type->getSemantic() == mx::TypeDesc::SEMATIC_COLOR);
+    REQUIRE(color3Type->isFloat3());
+    const mx::TypeDesc* color4Type = mx::TypeDesc::get("color4");
+    REQUIRE(color4Type != nullptr);
+    REQUIRE(color4Type->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT);
+    REQUIRE(color4Type->getSemantic() == mx::TypeDesc::SEMATIC_COLOR);
+    REQUIRE(color4Type->isFloat4());
 
-    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
-    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
-    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
+    // Make sure we can register a new sutom type
+    const mx::TypeDesc* fooType = mx::TypeDesc::registerType("foo", mx::TypeDesc::BASETYPE_FLOAT, mx::TypeDesc::SEMATIC_COLOR, 5);
+    REQUIRE(fooType != nullptr);
 
-    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
-    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
-
-    // Set fixed precision with one digit
-    mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
-
-    std::string value;
-    value = syntax->getDefaultValue(mx::Type::FLOAT);
-    REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue(mx::Type::COLOR3);
-    REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
-    REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR4);
-    REQUIRE(value == "vec4(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
-    REQUIRE(value == "vec4(0.0)");
-
-    mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
-    REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
-    REQUIRE(value == "42.0");
-
-    mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
-    REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
-    REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
-
-    mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
-    REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
-    REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
-}
-
-TEST_CASE("OgsFxSyntax", "[shadergen]")
-{
-    mx::SyntaxPtr syntax = mx::OgsFxSyntax::create();
-
-    REQUIRE(syntax->getTypeName(mx::Type::FLOAT) == "float");
-    REQUIRE(syntax->getTypeName(mx::Type::COLOR3) == "vec3");
-    REQUIRE(syntax->getTypeName(mx::Type::VECTOR3) == "vec3");
-
-    REQUIRE(syntax->getTypeName(mx::Type::BSDF) == "BSDF");
-    REQUIRE(syntax->getOutputTypeName(mx::Type::BSDF) == "out BSDF");
-
-    // Set fixed precision with one digit
-    mx::Value::ScopedFloatFormatting format(mx::Value::FloatFormatFixed, 1);
-
-    std::string value;
-    value = syntax->getDefaultValue(mx::Type::FLOAT);
-    REQUIRE(value == "0.0");
-    value = syntax->getDefaultValue(mx::Type::COLOR3);
-    REQUIRE(value == "vec3(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR3, true);
-    REQUIRE(value == "{0.0, 0.0, 0.0}");
-    value = syntax->getDefaultValue(mx::Type::COLOR4);
-    REQUIRE(value == "vec4(0.0)");
-    value = syntax->getDefaultValue(mx::Type::COLOR4, true);
-    REQUIRE(value == "{0.0, 0.0, 0.0, 0.0}");
-
-    mx::ValuePtr floatValue = mx::Value::createValue<float>(42.0f);
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue);
-    REQUIRE(value == "42.0");
-    value = syntax->getValue(mx::Type::FLOAT, *floatValue, true);
-    REQUIRE(value == "42.0");
-
-    mx::ValuePtr color3Value = mx::Value::createValue<mx::Color3>(mx::Color3(1.0f, 2.0f, 3.0f));
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value);
-    REQUIRE(value == "vec3(1.0, 2.0, 3.0)");
-    value = syntax->getValue(mx::Type::COLOR3, *color3Value, true);
-    REQUIRE(value == "{1.0, 2.0, 3.0}");
-
-    mx::ValuePtr color4Value = mx::Value::createValue<mx::Color4>(mx::Color4(1.0f, 2.0f, 3.0f, 4.0f));
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value);
-    REQUIRE(value == "vec4(1.0, 2.0, 3.0, 4.0)");
-    value = syntax->getValue(mx::Type::COLOR4, *color4Value, true);
-    REQUIRE(value == "{1.0, 2.0, 3.0, 4.0}");
+    // Make sure we can't use a name already take
+    REQUIRE_THROWS(mx::TypeDesc::registerType("color3", mx::TypeDesc::BASETYPE_FLOAT));
 }
 
 TEST_CASE("Reference Implementation Validity", "[shadergen]")

--- a/source/MaterialXView/ShaderValidators/Glsl/GlslProgram.cpp
+++ b/source/MaterialXView/ShaderValidators/Glsl/GlslProgram.cpp
@@ -1090,14 +1090,14 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                     }
                     if (Input->second->gltype == mapTypeToOpenGLType(input->type))
                     {
-                        Input->second->typeString = input->type;
+                        Input->second->typeString = input->type->getName();
                     }
                     else
                     {
                         errors.push_back(
                             "Pixel shader uniform block type mismatch[" + uniforms.first + "]. "
                             + "Name: \"" + input->name
-                            + "\". Type: \"" + input->type
+                            + "\". Type: \"" + input->type->getName()
                             + "\". Semantic: \"" + input->semantic
                             + "\". Value: \"" + (input->value ? input->value->getValueString() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(input->type))
@@ -1119,16 +1119,15 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
                 {
                     if (Input->second->gltype == mapTypeToOpenGLType(input->type))
                     {
-                        Input->second->typeString = input->type;
+                        Input->second->typeString = input->type->getName();
                         Input->second->value = input->value;
-                        Input->second->typeString = input->type;
                     }
                     else
                     {
                         errors.push_back(
                             "Vertex shader uniform block type mismatch[" + uniforms.first + "]. "
                             + "Name: \"" + input->name
-                            + "\". Type: \"" + input->type
+                            + "\". Type: \"" + input->type->getName()
                             + "\". Semantic: \"" + input->semantic
                             + "\". Value: \"" + (input->value ? input->value->getValueString() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(input->type))
@@ -1149,25 +1148,25 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
     return _uniformList;
 }
 
-int GlslProgram::mapTypeToOpenGLType(const std::string& type)
+int GlslProgram::mapTypeToOpenGLType(const TypeDesc* type)
 {
-    if (type == MaterialX::getTypeString<int>())
+    if (type == Type::INTEGER)
         return GL_INT;
-    else if (type == MaterialX::getTypeString<bool>())
+    else if (type == Type::BOOLEAN)
         return GL_BOOL;
-    else if (type == MaterialX::getTypeString<float>())
+    else if (type == Type::FLOAT)
         return GL_FLOAT;
-    else if (type == MaterialX::getTypeString<Vector2>() || type == MaterialX::getTypeString<Color2>())
+    else if (type->isFloat2())
         return GL_FLOAT_VEC2;
-    else if (type == MaterialX::getTypeString<Vector3>() || type == MaterialX::getTypeString<Color3>())
+    else if (type->isFloat3())
         return GL_FLOAT_VEC3;
-    else if (type == MaterialX::getTypeString<Vector4>() || type == MaterialX::getTypeString<Color4>())
+    else if (type->isFloat4())
         return GL_FLOAT_VEC4;
-    else if (type == MaterialX::getTypeString<Matrix33>())
+    else if (type == Type::MATRIX33)
         return GL_FLOAT_MAT3;
-    else if (type == MaterialX::getTypeString<Matrix44>())
+    else if (type == Type::MATRIX44)
         return GL_FLOAT_MAT4;
-    else if (type == MaterialX::FILENAME_TYPE_STRING)
+    else if (type == Type::FILENAME)
     {
         // A "filename" is not indicative of type, so just return a 2d sampler.
         return GL_SAMPLER_2D;
@@ -1249,13 +1248,13 @@ const GlslProgram::InputMap& GlslProgram::updateAttributesList()
 
                     if (Input->second->gltype == mapTypeToOpenGLType(input->type))
                     {
-                        Input->second->typeString = input->type;
+                        Input->second->typeString = input->type->getName();
                     }
                     else
                     {
                         errors.push_back(
                             "Application uniform type mismatch in block. Name: \"" + input->name
-                            + "\". Type: \"" + input->type
+                            + "\". Type: \"" + input->type->getName()
                             + "\". Semantic: \"" + input->semantic
                             + "\". Value: \"" + (input->value ? input->value->getValueString() : "<none>")
                             + "\". GLType: " + std::to_string(mapTypeToOpenGLType(input->type))

--- a/source/MaterialXView/ShaderValidators/Glsl/GlslProgram.h
+++ b/source/MaterialXView/ShaderValidators/Glsl/GlslProgram.h
@@ -205,10 +205,10 @@ class GlslProgram
     /// Clear out any cached input lists
     void clearInputLists();   
 
-    /// Utility to map a syntax type to an OpenGL type
-    /// @param type Syntax type
+    /// Utility to map a MaterialX type to an OpenGL type
+    /// @param type MaterialX type
     /// @return OpenGL type. INVALID_OPENGL_TYPE is returned if no mapping exists. For example strings have no OpenGL type.
-    static int mapTypeToOpenGLType(const std::string& type);
+    static int mapTypeToOpenGLType(const TypeDesc* type);
 
     /// @}
     /// @name Utilities


### PR DESCRIPTION
- TypeDesc class for registering and identification of MaterialX data types
- Improves performance of type matching from string compares to single pointer compare (small but noticeable speed-up of overall shader generation time)
- Improves support for registering new custom types
