### PR TITLE
Add in additional traversal for nodegraph nodedefs for transparency util

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalGlsl.cpp
@@ -34,7 +34,7 @@ namespace MaterialX
             "   float nx = S[0] - S[2] + (2.0*S[3]) - (2.0*S[5]) + S[6] - S[8];\n"
             "   float ny = S[0] + (2.0*S[1]) + S[2] - S[6] - (2.0*S[7]) - S[8];\n"
             "   float nz = _scale * sqrt(1.0 - nx*nx - ny*ny);\n"
-            "   return vec3(nx, ny, nz);\n"
+            "   return normalize(vec3(nx, ny, nz));\n"
             "}\n\n";
 
         shader.addBlock(SOBEL_FILTER_SOURCE, shadergen);

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -176,7 +176,7 @@ namespace
         return isOne(c[0]) && isOne(c[1]) && isOne(c[0]);
     }
 
-    bool isTransparentShaderGraph(OutputPtr output)
+    bool isTransparentShaderGraph(OutputPtr output, const ShaderGenerator& shadergen)
     {
         // Track how many nodes has the potential of being transparent
         // and how many of these we can say for sure are 100% opaque.
@@ -313,6 +313,29 @@ namespace
                         ++numOpaque;
                     }
                 }
+                else
+                {
+                    NodeDefPtr nodeDef = node->getNodeDef();
+                    const string& typeName2 = nodeDef->getType();
+                    const TypeDesc* type2 = TypeDesc::get(typeName2);
+                    if (type2 == Type::BSDF)
+                    {
+                        InterfaceElementPtr impl = nodeDef->getImplementation(shadergen.getTarget(), shadergen.getLanguage());
+                        if (impl && impl->isA<NodeGraph>())
+                        {
+                            NodeGraphPtr graph = impl->asA<NodeGraph>();
+
+                            vector<OutputPtr> outputs = graph->getActiveOutputs();
+                            if (outputs.size() > 0)
+                            {
+                                const OutputPtr& output2 = outputs[0];
+                                bool isTransparent = isTransparentShaderGraph(output2, shadergen);
+                                if (isTransparent)
+                                    return true;
+                            }
+                        }
+                    }
+                }
 
                 if (numOpaque != numCandidates)
                 {
@@ -403,7 +426,7 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
                     const OutputPtr& output = outputs[0];
                     if (TypeDesc::get(output->getType()) == Type::SURFACESHADER)
                     {
-                        return isTransparentShaderGraph(output);
+                        return isTransparentShaderGraph(output, shadergen);
                     }
                 }
             }
@@ -412,7 +435,7 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
     else if (element->isA<Output>())
     {
         OutputPtr output = element->asA<Output>();
-        return isTransparentShaderGraph(output);
+        return isTransparentShaderGraph(output, shadergen);
     }
 
     return false;


### PR DESCRIPTION
If a BSDF nodedef is being used then allow to check the nodegraph implementation
for transparency in the utility.
