### PR TITLE
Add interface to allow node implementations to filter inputs to publish as uniforms

### DIFF
--- a/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
@@ -5,6 +5,9 @@
 namespace MaterialX
 {
 
+static string IN_STRING("in");
+static string CHANNELS_STRING("channels");
+
 ShaderNodeImplPtr SwizzleNode::create()
 {
     return std::make_shared<SwizzleNode>();
@@ -14,8 +17,8 @@ void SwizzleNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
 {
     BEGIN_SHADER_STAGE(shader, HwShader::PIXEL_STAGE)
 
-    const ShaderInput* in = node.getInput("in");
-    const ShaderInput* channels = node.getInput("channels");
+    const ShaderInput* in = node.getInput(IN_STRING);
+    const ShaderInput* channels = node.getInput(CHANNELS_STRING);
     if (!in || !channels)
     {
         throw ExceptionShaderGenError("Node '" + node.getName() +"' is not a valid swizzle node");
@@ -60,6 +63,11 @@ void SwizzleNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
     shader.endLine();
 
     END_SHADER_STAGE(shader, HwShader::PIXEL_STAGE)
+}
+
+bool SwizzleNode::isEditable(const ShaderInput& input) const
+{
+    return (input.name != CHANNELS_STRING);
 }
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/Nodes/SwizzleNode.h
+++ b/source/MaterialXGenShader/Nodes/SwizzleNode.h
@@ -9,10 +9,15 @@ namespace MaterialX
 /// Implementation of swizzle node
 class SwizzleNode : public ShaderNodeImpl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderGenerator& shadergen, Shader& shader) override;
+
+    /// Returns true if the type is editable by users.
+    /// Editable inputs are allowed to be published as shader uniforms
+    /// and hence must be presentable in a user interface.
+    bool isEditable(const ShaderInput& input) const override;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -49,8 +49,11 @@ void Shader::initialize(ElementPtr element, ShaderGenerator& shadergen, const Ge
         // Only for inputs that are connected/used internally
         if (inputSocket->connections.size())
         {
-            // Create the uniform
-            createUniform(PIXEL_STAGE, PUBLIC_UNIFORMS, inputSocket->type, inputSocket->name, EMPTY_STRING, inputSocket->value);
+            if (_rootGraph->isEditable(*inputSocket))
+            {
+                // Create the uniform
+                createUniform(PIXEL_STAGE, PUBLIC_UNIFORMS, inputSocket->type, inputSocket->name, EMPTY_STRING, inputSocket->value);
+            }
         }
     }
     
@@ -66,7 +69,7 @@ void Shader::initialize(ElementPtr element, ShaderGenerator& shadergen, const Ge
                 {
                     // Check if the type is editable otherwise we can't 
                     // publish the input as an editable uniform.
-                    if (input->type->isEditable())
+                    if (input->type->isEditable() && node->isEditable(*input))
                     {
                         // Use a consistent naming convention: <nodename>_<inputname>
                         // so application side can figure out what uniforms to set

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -213,6 +213,22 @@ class ShaderNode
         return _samplingInput;
     }
 
+    /// Returns true if an input is editable by users.
+    /// Editable inputs are allowed to be published as shader uniforms
+    /// and hence must be presentable in a user interface.
+    bool isEditable(const ShaderInput& input) const
+    {
+        return (!_impl || _impl->isEditable(input));
+    }
+
+    /// Returns true if a graph input is accessible by users.
+    /// Editable inputs are allowed to be published as shader uniforms
+    /// and hence must be presentable in a user interface.
+    bool isEditable(const ShaderGraphInputSocket& input) const
+    {
+        return (!_impl || _impl->isEditable(input));
+    }
+
     /// Add the given contex id to the set of contexts used for this node.
     void addContextID(int id) { _contextIDs.insert(id); }
 

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -12,6 +12,9 @@ class ShaderGenerator;
 class ShaderNode;
 class ShaderGraph;
 class GenContext;
+class ShaderInput;
+class ShaderOutput;
+using ShaderGraphInputSocket = ShaderOutput;
 
 using ShaderNodeImplPtr = shared_ptr<class ShaderNodeImpl>;
 
@@ -51,6 +54,24 @@ class ShaderNodeImpl
     /// Return a pointer to the graph if this implementation is using a graph,
     /// or returns nullptr otherwise.
     virtual ShaderGraph* getGraph() const;
+
+    /// Returns true if an input is editable by users.
+    /// Editable inputs are allowed to be published as shader uniforms
+    /// and hence must be presentable in a user interface.
+    /// By default all inputs are considered to be editable.
+    virtual bool isEditable(const ShaderInput& /*input*/) const
+    {
+        return true;
+    }
+
+    /// Returns true if a graph input is accessible by users.
+    /// Accessible inputs are allowed to be published as shader uniforms
+    /// and hence must be presentable in a user interface.
+    /// By default all graph inputs are considered to be acessible.
+    virtual bool isEditable(const ShaderGraphInputSocket& /*input*/) const
+    {
+        return true;
+    }
 
   protected:
     /// Protected constructor


### PR DESCRIPTION
Add in filtering for publishing inputs per node implementation.
For now only swizzle overrides this to exclude the swizzle string.