### PR TITLE
Add support color more constant output types

### DIFF
--- a/documents/TestSuite/util/constant_color2.osl
+++ b/documents/TestSuite/util/constant_color2.osl
@@ -1,0 +1,11 @@
+#include "color2.h"
+
+surface 
+constant_color2
+    [[ string description = "Simple closure for constant color surface rendering" ]]
+(
+    color2 Cin = {0.0, 0.0},
+)
+{
+	Ci = color(Cin.r, Cin.a, 0) * emission();
+}

--- a/documents/TestSuite/util/constant_color4.osl
+++ b/documents/TestSuite/util/constant_color4.osl
@@ -1,0 +1,12 @@
+#include "color4.h"
+
+surface 
+constant_color4
+    [[ string description = "Simple closure for constant color surface rendering" ]]
+(
+	color4 Cin = {(0.0, 0.0, 0.0), 0.0}
+        [[  string description = "Input color to modulate emission with" ]]
+)
+{
+	Ci = color(Cin.rgb[0], Cin.rgb[1], Cin.rgb[2]) * emission(); 
+}

--- a/documents/TestSuite/util/constant_color_scene.xml
+++ b/documents/TestSuite/util/constant_color_scene.xml
@@ -11,19 +11,16 @@
    </ShaderGroup>
    <Background resolution="1024" />
 
-   <!-- Constant shaded input:
-   constant_color: "constant" color shader used to render without lighting
-   Cin : "constant" shader's default color (red). This color will be use if the connected
-   input shader fails to route properly.
-   %shader% : Is the name of an input color shader to feed into the "constant" shader.
-   %shader_output% : Is the name of the input shader's color output. This is connected to the color 
-   input (Cin) of the "constant" shader.
+   <!-- Shader graph for routing to output layer:
+   %input_shader_type% : type of an input shader to feed into the output shader.
+   %input_shader_output% : name of output argument on input shader.
+   %output_shader_type%: type of the output shader used to render with
+   %output_shader_input% : name of input argument on output shader.
    -->
    <ShaderGroup>
-      shader %shader% constant_input;
-      color Cin 1.0 0.0 0.0;
-      shader constant_color layer1;
-      connect constant_input.%shader_output% layer1.Cin;
+      shader %input_shader_type% inputShader;
+      shader %output_shader_type% outputShader;
+      connect inputShader.%input_shader_output% outputShader.%output_shader_input%;
    </ShaderGroup>
    <Sphere center="0,0,0" radius="1" />
 </World>

--- a/documents/TestSuite/util/constant_vector2.osl
+++ b/documents/TestSuite/util/constant_vector2.osl
@@ -1,0 +1,12 @@
+#include "vector2.h"
+
+surface 
+constant_vector2
+    [[ string description = "Simple closure for constant color surface rendering" ]]
+(
+	vector2 Cin = {0.0, 0.0}
+        [[  string description = "Input color to modulate emission with" ]]
+)
+{
+	Ci = color(Cin.x, Cin.y, 0.0) * emission(); 
+}

--- a/documents/TestSuite/util/constant_vector4.osl
+++ b/documents/TestSuite/util/constant_vector4.osl
@@ -1,0 +1,12 @@
+#include "vector4.h"
+
+surface 
+constant_vector4
+    [[ string description = "Simple closure for constant color surface rendering" ]]
+(
+	vector4 Cin = {0.0, 0.0, 0.0, 0.0}
+        [[  string description = "Input color to modulate emission with" ]]
+)
+{
+	Ci = color(Cin.x, Cin.y, Cin.z) * emission(); 
+}

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -122,18 +122,6 @@ OslShaderGenerator::OslShaderGenerator()
     registerImplementation("IM_swizzle_vector4_vector2_sx_osl", Swizzle::create);
     registerImplementation("IM_swizzle_vector4_vector3_sx_osl", Swizzle::create);
     registerImplementation("IM_swizzle_vector4_vector4_sx_osl", Swizzle::create);
-
-
-    // Color2/4 and Vector2/4 must be remapped to Color3 and Vector3 when used
-    // as shader outputs since in OSL a custom struct type is not supported as 
-    // shader output.
-    _shaderOutputTypeRemap =
-    {
-        { Type::COLOR2,  { Type::COLOR3, "rg0" } },
-        { Type::COLOR4,  { Type::COLOR3, "rgb" } },
-        { Type::VECTOR2, { Type::COLOR3, "xy0" } },
-        { Type::VECTOR4, { Type::COLOR3, "xyz" } }
-    };
 }
 
 ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr element, const SgOptions& options)
@@ -193,11 +181,6 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
 
     // Emit shader output
     const TypeDesc* outputType = outputSocket->type;
-    auto it = _shaderOutputTypeRemap.find(outputType);
-    if (it != _shaderOutputTypeRemap.end())
-    {
-        outputType = it->second.first;
-    }
     const string type = _syntax->getOutputTypeName(outputType);
     const string value = _syntax->getDefaultValue(outputType, true);
     shader.addLine(type + " " + outputSocket->name + " = " + value, false);
@@ -272,13 +255,6 @@ void OslShaderGenerator::emitFinalOutput(Shader& shader) const
     }
 
     string finalResult = outputSocket->connection->name;
-
-    // Handle output type remapping
-    auto it = _shaderOutputTypeRemap.find(outputSocket->type);
-    if (it != _shaderOutputTypeRemap.end())
-    {
-        finalResult = _syntax->getSwizzledVariable(finalResult, outputSocket->type, it->second.second, it->second.first);
-    }
 
     shader.addLine(outputSocket->name + " = " + finalResult);
 }

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -38,8 +38,6 @@ protected:
 
     /// Emit include headers needed by the generated shader code.
     void emitIncludes(Shader& shader);
-
-    std::unordered_map<const TypeDesc*, std::pair<const TypeDesc*, string>> _shaderOutputTypeRemap;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -494,8 +494,9 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
             validator.validateCreation(shader);
 
             const std::string SURFACE_SHADER("surfaceshader");
+            const std::string elementType(element->getType());
             bool isShader = element->isA<mx::ShaderRef>() ||
-                element->getType() == SURFACE_SHADER;
+                elementType == SURFACE_SHADER;
 
             // TODO: testrender is the default, except for shaders
             // which do not have an appropriate scene setup currently.
@@ -519,7 +520,7 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
                 // to the actual name.
                 outputName = "out";
             }
-            validator.setOslShaderOutputName(outputName);
+            validator.setOslShaderOutputNameAndType(outputName, elementType);
 
             // Set scene template file. For now we only have the constant color scene file
             const std::string CONSTANT_COLOR_SCENE_XML_FILE("constant_color_scene.xml");

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
@@ -75,8 +75,10 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
         std::istreambuf_iterator<char>());
 
     StringMap replacementMap;
-    replacementMap["%shader%"] = shaderName;
-    replacementMap["%shader_output%"] = outputName;
+    replacementMap["%output_shader_name%"] = "constant_color"; // This needs to be type specific
+    replacementMap["%output_shader_input%"] = "Cin";
+    replacementMap["%input_shader_name%"] = shaderName;
+    replacementMap["%input_shader_output%"] = outputName;
     const string backgroundColor("0.5 0.6 0.7"); // TODO: Make this a user input
     replacementMap["%background_color%"] = backgroundColor;
     std::string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.cpp
@@ -46,11 +46,29 @@ void OslValidator::initialize()
 
 void OslValidator::renderOSL(const std::string& outputPath, const std::string& shaderName, const std::string& outputName)
 {
+    ShaderValidationErrorList errors;
+    const std::string errorType("OSL rendering error.");
+
     // If command options missing, skip testing.
     if (_oslTestRenderExecutable.empty() || _oslIncludePathString.empty() || 
         _oslTestRenderSceneTemplateFile.empty() || _oslUtilityOSOPath.empty())
     {
-        return;
+        errors.push_back("Command input arguments are missing");
+        throw ExceptionShaderValidationError(errorType, errors);
+    }
+
+    // If the output type is not which can be supported for rendering then skip testing.
+    bool requiresTypeMapping = (_oslShaderOutputType == getTypeString<Color2>() ||
+        _oslShaderOutputType == getTypeString<Color4>() ||
+        _oslShaderOutputType == getTypeString<Vector2>() ||
+        _oslShaderOutputType == getTypeString<Vector4>());
+    bool directlyConnectable = (_oslShaderOutputType == getTypeString<float>() ||
+        _oslShaderOutputType == getTypeString<Color3>() ||
+        _oslShaderOutputType == getTypeString<Vector3>());
+    if (!(requiresTypeMapping || directlyConnectable))
+    {
+        errors.push_back("Output type to render is not supported: " + _oslShaderOutputType);
+        throw ExceptionShaderValidationError(errorType, errors);
     }
 
     // Determine the shader path from output path and shader name
@@ -75,17 +93,20 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
         std::istreambuf_iterator<char>());
 
     StringMap replacementMap;
-    replacementMap["%output_shader_name%"] = "constant_color"; // This needs to be type specific
+    std::string outputShader("constant_color");
+    if (requiresTypeMapping)
+    {
+        outputShader = "constant_" + _oslShaderOutputType;
+    }
+    replacementMap["%output_shader_type%"] = outputShader; 
     replacementMap["%output_shader_input%"] = "Cin";
-    replacementMap["%input_shader_name%"] = shaderName;
+    replacementMap["%input_shader_type%"] = shaderName;
     replacementMap["%input_shader_output%"] = outputName;
     const string backgroundColor("0.5 0.6 0.7"); // TODO: Make this a user input
     replacementMap["%background_color%"] = backgroundColor;
     std::string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);
     if ((sceneString == sceneTemplateString) || sceneTemplateString.empty())
     {
-        const std::string errorType("OSL rendering error.");
-        ShaderValidationErrorList errors;
         errors.push_back("Scene template file: " + _oslTestRenderSceneTemplateFile + 
                          "does not include proper tokens for rendering");
         throw ExceptionShaderValidationError(errorType, errors);
@@ -122,8 +143,6 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
 
     if (!result.empty())
     {
-        const std::string errorType("OSL rendering error.");
-        ShaderValidationErrorList errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
         errors.push_back("Shader failed to render:");

--- a/source/MaterialXView/ShaderValidators/Osl/OslValidator.h
+++ b/source/MaterialXView/ShaderValidators/Osl/OslValidator.h
@@ -121,9 +121,11 @@ class OslValidator : public ShaderValidator
     /// For testrender this value is used to replace the %shader_output% token in the
     /// input scene file.
     /// @param outputName Name of shader output
-    void setOslShaderOutputName(const std::string outputName)
+    /// @param outputName The MaterialX type of the output
+    void setOslShaderOutputNameAndType(const std::string outputName, const std::string outputType)
     {
         _oslShaderOutputName = outputName;
+        _oslShaderOutputType = outputType;
     }
 
     /// Set the OSL shading tester path string. Note that it is assumed that this
@@ -217,8 +219,10 @@ class OslValidator : public ShaderValidator
     std::string _oslTestRenderSceneTemplateFile;
     /// Name of shader. Used for rendering with "testrender"
     std::string _oslShaderName;
-    /// Name of output on shader. Used for rendering with "testshade" and "testrender"
+    /// Name of output on the shader. Used for rendering with "testshade" and "testrender"
     std::string _oslShaderOutputName;
+    /// MaterialX type of the output on the shader. Used for rendering with "testshade" and "testrender"
+    std::string _oslShaderOutputType;
     /// Path for utility shaders (.oso) used when rendering with "testrender"
     std::string _oslUtilityOSOPath;
     /// Use "testshade" or "testender" for render validation


### PR DESCRIPTION
As OSL now supports structured outputs (color2, color4, vec2, vec4), we can remove the requirement to remap the output from shader generation to color3.
- For testrender setup, we have 4 new emission surface shaders which can be used instead of color3 when setting up the shading graph for rendering. color3 and vector3 use the existing color3 emission surface shader.