### PR TITLE
Renames inserted color input transform variables to have the same nam…

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -257,9 +257,11 @@ void ShaderGraph::addColorTransformNode(ShaderInput* input, const ColorSpaceTran
         ShaderNode* colorTransformNode = colorTransformNodePtr.get();
         ShaderOutput* colorTransformNodeOutput = colorTransformNode->getOutput(0);
 
-        // TODO: For now copy the value of the input to the transform node. In the future we don't want to do things
-        // this way. Instead we want to set the color transform uniform to be equal to the input uniform.
-        colorTransformNode->getInput(0)->value = input->value;
+        ShaderInput* shaderInput = colorTransformNode->getInput(0);
+        shaderInput->variable = input->node->getName() + "_" + input->name;
+        shaderInput->value = input->value;
+        shaderInput->noRename = true;
+        _renameTransformMap[shaderInput->variable + "_cm_" + shaderInput->name] = shaderInput->variable;
 
         input->makeConnection(colorTransformNodeOutput);
     }
@@ -564,11 +566,11 @@ ShaderNode* ShaderGraph::addNode(const Node& node, ShaderGenerator& shadergen, c
     {
         for (InputPtr input : node.getInputs())
         {
-            populateInputColorTransformMap(colorManagementSystem, node, newNode, input, targetColorSpace);
+            populateInputColorTransformMap(colorManagementSystem, newNode, input, targetColorSpace);
         }
         for (ParameterPtr parameter : node.getParameters())
         {
-            populateInputColorTransformMap(colorManagementSystem, node, newNode, parameter, targetColorSpace);
+            populateInputColorTransformMap(colorManagementSystem, newNode, parameter, targetColorSpace);
         }
 
         // Check if this is a file texture node that requires color transformation.
@@ -668,6 +670,11 @@ void ShaderGraph::finalize(ShaderGenerator& shadergen, const GenOptions& options
                         {
                             inputSocket = addInputSocket(interfaceName, input->type);
                             inputSocket->value = input->value;
+                            if (_renameTransformMap.find(inputSocket->name) != _renameTransformMap.end())
+                            {
+                                inputSocket->variable = _renameTransformMap[inputSocket->name];
+                                inputSocket->noRename = true;
+                            }
                         }
                         inputSocket->makeConnection(input);
                     }
@@ -981,7 +988,10 @@ void ShaderGraph::setVariableNames(ShaderGenerator& shadergen)
     Syntax::UniqueNameMap uniqueNames;
     for (ShaderGraphInputSocket* inputSocket : getInputSockets())
     {
-        inputSocket->variable = inputSocket->name;
+        if (!inputSocket->noRename)
+        {
+            inputSocket->variable = inputSocket->name;
+        }
         shadergen.getSyntax()->makeUnique(inputSocket->variable, uniqueNames);
     }
     for (ShaderGraphOutputSocket* outputSocket : getOutputSockets())
@@ -994,7 +1004,10 @@ void ShaderGraph::setVariableNames(ShaderGenerator& shadergen)
         for (ShaderInput* input : node->getInputs())
         {
             // Node outputs use long names for better code readability
-            input->variable = input->node->getName() + "_" + input->name;
+            if (!input->noRename)
+            {
+                input->variable = input->node->getName() + "_" + input->name;
+            }
             shadergen.getSyntax()->makeUnique(input->variable, uniqueNames);
         }
         for (ShaderOutput* output : node->getOutputs())
@@ -1006,7 +1019,7 @@ void ShaderGraph::setVariableNames(ShaderGenerator& shadergen)
     }
 }
 
-void ShaderGraph::populateInputColorTransformMap(ColorManagementSystemPtr colorManagementSystem, const Node& node, ShaderNodePtr shaderNode, ValueElementPtr input, const string& targetColorSpace)
+void ShaderGraph::populateInputColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderNodePtr shaderNode, ValueElementPtr input, const string& targetColorSpace)
 {
     ShaderInput* shaderInput = shaderNode->getInput(input->getName());
     const string& sourceColorSpace = input->getActiveColorSpace();
@@ -1026,10 +1039,6 @@ void ShaderGraph::populateInputColorTransformMap(ColorManagementSystemPtr colorM
                         _inputColorTransformMap.emplace(shaderInput, transform);
                     }
                 }
-            }
-            else if(shaderInput->type != Type::FILENAME)
-            {
-                throw ExceptionShaderGenError("Color space attribute for: '" + node.getName() + "." + input->getName() + "' of unsupported type (must be color3 or color4).");
             }
         }
     }

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -119,13 +119,13 @@ class ShaderGraph : public ShaderNode
     void calculateScopes();
 
     /// For inputs and outputs in the graph set the variable names to be used
-    /// in generated code. Making sure variable names are valid and unique 
+    /// in generated code. Making sure variable names are valid and unique
     /// to avoid name conflicts during shader generation.
     void setVariableNames(ShaderGenerator& shadergen);
 
     /// Populates the input color transform map if the provided input/parameter
     /// has a color space attribute and has a type of color3 or color4.
-    void populateInputColorTransformMap(ColorManagementSystemPtr colorManagementSystem, const Node& node, ShaderNodePtr shaderNode, ValueElementPtr input, const string& targetColorSpace);
+    void populateInputColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderNodePtr shaderNode, ValueElementPtr input, const string& targetColorSpace);
 
     /// Break all connections on a node
     static void disconnect(ShaderNode* node);
@@ -133,6 +133,9 @@ class ShaderGraph : public ShaderNode
     DocumentPtr _document;
     std::unordered_map<string, ShaderNodePtr> _nodeMap;
     std::vector<ShaderNode*> _nodeOrder;
+
+    // Temporary storage for transform variable renaming
+    std::unordered_map<string, string> _renameTransformMap;
 
     // Temporary storage for inputs that require color transformations
     std::unordered_map<ShaderInput*, ColorSpaceTransform> _inputColorTransformMap;

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -43,6 +43,8 @@ class ShaderInput
     /// A connection to an upstream node output, or nullptr if not connected.
     ShaderOutput* connection;
 
+    bool noRename;
+
     /// Make a connection from the given source output to this input.
     void makeConnection(ShaderOutput* src);
 
@@ -71,6 +73,8 @@ class ShaderOutput
 
     /// A set of connections to downstream node inputs, empty if not connected.
     ShaderInputSet connections;
+
+    bool noRename;
 
     /// Make a connection from this output to the given input
     void makeConnection(ShaderInput* dst);

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -45,7 +45,7 @@ namespace mx = MaterialX;
 
 #define LOG_TO_FILE
 
-extern void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath& searchPath, mx::DocumentPtr doc, 
+extern void loadLibraries(const mx::StringVec& libraryNames, const mx::FilePath& searchPath, mx::DocumentPtr doc,
                           const std::set<std::string>* excludeFiles = nullptr);
 extern void createLightRig(mx::DocumentPtr doc, mx::HwLightHandler& lightHandler, mx::HwShaderGenerator& shadergen, const mx::GenOptions& options);
 
@@ -244,7 +244,7 @@ class LanguageProfileTimes
 public:
     void print(const std::string& label, std::ostream& output) const
     {
-        output << label << std::endl; 
+        output << label << std::endl;
         output << "\tTotal: " << totalTime << " seconds" << std::endl;;
         output << "\tSetup: " << setupTime << " seconds" << std::endl;;
         output << "\tTransparency: " << transparencyTime << " seconds" << std::endl;;
@@ -428,7 +428,7 @@ static void runOGSFXValidation(const std::string& shaderName, mx::TypedElementPt
             }
             const std::string& sourceCode = shader->getSourceCode(mx::OgsFxShader::FINAL_FX_STAGE);
             validated = sourceCode.length() > 0;
-            CHECK(validated);          
+            CHECK(validated);
         }
     }
 }
@@ -644,7 +644,7 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
 
     std::vector<mx::GenOptions> optionsList;
     getGenerationOptions(testOptions, optionsList);
-    
+
     if(element && doc)
     {
         log << "------------ Run OSL validation with element: " << element->getNamePath() << "-------------------" << std::endl;
@@ -781,7 +781,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
     options.overrideFiles.clear();
     options.cmsFiles.clear();
 
-    MaterialX::DocumentPtr doc = MaterialX::createDocument();            
+    MaterialX::DocumentPtr doc = MaterialX::createDocument();
     try {
         MaterialX::readFromXmlFile(doc, optionFile);
 
@@ -825,7 +825,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
                     else if (name == "dumpGlslUniformsAndAttributes")
                     {
                         options.dumpGlslUniformsAndAttributes = val->asA<bool>();
-                    }                    
+                    }
                     else if (name == "runOSLTests")
                     {
                         options.runOSLTests = val->asA<bool>();
@@ -841,7 +841,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
                     else if (name == "checkImplCount")
                     {
                         options.checkImplCount = val->asA<bool>();
-                    }                    
+                    }
                     else if (name == "dumpGlslFiles")
                     {
                         options.dumpGlslFiles = val->asA<bool>();
@@ -887,7 +887,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
 
 void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidTestOptions& options,
     std::set<std::string>& usedImpls, std::ostream& profilingLog, mx::DocumentPtr dependLib,
-    mx::ArnoldShaderGeneratorPtr oslShaderGenerator, mx::GlslShaderGeneratorPtr glslShaderGenerator, 
+    mx::ArnoldShaderGeneratorPtr oslShaderGenerator, mx::GlslShaderGeneratorPtr glslShaderGenerator,
     mx::OgsFxShaderGeneratorPtr ogsfxShaderGenerator)
 {
     profileTimes.print(profilingLog);
@@ -1231,7 +1231,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
             mx::DocumentPtr doc = mx::createDocument();
             readFromXmlFile(doc, filename);
 
-            if (options.cmsFiles.size() && options.cmsFiles.count(filename))
+            if (options.cmsFiles.size() && options.cmsFiles.count(file))
             {
 #if defined(MATERIALX_BUILD_GEN_GLSL) || defined(MATERIALX_BUILD_GEN_OGSFX)
                 // Load CMS system on demand if there is a file requiring color transforms


### PR DESCRIPTION
…e as the

color input variable. This is needed to allow users to manipulate the
color input uniform without needing to know about the color input
transform.