### PR TITLE
Fixes for ramp nodegraph implementation from ILM.

### DIFF
--- a/documents/Libraries/stdlib/stdlib_ng.mtlx
+++ b/documents/Libraries/stdlib/stdlib_ng.mtlx
@@ -950,12 +950,15 @@
     A 4-corner bilinear value ramp.
   -->
   <nodegraph name="NG_ramp4_float" nodedef="ND_ramp4_float">
-    <extract name="N_s_float" type="float">
+    <clamp name="N_txclamp_float" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_float" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_float"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_float" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_float"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_float" type="float">
@@ -977,12 +980,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_color2" nodedef="ND_ramp4_color2">
-    <extract name="N_s_color2" type="float">
+    <clamp name="N_txclamp_color2" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_color2" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_color2"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_color2" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_color2"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_color2" type="color2">
@@ -1004,12 +1010,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_color3" nodedef="ND_ramp4_color3">
-    <extract name="N_s_color3" type="float">
+    <clamp name="N_txclamp_color3" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_color3" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_color3"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_color3" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_color3"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_color3" type="color3">
@@ -1031,12 +1040,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_color4" nodedef="ND_ramp4_color4">
-    <extract name="N_s_color4" type="float">
+    <clamp name="N_txclamp_color4" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_color4" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_color4"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_color4" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_color4"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_color4" type="color4">
@@ -1058,12 +1070,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_vector2" nodedef="ND_ramp4_vector2">
-    <extract name="N_s_vector2" type="float">
+    <clamp name="N_txclamp_vector2" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_vector2" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_vector2"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_vector2" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_vector2"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_vector2" type="vector2">
@@ -1085,12 +1100,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_vector3" nodedef="ND_ramp4_vector3">
-    <extract name="N_s_vector3" type="float">
+    <clamp name="N_txclamp_vector3" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_vector3" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_vector3"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_vector3" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_vector3"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_vector3" type="vector3">
@@ -1112,12 +1130,15 @@
   </nodegraph>
 
   <nodegraph name="NG_ramp4_vector4" nodedef="ND_ramp4_vector4">
-    <extract name="N_s_vector4" type="float">
+    <clamp name="N_txclamp_vector4" type="vector2">
       <input name="in" type="vector2" interfacename="texcoord"/>
+    </clamp>
+    <extract name="N_s_vector4" type="float">
+      <input name="in" type="vector2" nodename="N_txclamp_vector4"/>
       <parameter name="index" type="integer" value="0"/>
     </extract>
     <extract name="N_t_vector4" type="float">
-      <input name="in" type="vector2" interfacename="texcoord"/>
+      <input name="in" type="vector2" nodename="N_txclamp_vector4"/>
       <parameter name="index" type="integer" value="1"/>
     </extract>
     <mix name="N_mixtop_vector4" type="vector4">


### PR DESCRIPTION
Fixes to ramp node graph implementation from ILM.
Note that the index exposure was already added locally so does not show up in this PR.

