### PR TITLE
Fix constant block output for OGSFX

### DIFF
--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
@@ -215,7 +215,7 @@ ShaderPtr OgsFxShaderGenerator::generate(const string& shaderName, ElementPtr el
     if (!psConstants.empty())
     {
         shader.addComment("Constant block: " + psConstants.name);
-        emitVariableBlock(psConstants, _syntax->getUniformQualifier(), shader);
+        emitVariableBlock(psConstants, _syntax->getConstantQualifier(), shader);
     }
 
     // Add main function


### PR DESCRIPTION
- Was outputting with a uniform qualifier vs a const qualifier for pixel stage constant block.
