### PR TITLE
Spec conformance update: Remove check for vdirection based on Document

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -442,8 +442,8 @@ void GlslShaderGenerator::emitFunctionDefinitions(Shader& shader)
     BEGIN_SHADER_STAGE(shader, HwShader::PIXEL_STAGE)
 
         // Emit function for handling texture coords v-flip 
-        // as needed by the v-direction set by the user
-        shader.addBlock(shader.getRequestedVDirection() != getTargetVDirection() ? VDIRECTION_FLIP : VDIRECTION_NOOP, *this);
+        // as needed relative to the default v-direction 
+        shader.addBlock(Shader::getDefaultVDirection() != getTargetVDirection() ? VDIRECTION_FLIP : VDIRECTION_NOOP, *this);
 
         // For surface shaders we need light shaders
         if (shader.hasClassification(ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE))

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -256,8 +256,8 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
 void OslShaderGenerator::emitFunctionDefinitions(Shader& shader)
 {
     // Emit function for handling texture coords v-flip
-    // as needed by the v-direction set by the user
-    shader.addBlock(shader.getRequestedVDirection() != getTargetVDirection() ? VDIRECTION_FLIP : VDIRECTION_NOOP, *this);
+    // as needed relative to the default v-direction 
+    shader.addBlock(Shader::getDefaultVDirection() != getTargetVDirection() ? VDIRECTION_FLIP : VDIRECTION_NOOP, *this);
 
     // Call parent to emit all other functions
     ParentClass::emitFunctionDefinitions(shader);

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -36,11 +36,6 @@ void Shader::initialize(ElementPtr element, ShaderGenerator& shadergen, const Ge
     // Make it active
     pushActiveGraph(_rootGraph.get());
 
-    // Set the vdirection to use for texture nodes
-    // Default is to use direction UP
-    const string& vdir = element->getRoot()->getAttribute("vdirection");
-    _vdirection = vdir == "down" ? VDirection::DOWN : VDirection::UP;
-
     // Create shader variables for all nodes that need this (geometric nodes / input streams)
     for (ShaderNode* node : _rootGraph->getNodes())
     {

--- a/source/MaterialXGenShader/Shader.h
+++ b/source/MaterialXGenShader/Shader.h
@@ -224,8 +224,8 @@ public:
     /// Return true if this shader matches the given classification.
     bool hasClassification(unsigned int c) const { return getGraph()->hasClassification(c); }
 
-    /// Return the vdirection requested in the current document.
-    VDirection getRequestedVDirection() const { return _vdirection; }
+    /// Return the default vdirection which is up.
+    static VDirection getDefaultVDirection() { return VDirection::UP; }
 
     /// Return the final shader source code for a given shader stage
     const string& getSourceCode(size_t stage = PIXEL_STAGE) const { return _stages[stage].code; }


### PR DESCRIPTION
Remove logic to check document for vdirection as it is fixed as being UP based on the current specification. Leave the variable there in case there are any figure changes.
