### PR TITLE
Fix bsdf unit test

### DIFF
--- a/documents/TestSuite/sxpbrlib/bsdf/bsdf_graph.mtlx
+++ b/documents/TestSuite/sxpbrlib/bsdf/bsdf_graph.mtlx
@@ -6,9 +6,9 @@
   -->
   <nodedef name="ND_mybsdf" node="mybsdf" type="BSDF">
     <input name="diffuse" type="float" />
-    <input name="diffuseColor" type="color3" />
-    <input name="transmission" type="float" />
-    <input name="transmissionColor" type="color3" />
+    <input name="diffuseColor" type="color3" value="0.0, 1.0, 0.0"/>
+    <input name="transmission" type="float" value="0.5"/>
+    <input name="transmissionColor" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodegraph name="IMP_mybsdf" nodedef="ND_mybsdf">
     <dielectricbtdf name="dielectricbtdf1" type="BSDF">

--- a/documents/TestSuite/sxpbrlib/bsdf/transmission.mtlx
+++ b/documents/TestSuite/sxpbrlib/bsdf/transmission.mtlx
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <materialx version="1.36">
   <nodedef name="ND_mysurface" type="surfaceshader" node="mysurface">
-    <input name="diffuse" type="float" />
-    <input name="diffuseColor" type="color3" />
-    <input name="transmission" type="float" />
-    <input name="transmissionColor" type="color3" />
+    <input name="diffuse" type="float" value="1.0"/>
+    <input name="diffuseColor" type="color3" value="0.8, 0.8, 0.8"/>
+    <input name="transmission" type="float" value="0.6"/>
+    <input name="transmissionColor" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodegraph name="IMP_mysurface" nodedef="ND_mysurface">
     <output name="out" type="surfaceshader" nodename="surface3" />

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalGlsl.cpp
@@ -34,7 +34,7 @@ namespace MaterialX
             "   float nx = S[0] - S[2] + (2.0*S[3]) - (2.0*S[5]) + S[6] - S[8];\n"
             "   float ny = S[0] + (2.0*S[1]) + S[2] - S[6] - (2.0*S[7]) - S[8];\n"
             "   float nz = _scale * sqrt(1.0 - nx*nx - ny*ny);\n"
-            "   return vec3(nx, ny, nz);\n"
+            "   return normalize(vec3(nx, ny, nz));\n"
             "}\n\n";
 
         shader.addBlock(SOBEL_FILTER_SOURCE, shadergen);


### PR DESCRIPTION
 As node values are published via interfacename we require the nodedef to have default values otherwise everything renders black (using 0 as default values).
