### PR TITLE
Tiled image and triplanar test suite data

### DIFF
--- a/documents/TestSuite/stdlib/texture/image.mtlx
+++ b/documents/TestSuite/stdlib/texture/image.mtlx
@@ -1,3 +1,8 @@
+<!--
+
+Basic image unit test with one image node for each variation in input type.
+
+-->
 <?xml version="1.0"?>
 <materialx version="1.36">
    <output name="image4_output" type="color4" nodename="image4" />

--- a/documents/TestSuite/stdlib/texture/tiledimage.mtlx
+++ b/documents/TestSuite/stdlib/texture/tiledimage.mtlx
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+   <output name="tiled_image4_output" type="color4" nodename="tiled_image4" />
+   <tiledimage name="tiled_image4" type="color4">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image3_output" type="color3" nodename="tiled_image3" />
+   <tiledimage name="tiled_image3" type="color3">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image2_output" type="color2" nodename="tiled_image2" />
+   <tiledimage name="tiled_image2" type="color2">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image1_output" type="float" nodename="tiled_image1" />
+   <tiledimage name="tiled_image1" type="float">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image4v_output" type="vector4" nodename="tiled_image4v" />
+   <tiledimage name="tiled_image4v" type="vector4">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image3v_output" type="vector3" nodename="tiled_image3v" />
+   <tiledimage name="tiled_image3v" type="vector3">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+
+   <output name="tiled_image2v_output" type="vector2" nodename="tiled_image2v" />
+   <tiledimage name="tiled_image2v" type="vector2">
+      <parameter name="file" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="uvtiling" type="vector2" value="2.0, 2.0"/>
+      <parameter name="uvoffset" type="vector2" value="0.5, 0.5"/>
+   </tiledimage>
+</materialx>

--- a/documents/TestSuite/stdlib/texture/tiledimage.mtlx
+++ b/documents/TestSuite/stdlib/texture/tiledimage.mtlx
@@ -1,3 +1,10 @@
+<!--
+
+Basic tiled image unit test with one image node for each variation in input type.
+A scale and offset of 2,2 and 0.5,0.5 is applied to the texture coordinates 
+used to lookup each image
+
+-->
 <?xml version="1.0"?>
 <materialx version="1.36">
    <output name="tiled_image4_output" type="color4" nodename="tiled_image4" />

--- a/documents/TestSuite/stdlib/texture/triplanarprojection.mtlx
+++ b/documents/TestSuite/stdlib/texture/triplanarprojection.mtlx
@@ -1,0 +1,56 @@
+<!--
+
+Basic triplanar mapping unit test.
+
+-->
+<?xml version="1.0"?>
+<materialx version="1.36">
+   <output name="triplanarprojection_4_output" type="color4" nodename="triplanarprojection_4" />
+   <triplanarprojection name="triplanarprojection_4" type="color4">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_3_output" type="color3" nodename="triplanarprojection_3" />
+   <triplanarprojection name="triplanarprojection_3" type="color3">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_2_output" type="color2" nodename="triplanarprojection_2" />
+   <triplanarprojection name="triplanarprojection_2" type="color2">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_1_output" type="float" nodename="triplanarprojection_1" />
+   <triplanarprojection name="triplanarprojection_1" type="float">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_4v_output" type="vector4" nodename="triplanarprojection_4v" />
+   <triplanarprojection name="triplanarprojection_4v" type="vector4">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_3v_output" type="vector3" nodename="triplanarprojection_3v" />
+   <triplanarprojection name="triplanarprojection_3v" type="vector3">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+
+   <output name="triplanarprojection_2v_output" type="vector2" nodename="triplanarprojection_2v" />
+   <triplanarprojection name="triplanarprojection_2v" type="vector2">
+      <parameter name="filex" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filey" type="filename" value="documents/Images/MaterialXLogo.exr" />
+      <parameter name="filez" type="filename" value="documents/Images/MaterialXLogo.exr" />
+   </triplanarprojection>
+</materialx>


### PR DESCRIPTION
- Add in tiled image support
- Add in triplanar support (to verify when testing node-graph nodes but appears only 1 of the 3 planes blends properly in hardware).
