### PR TITLE
Add in data-driven unit test validation options 

### DIFF
--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Test suite options file. A file with this format can be placed in any folder within the TestSuite area and will
-    set the options for all testing of files at that level as well as sub-folders, unless there is a file in the sub-folder
-    which super-cedes the parent
+    Test suite options file. 
 -->
 <materialx version="1.36">
     <nodedef name="ShaderValidOptions">

--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+    <nodedef name="ShaderValidOptions">
+        <!-- Add files names here to filter to only test documents with these file names -->
+        <parameter name="overrideFiles" type="stromg" value="" />
+        <parameter name="dumpGlslFiles" type="boolean" value="false" />
+    </nodedef>
+</materialx>

--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -1,27 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Test suite options file. 
+    Test suite options file which is parsed when the "shadervalid" category units tests are executed.
 -->
 <materialx version="1.36">
-    <nodedef name="ShaderValidOptions">
+    <nodedef name="ShaderValidTestOptions">
+
         <!-- List of comma separated file names acts as a filter to only test documents with these names -->
         <parameter name="overrideFiles" type="string" value="" />
+
         <!-- Set to false to disable execution of OSL tests. Default is true. -->
         <parameter name="runOSLTests" type="boolean" value="true" />
+
         <!-- Set to false to disable execution of GLSL tests. Default is true. -->
         <parameter name="runGLSLTests" type="boolean" value="true" />
-        <!-- Run using a given set of shader interface generation options. Default value is 2 where: 
-            - 3 = run complete + reduced. 
-            - 2 = run complete only. 
-            - 1 = run reduced only. 
+
+        <!-- Run using a given set of shader interface generation options. Default value is 2 where:
+            - 3 = run complete + reduced.
+            - 2 = run complete only.
+            - 1 = run reduced only.
         -->
         <parameter name="shaderInterfaces" type="integer" value="2" />
+
         <!-- Set this to be true if it is desired to always dump out GLSL source files to disk instead of just on compile errors -->
         <parameter name="dumpGlslFiles" type="boolean" value="false" />
+
         <!-- Geometry file to use for rendering non-shader elements in GLSL.
         A relative path specifier is relative to the folder "/documents/TestSuite/Geometry/" -->
-        <parameter name="glslNonShaderGeom" type="string" value="/sphere.obj" />
+        <parameter name="glslNonShaderGeometry" type="string" value="sphere.obj" />
+
         <!-- Geometry file to use for rendering shader elements in GLSL -->
-        <parameter name="glslShaderGeom" type="string" value="/shaderball.obj" />
+        <parameter name="glslShaderGeometry" type="string" value="shaderball.obj" />
+
     </nodedef>
 </materialx>

--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -1,8 +1,29 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Test suite options file. A file with this format can be placed in any folder within the TestSuite area and will
+    set the options for all testing of files at that level as well as sub-folders, unless there is a file in the sub-folder
+    which super-cedes the parent
+-->
 <materialx version="1.36">
     <nodedef name="ShaderValidOptions">
-        <!-- Add files names here to filter to only test documents with these file names -->
-        <parameter name="overrideFiles" type="stromg" value="" />
+        <!-- List of comma separated file names acts as a filter to only test documents with these names -->
+        <parameter name="overrideFiles" type="string" value="wood.mtlx" />
+        <!-- Set to false to disable execution of OSL tests. Default is true. -->
+        <parameter name="runOSLTests" type="boolean" value="true" />
+        <!-- Set to false to disable execution of GLSL tests. Default is true. -->
+        <parameter name="runGLSLTests" type="boolean" value="true" />
+        <!-- Run using a given set of shader interface generation options. Default value is 2 where: 
+            - 3 = run complete + reduced. 
+            - 2 = run complete only. 
+            - 1 = run reduced only. 
+        -->
+        <parameter name="shaderInterfaces" type="integer" value="2" />
+        <!-- Set this to be true if it is desired to always dump out GLSL source files to disk instead of just on compile errors -->
         <parameter name="dumpGlslFiles" type="boolean" value="false" />
+        <!-- Geometry file to use for rendering non-shader elements in GLSL.
+        A relative path specifier is relative to the folder "/documents/TestSuite/Geometry/" -->
+        <parameter name="glslNonShaderGeom" type="string" value="/sphere.obj" />
+        <!-- Geometry file to use for rendering shader elements in GLSL -->
+        <parameter name="glslShaderGeom" type="string" value="/shaderball.obj" />
     </nodedef>
 </materialx>

--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -7,7 +7,7 @@
 <materialx version="1.36">
     <nodedef name="ShaderValidOptions">
         <!-- List of comma separated file names acts as a filter to only test documents with these names -->
-        <parameter name="overrideFiles" type="string" value="wood.mtlx" />
+        <parameter name="overrideFiles" type="string" value="" />
         <!-- Set to false to disable execution of OSL tests. Default is true. -->
         <parameter name="runOSLTests" type="boolean" value="true" />
         <!-- Set to false to disable execution of GLSL tests. Default is true. -->

--- a/source/MaterialXTest/ShaderGen.cpp
+++ b/source/MaterialXTest/ShaderGen.cpp
@@ -658,6 +658,10 @@ TEST_CASE("ShaderX Implementation Validity", "[shadergen]")
                 {
                     msg += ", target: " + targetName;
                 }
+                else
+                {
+                    msg += ", target: NONE ";
+                }
                 mx::NodeDefPtr nodedef = impl->getNodeDef();
                 if (!nodedef)
                 {
@@ -764,7 +768,7 @@ TEST_CASE("ShaderX Implementation Validity", "[shadergen]")
                         else
                         {
                             found_str += "Found impl and src for nodedef: " + nodeDefName + ", Node: "
-                                + nodeName + +". Impl: " + impl->getName() + ".\n";
+                                + nodeName + +". Impl: " + impl->getName() + "Path: " + resolvedPath.asString() + ".\n";
                         }
                     }
                 }

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -502,7 +502,7 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
                     }
                     else
                     {
-                        geomPath = mx::FilePath::getCurrentPath().asString() + "/documents/TestSuite/Geometry/shaderball.obj";
+                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry/shaderball.obj");
                     }
                     geomHandler->setIdentifier(geomPath);
                     validator.setLightHandler(lightHandler);
@@ -523,7 +523,7 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
                     }
                     else
                     {
-                        geomPath = mx::FilePath::getCurrentPath().asString() + "/documents/TestSuite/Geometry/sphere.obj";
+                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry/sphere.obj");
                     }
                     geomHandler->setIdentifier(geomPath);
                     validator.setLightHandler(nullptr);

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -703,7 +703,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
     try {
         MaterialX::readFromXmlFile(doc, optionFile);
 
-        MaterialX::NodeDefPtr optionDefs = doc->getNodeDef("ShaderValidOptions");
+        MaterialX::NodeDefPtr optionDefs = doc->getNodeDef("ShaderValidTestOptions");
         if (optionDefs)
         {
             for (MaterialX::ParameterPtr p : optionDefs->getParameters())

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -77,7 +77,7 @@ TEST_CASE("GLSL Source", "[shadervalid]")
         validator->initialize();
         validator->setImageHandler(handler);
         // Set geometry to draw with
-        const std::string geometryFile(mx::FilePath::getCurrentPath().asString() + "/documents/TestSuite/Geometry/sphere.obj");
+        const std::string geometryFile(mx::FilePath::getCurrentPath().asString() + "documents/TestSuite/Geometry/sphere.obj");
         mx::GeometryHandlerPtr geometryHandler = validator->getGeometryHandler();
         geometryHandler->setIdentifier(geometryFile);
         if (geometryHandler->getIdentifier() == geometryFile)
@@ -289,7 +289,7 @@ static mx::GlslValidatorPtr createGLSLValidator(bool& orthographicView, const st
         std::string geometryFile;
         if (fileName.length())
         {
-            geometryFile =  mx::FilePath::getCurrentPath().asString() + "/documents/TestSuite/Geometry/" + fileName;
+            geometryFile =  mx::FilePath::getCurrentPath().asString() + "documents/TestSuite/Geometry/" + fileName;
             geometryHandler->setIdentifier(geometryFile);
         }
         if (geometryHandler->getIdentifier() == geometryFile)
@@ -374,31 +374,36 @@ static mx::OslValidatorPtr createOSLValidator(bool& orthographicView, std::ostre
 //
 // Shader validation options structure
 //
-class ShaderValid_TestOptions
+class ShaderValidTestOptions
 {
 public:
     // Filter list of files to only run validation on.
     MaterialX::StringVec overrideFiles;
+
     // Set to true to always dump glsl generated files to disk
     bool dumpGlslFiles = false;
+
     // Execute GLSL tests
     bool runGLSLTests = true;
+
     // Execute OSL tests
     bool runOSLTests = true;
+
     // Run using a set of interfaces:
     // - 3 = run complete + reduced.
     // - 2 = run complete only (default)
     // - 1 = run reduced only.
     int shaderInterfaces = 2;
+
     // Non-shader GLSL geometry file
-    MaterialX::FilePath glslNonShaderGeom = "/sphere.obj";
+    MaterialX::FilePath glslNonShaderGeometry = "sphere.obj";
+
     // Shader GLSL geometry file
-    MaterialX::FilePath glslShaderGeom = "/shaderball.obj";
-    // Add more options as desired...
+    MaterialX::FilePath glslShaderGeometry = "shaderball.obj";
 };
 
 // Create a list of generation options based on unit test options
-void getGenerationOptions(std::vector<mx::GenOptions>& optionsList, const ShaderValid_TestOptions& testOptions)
+void getGenerationOptions(const ShaderValidTestOptions& testOptions, std::vector<mx::GenOptions>& optionsList)
 {
     optionsList.clear();
     if (testOptions.shaderInterfaces & 1)
@@ -430,10 +435,10 @@ void getGenerationOptions(std::vector<mx::GenOptions>& optionsList, const Shader
 //
 static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr element, mx::GlslValidator& validator,
                               mx::GlslShaderGenerator& shaderGenerator, const mx::HwLightHandlerPtr lightHandler, mx::DocumentPtr doc,
-                              std::ostream& log, ShaderValid_TestOptions testOptions, bool outputMtlxDoc=true, const std::string& outputPath=".")
+                              std::ostream& log, const ShaderValidTestOptions& testOptions, const std::string& outputPath=".")
 {
     std::vector<mx::GenOptions> optionsList;
-    getGenerationOptions(optionsList, testOptions);
+    getGenerationOptions(testOptions, optionsList);
 
     if(element && doc)
     {
@@ -446,7 +451,7 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
             // Use separate directory for reduced output
             if (options.shaderInterfaceType == mx::SHADER_INTERFACE_REDUCED)
             {
-                outputFilePath = outputFilePath / mx::FilePath("/reduced");
+                outputFilePath = outputFilePath / mx::FilePath("reduced");
             }
 
             // Note: mkdir will fail if the directory already exists which is ok.
@@ -473,11 +478,6 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
             CHECK(shader->getSourceCode(mx::HwShader::PIXEL_STAGE).length() > 0);
             CHECK(shader->getSourceCode(mx::HwShader::VERTEX_STAGE).length() > 0);
 
-            if (outputMtlxDoc)
-            {
-                mx::writeToXmlFile(doc, shaderPath + ".mtlx");
-            }
-
             // Validate
             MaterialX::GlslProgramPtr program = validator.program();
             bool validated = false;
@@ -489,20 +489,20 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
                 if (isShader)
                 {
                     mx::FilePath geomPath;
-                    if (!testOptions.glslShaderGeom.isEmpty())
+                    if (!testOptions.glslShaderGeometry.isEmpty())
                     {
-                        if (!testOptions.glslShaderGeom.isAbsolute())
+                        if (!testOptions.glslShaderGeometry.isAbsolute())
                         {
-                            geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry") / testOptions.glslShaderGeom;
+                            geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry") / testOptions.glslShaderGeometry;
                         }
                         else
                         {
-                            geomPath = testOptions.glslShaderGeom;
+                            geomPath = testOptions.glslShaderGeometry;
                         }
                     }
                     else
                     {
-                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry/shaderball.obj");
+                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry/shaderball.obj");
                     }
                     geomHandler->setIdentifier(geomPath);
                     validator.setLightHandler(lightHandler);
@@ -510,20 +510,20 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
                 else
                 {
                     mx::FilePath geomPath;
-                    if (!testOptions.glslNonShaderGeom.isEmpty())
+                    if (!testOptions.glslNonShaderGeometry.isEmpty())
                     {
-                        if (!testOptions.glslNonShaderGeom.isAbsolute())
+                        if (!testOptions.glslNonShaderGeometry.isAbsolute())
                         {
-                            geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry") / testOptions.glslNonShaderGeom;
+                            geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry") / testOptions.glslNonShaderGeometry;
                         }
                         else
                         {
-                            geomPath = testOptions.glslNonShaderGeom;
+                            geomPath = testOptions.glslNonShaderGeometry;
                         }
                     }
                     else
                     {
-                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("/documents/TestSuite/Geometry/sphere.obj");
+                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry/sphere.obj");
                     }
                     geomHandler->setIdentifier(geomPath);
                     validator.setLightHandler(nullptr);
@@ -580,10 +580,10 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
 #ifdef MATERIALX_BUILD_GEN_OSL
 static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr element, mx::OslValidator& validator,
                              mx::ArnoldShaderGenerator& shaderGenerator, mx::DocumentPtr doc, std::ostream& log,
-                            ShaderValid_TestOptions testOptions, bool outputMtlxDoc=true, const std::string& outputPath=".")
+                             const ShaderValidTestOptions& testOptions, const std::string& outputPath=".")
 {
     std::vector<mx::GenOptions> optionsList;
-    getGenerationOptions(optionsList, testOptions);
+    getGenerationOptions(testOptions, optionsList);
 
     if(element && doc)
     {
@@ -614,17 +614,12 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
             // Use separate directory for reduced output
             if (options.shaderInterfaceType == mx::SHADER_INTERFACE_REDUCED)
             {
-                outputFilePath = outputFilePath / mx::FilePath("/reduced");
+                outputFilePath = outputFilePath / mx::FilePath("reduced");
             }
 
             // Note: mkdir will fail if the directory already exists which is ok.
             mx::makeDirectory(outputFilePath);
             shaderPath = mx::FilePath(outputFilePath) / mx::FilePath(shaderName);
-
-            if (outputMtlxDoc)
-            {
-                mx::writeToXmlFile(doc, shaderPath + ".mtlx");
-            }
 
             // Write out osl file
             std::ofstream file;
@@ -699,7 +694,7 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
 }
 #endif
 
-bool getTestOptions(const std::string& optionFile, ShaderValid_TestOptions& options)
+bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& options)
 {
     options.overrideFiles.clear();
     options.dumpGlslFiles = false;
@@ -737,13 +732,13 @@ bool getTestOptions(const std::string& optionFile, ShaderValid_TestOptions& opti
                     {
                         options.dumpGlslFiles = val->asA<bool>();
                     }
-                    else if (name == "glslNonShaderGeom")
+                    else if (name == "glslNonShaderGeometry")
                     {
-                        options.glslNonShaderGeom = p->getValueString();
+                        options.glslNonShaderGeometry = p->getValueString();
                     }
-                    else if (name == "glslShaderGeom")
+                    else if (name == "glslShaderGeometry")
                     {
-                        options.glslShaderGeom = p->getValueString();
+                        options.glslShaderGeometry = p->getValueString();
                     }
                 }
             }
@@ -843,7 +838,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
     const std::string MTLX_EXTENSION("mtlx");
 
     // Check for an option file
-    ShaderValid_TestOptions options;
+    ShaderValidTestOptions options;
     const mx::FilePath optionsPath = path / mx::FilePath("_options.mtlx");
     // Append to file filter list
     if (getTestOptions(optionsPath, options))
@@ -918,13 +913,13 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
 #ifdef MATERIALX_BUILD_GEN_GLSL
                     if (options.runGLSLTests && nodeDef->getImplementation(glslShaderGenerator->getTarget(), glslShaderGenerator->getLanguage()))
                     {
-                        runGLSLValidation(elementName, element, *glslValidator, *glslShaderGenerator, lightHandler, doc, glslLog, options, false, outputPath);
+                        runGLSLValidation(elementName, element, *glslValidator, *glslShaderGenerator, lightHandler, doc, glslLog, options, outputPath);
                     }
 #endif
 #ifdef MATERIALX_BUILD_GEN_OSL
                     if (options.runOSLTests && nodeDef->getImplementation(oslShaderGenerator->getTarget(), oslShaderGenerator->getLanguage()))
                     {
-                        runOSLValidation(elementName, element, *oslValidator, *oslShaderGenerator, doc, oslLog, options, false, outputPath);
+                        runOSLValidation(elementName, element, *oslValidator, *oslShaderGenerator, doc, oslLog, options, outputPath);
                     }
 #endif
                 }

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -77,7 +77,7 @@ TEST_CASE("GLSL Source", "[shadervalid]")
         validator->initialize();
         validator->setImageHandler(handler);
         // Set geometry to draw with
-        const std::string geometryFile(mx::FilePath::getCurrentPath().asString() + "documents/TestSuite/Geometry/sphere.obj");
+        const std::string geometryFile(mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry/sphere.obj"));
         mx::GeometryHandlerPtr geometryHandler = validator->getGeometryHandler();
         geometryHandler->setIdentifier(geometryFile);
         if (geometryHandler->getIdentifier() == geometryFile)
@@ -289,7 +289,7 @@ static mx::GlslValidatorPtr createGLSLValidator(bool& orthographicView, const st
         std::string geometryFile;
         if (fileName.length())
         {
-            geometryFile =  mx::FilePath::getCurrentPath().asString() + "documents/TestSuite/Geometry/" + fileName;
+            geometryFile =  mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite/Geometry/") / mx::FilePath(fileName);
             geometryHandler->setIdentifier(geometryFile);
         }
         if (geometryHandler->getIdentifier() == geometryFile)


### PR DESCRIPTION
- Options are specified in a mtlx file (_options.mtlx). It can reside at the top level of TestSuite but
subfolders can also contain this file to replace the parent folder options. 
