### PR TITLE
Update for using OSL 1.9.10 distro build

### DIFF
--- a/source/MaterialXGenOsl/ArnoldShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/ArnoldShaderGenerator.cpp
@@ -5,6 +5,15 @@ namespace MaterialX
 
 const string ArnoldShaderGenerator::TARGET = "arnold";
 
+
+ArnoldShaderGenerator::ArnoldShaderGenerator() 
+    : OslShaderGenerator() 
+{
+    const StringSet restrictedNames = { "translucent", "empirical_bssrdf", "randomwalk_bssrdf", "volume_absorption",
+                                        "volume_emission", "volume_henyey_greenstein", "volume_matte" };
+    _syntax->registerRestrictedNames(restrictedNames);
+}
+
 Shader::VDirection ArnoldShaderGenerator::getTargetVDirection() const
 {
     return Shader::VDirection::DOWN;

--- a/source/MaterialXGenOsl/ArnoldShaderGenerator.h
+++ b/source/MaterialXGenOsl/ArnoldShaderGenerator.h
@@ -12,7 +12,7 @@ using ArnoldShaderGeneratorPtr = shared_ptr<class ArnoldShaderGenerator>;
 class ArnoldShaderGenerator : public OslShaderGenerator
 {
 public:
-    ArnoldShaderGenerator() : OslShaderGenerator() {}
+    ArnoldShaderGenerator();
 
     static ShaderGeneratorPtr create() { return std::make_shared<ArnoldShaderGenerator>(); }
 

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -127,7 +127,9 @@ OslSyntax::OslSyntax()
         "false", "friend", "goto", "inline", "long", "new", "operator", "private", "protected", "short",
         "signed", "sizeof", "static", "switch", "template", "this", "throw", "true", "try", "typedef", "uniform",
         "union", "unsigned", "varying", "virtual", "volatile",
-        "emission"
+        "emission", "background", "diffuse", "oren_nayer", "translucent", "phong", "ward", "microfacet", 
+        "reflection", "transparent", "debug", "holdout", "subsurface",
+        ""
     });
 
     //

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -225,6 +225,13 @@ void createLightRig(mx::DocumentPtr doc, mx::HwLightHandler& lightHandler, mx::H
     lightHandler.bindLightShaders(shadergen);
 }
 
+static std::string RESULT_DIRECTORY("results/");
+TEST_CASE("Bootstrap", "[shadergen]")
+{
+    // This must always come first
+    mx::makeDirectory(RESULT_DIRECTORY);
+}
+
 TEST_CASE("Syntax", "[shadergen]")
 {
 #ifdef MATERIALX_BUILD_GEN_OSL
@@ -874,12 +881,16 @@ static void validateOSL(const std::string oslFileName, std::string& errorResult)
         return;
     }
 
+    // Set oso output name
+    std::string osoFileName = mx::removeExtension(oslFileName);
+    osoFileName += ".oso";
+
     // Use a known error file name to check
     std::string errorFile(oslFileName + "_errors.txt");
     const std::string redirectString(" 2>&1");
 
     // Run the command and get back the result. If non-empty string throw exception with error
-    std::string command = oslcCommand + " -q -I\"" + oslIncludePath + "\" " + oslFileName + " > " +
+    std::string command = oslcCommand + " -o " + osoFileName + " -q -I\"" + oslIncludePath + "\" " + oslFileName + " > " +
         errorFile + redirectString;
 
     int returnValue = std::system(command.c_str());
@@ -946,7 +957,7 @@ TEST_CASE("Hello World", "[shadergen]")
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
         std::ofstream file;
-        std::string fileName(shader->getName() + "_graph.osl");
+        std::string fileName(RESULT_DIRECTORY + shader->getName() + "_graph.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -962,7 +973,7 @@ TEST_CASE("Hello World", "[shadergen]")
         REQUIRE(shader != nullptr);
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
-        fileName.assign(shader->getName() + "_shaderref.osl");
+        fileName.assign(RESULT_DIRECTORY + shader->getName() + "_shaderref.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -986,7 +997,7 @@ TEST_CASE("Hello World", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + "_graph.ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_graph.ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
         file.close();
 
@@ -996,7 +1007,7 @@ TEST_CASE("Hello World", "[shadergen]")
         REQUIRE(shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE).length() > 0);
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
-        file.open(shader->getName() + "_shaderref.ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_shaderref.ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
         file.close();
     }
@@ -1015,10 +1026,10 @@ TEST_CASE("Hello World", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + "_graph.vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_graph.vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         file.close();
-        file.open(shader->getName() + "_graph.frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_graph.frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
 
@@ -1029,10 +1040,10 @@ TEST_CASE("Hello World", "[shadergen]")
         REQUIRE(shader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
-        file.open(shader->getName() + "_shaderref.vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_shaderref.vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         file.close();
-        file.open(shader->getName() + "_shaderref.frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + "_shaderref.frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
     }
@@ -1084,7 +1095,7 @@ TEST_CASE("Conditionals", "[shadergen]")
     // Write out a .dot file for visualization
     std::ofstream file;
     std::string dot = nodeGraph->asStringDot();
-    file.open(nodeGraph->getName() + ".dot");
+    file.open(RESULT_DIRECTORY + nodeGraph->getName() + ".dot");
     file << dot;
     file.close();
 
@@ -1109,7 +1120,7 @@ TEST_CASE("Conditionals", "[shadergen]")
         REQUIRE(shader->getNodeGraph()->getOutputSocket()->value->getValueString() == constant2->getParameterValue("value")->getValueString());
 
         // Write out to file for inspection
-        const std::string fileName(shader->getName() + ".osl");
+        const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -1132,7 +1143,7 @@ TEST_CASE("Conditionals", "[shadergen]")
 
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
-        file.open(shader->getName() + ".ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
         file << shader->getSourceCode();
         file.close();
 
@@ -1156,10 +1167,10 @@ TEST_CASE("Conditionals", "[shadergen]")
 
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
-        file.open(shader->getName() + ".vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         file.close();
-        file.open(shader->getName() + ".frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
 
@@ -1253,7 +1264,7 @@ TEST_CASE("Geometric Nodes", "[shadergen]")
 
         // Write out to file for inspection
         std::ofstream file;
-        const std::string fileName(shader->getName() + ".osl");
+        const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -1277,7 +1288,7 @@ TEST_CASE("Geometric Nodes", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -1295,10 +1306,10 @@ TEST_CASE("Geometric Nodes", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
-        file.open(shader->getName() + ".vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -1402,7 +1413,7 @@ TEST_CASE("Noise", "[shadergen]")
 
             // Write out to file for inspection
             std::ofstream file;
-            const std::string fileName(shader->getName() + ".osl");
+            const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
             file.open(fileName);
             file << shader->getSourceCode();
             file.close();
@@ -1426,7 +1437,7 @@ TEST_CASE("Noise", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".ogsfx");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
             file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
             file.close();
         }
@@ -1445,10 +1456,10 @@ TEST_CASE("Noise", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".vert");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
             file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
             file.close();
-            file.open(shader->getName() + ".frag");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
             file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
             file.close();
         }
@@ -1504,7 +1515,7 @@ TEST_CASE("Unique Names", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        const std::string fileName(exampleName + ".osl");
+        const std::string fileName(RESULT_DIRECTORY + exampleName + ".osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -1537,7 +1548,7 @@ TEST_CASE("Unique Names", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(exampleName + ".ogsfx");
+        file.open(RESULT_DIRECTORY + exampleName + ".ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -1564,10 +1575,10 @@ TEST_CASE("Unique Names", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(exampleName + ".frag");
+        file.open(RESULT_DIRECTORY + exampleName + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
-        file.open(exampleName + ".vert");
+        file.open(RESULT_DIRECTORY + exampleName + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -1610,7 +1621,7 @@ TEST_CASE("Subgraphs", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            const std::string fileName(shader->getName() + ".osl");
+            const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
             file.open(fileName);
             file << shader->getSourceCode();
             file.close();
@@ -1647,7 +1658,7 @@ TEST_CASE("Subgraphs", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".ogsfx");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
             file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
         }
     }
@@ -1679,10 +1690,10 @@ TEST_CASE("Subgraphs", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".frag");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
             file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
             file.close();
-            file.open(shader->getName() + ".vert");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
             file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         }
     }
@@ -1723,7 +1734,7 @@ TEST_CASE("Materials", "[shadergen]")
 
                 // Write out to file for inspection
                 std::ofstream file;
-                const std::string fileName(shader->getName() + ".osl");
+                const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
                 file.open(fileName);
                 file << shader->getSourceCode();
                 file.close();
@@ -1758,7 +1769,7 @@ TEST_CASE("Materials", "[shadergen]")
                 // Write out to file for inspection
                 // TODO: Use validation in MaterialXView library
                 std::ofstream file;
-                file.open(shader->getName() + ".ogsfx");
+                file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
                 file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
             }
         }
@@ -1787,10 +1798,10 @@ TEST_CASE("Materials", "[shadergen]")
                 // Write out to file for inspection
                 // TODO: Use validation in MaterialXView library
                 std::ofstream file;
-                file.open(shader->getName() + ".frag");
+                file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
                 file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
                 file.close();
-                file.open(shader->getName() + ".vert");
+                file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
                 file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
             }
         }
@@ -1844,7 +1855,7 @@ TEST_CASE("Color Spaces", "[shadergen]")
 
         // Write out to file for inspection
         std::ofstream file;
-        const std::string fileName(shader->getName() + ".osl");
+        const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -1868,7 +1879,7 @@ TEST_CASE("Color Spaces", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -1886,10 +1897,10 @@ TEST_CASE("Color Spaces", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
-        file.open(shader->getName() + ".vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -1995,7 +2006,7 @@ TEST_CASE("BSDF Layering", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            const std::string fileName(shader->getName() + ".osl");
+            const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
             file.open(fileName);
             file << shader->getSourceCode();
             file.close();
@@ -2023,7 +2034,7 @@ TEST_CASE("BSDF Layering", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".ogsfx");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
             file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
         }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -2045,10 +2056,10 @@ TEST_CASE("BSDF Layering", "[shadergen]")
             // Write out to file for inspection
             // TODO: Use validation in MaterialXView library
             std::ofstream file;
-            file.open(shader->getName() + ".frag");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
             file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
             file.close();
-            file.open(shader->getName() + ".vert");
+            file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
             file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
         }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -2133,7 +2144,7 @@ TEST_CASE("Transparency", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        const std::string fileName(shader->getName() + ".osl");
+        const std::string fileName(RESULT_DIRECTORY + shader->getName() + ".osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -2161,7 +2172,7 @@ TEST_CASE("Transparency", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -2183,10 +2194,10 @@ TEST_CASE("Transparency", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
-        file.open(shader->getName() + ".vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -2275,7 +2286,7 @@ TEST_CASE("Surface Layering", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".ogsfx");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".ogsfx");
         file << shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_OGSFX
@@ -2297,10 +2308,10 @@ TEST_CASE("Surface Layering", "[shadergen]")
         // Write out to file for inspection
         // TODO: Use validation in MaterialXView library
         std::ofstream file;
-        file.open(shader->getName() + ".frag");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".frag");
         file << shader->getSourceCode(mx::HwShader::PIXEL_STAGE);
         file.close();
-        file.open(shader->getName() + ".vert");
+        file.open(RESULT_DIRECTORY + shader->getName() + ".vert");
         file << shader->getSourceCode(mx::HwShader::VERTEX_STAGE);
     }
 #endif // MATERIALX_BUILD_GEN_GLSL
@@ -2353,7 +2364,7 @@ TEST_CASE("Osl Output Types", "[shadergen]")
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
         std::ofstream file;
-        std::string fileName(exampleName + "_color2.osl");
+        std::string fileName(RESULT_DIRECTORY + exampleName + "_color2.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -2368,7 +2379,7 @@ TEST_CASE("Osl Output Types", "[shadergen]")
         REQUIRE(shader != nullptr);
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
-        fileName.assign(exampleName + "_color4.osl");
+        fileName.assign(RESULT_DIRECTORY + exampleName + "_color4.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -2403,7 +2414,7 @@ TEST_CASE("Osl Output Types", "[shadergen]")
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
         std::ofstream file;
-        std::string fileName(exampleName + "_vector2.osl");
+        std::string fileName(RESULT_DIRECTORY + exampleName + "_vector2.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();
@@ -2418,7 +2429,7 @@ TEST_CASE("Osl Output Types", "[shadergen]")
         REQUIRE(shader != nullptr);
         REQUIRE(shader->getSourceCode().length() > 0);
         // Write out to file for inspection
-        fileName.assign(exampleName + "_vector4.osl");
+        fileName.assign(RESULT_DIRECTORY + exampleName + "_vector4.osl");
         file.open(fileName);
         file << shader->getSourceCode();
         file.close();

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -16,11 +16,16 @@
 #include <MaterialXGenShader/HwShader.h>
 #include <MaterialXGenShader/HwLightHandler.h>
 
+#ifdef MATERIALX_BUILD_GEN_GLSL
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
-#include <MaterialXGenOsl/ArnoldShaderGenerator.h>
-
 #include <MaterialXView/ShaderValidators/Glsl/GlslValidator.h>
+#endif
+
+#ifdef MATERIALX_BUILD_GEN_OSL
+#include <MaterialXGenOsl/ArnoldShaderGenerator.h>
 #include <MaterialXView/ShaderValidators/Osl/OslValidator.h>
+#endif
+
 #include <MaterialXView/Handlers/TinyEXRImageHandler.h>
 
 #include <fstream>
@@ -253,6 +258,7 @@ TEST_CASE("GLSL Source", "[shadervalid]")
     }
 }
 
+#ifdef MATERIALX_BUILD_GEN_GLSL
 //
 // Create a validator with an image and geometry handler
 // If a filename is supplied then a stock geometry of that name will be used if it can be loaded.
@@ -295,7 +301,9 @@ static mx::GlslValidatorPtr createGLSLValidator(bool& orthographicView, const st
 
     return validator;
 }
+#endif
 
+#ifdef MATERIALX_BUILD_GEN_OSL
 static mx::OslValidatorPtr createOSLValidator(bool& orthographicView, std::ostream& log)
 {
     bool initialized = false;
@@ -322,7 +330,9 @@ static mx::OslValidatorPtr createOSLValidator(bool& orthographicView, std::ostre
 
     return validator;
 }
+#endif
 
+#ifdef MATERIALX_BUILD_GEN_GLSL
 // Test by connecting it to a supplied element
 // 1. Create the shader and checks for source generation
 // 2. Writes doc to disk if valid
@@ -400,7 +410,9 @@ static void runGLSLValidation(const std::string& shaderName, mx::ElementPtr elem
         CHECK(validated);
     }
 }
+#endif
 
+#ifdef MATERIALX_BUILD_GEN_OSL
 static void runOSLValidation(const std::string& shaderName, mx::ElementPtr element, mx::OslValidator& validator,
                              mx::ArnoldShaderGenerator& shaderGenerator, mx::DocumentPtr doc, std::ostream& log,
                              bool outputMtlxDoc=true, const std::string& outputPath=".")
@@ -456,34 +468,57 @@ static void runOSLValidation(const std::string& shaderName, mx::ElementPtr eleme
         CHECK(validated);
     }
 }
+#endif
 
-TEST_CASE("GLSL MaterialX documents", "[shadervalid]")
+TEST_CASE("MaterialX documents", "[shadervalid]")
 {
+    bool runValidation = false;
+#ifdef MATERIALX_BUILD_GEN_GLSL
+    runValidation = true;
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
+    runValidation = true;
+#endif
+    if (!runValidation)
+    {
+        // No generators exist so there is nothing to test. Just return
+        return;
+    }
+
 #ifdef LOG_TO_FILE
+    #ifdef MATERIALX_BUILD_GEN_GLSL
     std::ofstream glslLogfile("log_shadervalid_glsl_materialx_documents.txt");
-    std::ofstream oslLogfile("log_shadervalid_osl_materialx_documents.txt");
     std::ostream& glslLog(glslLogfile);
+    #endif
+    #ifdef MATERIALX_BUILD_GEN_OSL
+    std::ofstream oslLogfile("log_shadervalid_osl_materialx_documents.txt");
     std::ostream& oslLog(oslLogfile);
+    #endif
 #else
+    #ifdef MATERIALX_BUILD_GEN_GLSL
     std::ostream& glslLog(std::cout);
+    #endif
+    #ifdef MATERIALX_BUILD_GEN_OSL
     std::ostream& oslLog(std::cout);
+    #endif
 #endif
 
     // Library search path
     mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/Libraries");
 
-    // Create a validator
+    // Create validators and generators
     bool orthographicView = true;
+#ifdef MATERIALX_BUILD_GEN_GLSL
     mx::GlslValidatorPtr glslValidator = createGLSLValidator(orthographicView, "shaderball.obj", glslLog);
-    mx::OslValidatorPtr oslValidator = createOSLValidator(orthographicView, oslLog);
-
-    // Set up GLSL shader generator.
-    // TODO : Need to add in other generators
     mx::GlslShaderGeneratorPtr glslShaderGenerator = std::static_pointer_cast<mx::GlslShaderGenerator>(mx::GlslShaderGenerator::create());
     glslShaderGenerator->registerSourceCodeSearchPath(searchPath);
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
+    mx::OslValidatorPtr oslValidator = createOSLValidator(orthographicView, oslLog);
     mx::ArnoldShaderGeneratorPtr oslShaderGenerator = std::static_pointer_cast<mx::ArnoldShaderGenerator>(mx::ArnoldShaderGenerator::create());
     oslShaderGenerator->registerSourceCodeSearchPath(searchPath);
     oslShaderGenerator->registerSourceCodeSearchPath(searchPath / mx::FilePath("stdlib/osl"));
+#endif
 
     // Load in the library dependencies once
     // This will be imported in each test document below
@@ -529,8 +564,12 @@ TEST_CASE("GLSL MaterialX documents", "[shadervalid]")
 
             if (!materials.empty() || !nodeGraphs.empty() || !outputList.empty())
             {
+#ifdef MATERIALX_BUILD_GEN_GLSL
                 glslLog << "MTLX Filename: " << filename << std::endl;
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
                 oslLog << "MTLX Filename: " << filename << std::endl;
+#endif
 
                 doc->importLibrary(dependLib, &importOptions);
 
@@ -543,8 +582,12 @@ TEST_CASE("GLSL MaterialX documents", "[shadervalid]")
                         {
                             std::string outputPath = mx::FilePath(dir) / mx::FilePath(mx::removeExtension(file));
                             mx::string elementName = mx::replaceSubstrings(shaderRef->getNamePath(), pathMap);
+#ifdef MATERIALX_BUILD_GEN_GLSL
                             runGLSLValidation(elementName, shaderRef, *glslValidator, *glslShaderGenerator, orthographicView, doc, glslLog, false, outputPath);
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
                             runOSLValidation(elementName, shaderRef, *oslValidator, *oslShaderGenerator, doc, oslLog, false, outputPath);
+#endif
 
                             // Find all bindinputs which reference outputs and outputgraphs
                             for (auto bindInput : shaderRef->getBindInputs())
@@ -586,8 +629,12 @@ TEST_CASE("GLSL MaterialX documents", "[shadervalid]")
                     {
                         std::string outputPath = mx::FilePath(dir) / mx::FilePath(mx::removeExtension(file));
                         mx::string elementName = mx::replaceSubstrings(output->getNamePath(), pathMap);
+#ifdef MATERIALX_BUILD_GEN_GLSL
                         runGLSLValidation(elementName, output, *glslValidator, *glslShaderGenerator, orthographicView, doc, glslLog, false, outputPath);
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
                         runOSLValidation(elementName, output, *oslValidator, *oslShaderGenerator, doc, oslLog, false, outputPath);
+#endif
                     }
                 }
             }

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -440,6 +440,7 @@ static void runOSLValidation(const std::string& shaderName, mx::ElementPtr eleme
         bool validated = false;
         try
         {
+            validator.setOslOutputFilePath(shaderPath);
             validator.validateCreation(shader);
             // TODO: Call additional validation routines here when they are available
             validated = true;

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
@@ -37,8 +37,9 @@ void OslValidator::compileOSL(const std::string& oslFileName)
         return;
     }
 
-    // Add .oso extension for output. 
-    std::string outputFileName(oslFileName + ".oso");
+    // Remove .osl and add .oso extension for output. 
+    std::string outputFileName = removeExtension(oslFileName);
+    outputFileName += ".oso";
 
     // Use a known error file name to check
     std::string errorFile(oslFileName + "_errors.txt");

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
@@ -1,5 +1,6 @@
 #include <MaterialXView/ShaderValidators/Osl/OslValidator.h>
 #include <MaterialXView/Handlers/ObjGeometryHandler.h>
+#include <MaterialXGenShader/Util.h>
 
 #include <fstream>
 #include <iostream>
@@ -36,12 +37,15 @@ void OslValidator::compileOSL(const std::string& oslFileName)
         return;
     }
 
+    // Add .oso extension for output. 
+    std::string outputFileName(oslFileName + ".oso");
+
     // Use a known error file name to check
     std::string errorFile(oslFileName + "_errors.txt");
     const std::string redirectString(" 2>&1");
 
     // Run the command and get back the result. If non-empty string throw exception with error
-    std::string command = _oslCompilerExecutable + " -q -I\"" + _oslIncludePathString + "\" " + oslFileName + " > " +
+    std::string command = _oslCompilerExecutable + " -q -I\"" + _oslIncludePathString + "\" " + oslFileName + " -o " + outputFileName + " > " +
         errorFile + redirectString;
 
     int returnValue = std::system(command.c_str());
@@ -89,7 +93,15 @@ void OslValidator::validateCreation(const std::vector<std::string>& stages)
     }
 
     // Dump string to disk. For OSL assume shader is in stage 0 slot.
-    const std::string fileName("_osl_temp.osl");
+    std::string fileName = _oslOutputFilePathString;
+    if (fileName.empty())
+    {
+        fileName = "_osl_temp.osl";
+    }
+    else
+    {
+        fileName += ".osl";
+    }
     std::ofstream file;
     file.open(fileName);
     file << stages[0];

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.h
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.h
@@ -89,6 +89,15 @@ class OslValidator : public ShaderValidator
         _oslIncludePathString = includePathString;
     }
 
+    /// Set OSL output name, excluding any extension.
+    /// During compiler checking an OSL file of the given output name will be used if it
+    /// is not empty. If temp then OSL will be written to a temporary file.
+    /// @param filePathString Full path name
+    void setOslOutputFilePath(const std::string filePathString)
+    {
+        _oslOutputFilePathString = filePathString;
+    }
+
     /// @}
 
   protected:
@@ -103,6 +112,7 @@ class OslValidator : public ShaderValidator
   private:
     std::string _oslCompilerExecutable;
     std::string _oslIncludePathString;
+    std::string _oslOutputFilePathString;
 };
 
 } // namespace MaterialX


### PR DESCRIPTION
- Add in disallowed closure definions for OSL and Arnold
- Set ShaderGen to output results to "results" folder
- Add an output file name for oslc generation so that oso files are placed beside osl files. This is required for testshade testing for example.
- Add in proper ifdef protections which are set based on generator build options.
