### PR TITLE
Add VariantAssign methods to MaterialAssign Element

### DIFF
--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -17,6 +17,21 @@ const string Visibility::VISIBILITY_TYPE_ATTRIBUTE = "vistype";
 const string Visibility::VISIBLE_ATTRIBUTE = "visible";
 
 //
+// MaterialAssign methods
+//
+
+vector<VariantAssignPtr> MaterialAssign::getActiveVariantAssigns() const
+{
+    vector<VariantAssignPtr> activeAssigns;
+    for (ConstElementPtr elem : traverseInheritance())
+    {
+        vector<VariantAssignPtr> assigns = elem->asA<MaterialAssign>()->getVariantAssigns();
+        activeAssigns.insert(activeAssigns.end(), assigns.begin(), assigns.end());
+    }
+    return activeAssigns;
+}
+
+//
 // Look methods
 //
 

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -291,7 +291,40 @@ class MaterialAssign : public GeomElement
     MaterialPtr getReferencedMaterial() const;
 
     /// @}
+    /// @name VariantAssign Elements
+    /// @{
 
+    /// Add a VariantAssign to the look.
+    /// @param name The name of the new VariantAssign.
+    ///     If no name is specified, then a unique name will automatically be
+    ///     generated.
+    /// @return A shared pointer to the new VariantAssign.
+    VariantAssignPtr addVariantAssign(const string& name = EMPTY_STRING)
+    {
+        return addChild<VariantAssign>(name);
+    }
+
+    /// Return the VariantAssign, if any, with the given name.
+    VariantAssignPtr getVariantAssign(const string& name) const
+    {
+        return getChildOfType<VariantAssign>(name);
+    }
+
+    /// Return a vector of all VariantAssign elements in the look.
+    vector<VariantAssignPtr> getVariantAssigns() const
+    {
+        return getChildrenOfType<VariantAssign>();
+    }
+
+    /// Return a vector of all VariantAssign elements that belong to this look,
+    /// taking look inheritance into account.
+    vector<VariantAssignPtr> getActiveVariantAssigns() const;
+
+    /// Remove the VariantAssign, if any, with the given name.
+    void removeVariantAssign(const string& name)
+    {
+        removeChildOfType<VariantAssign>(name);
+    }
   public:
     static const string CATEGORY;
     static const string MATERIAL_ATTRIBUTE;

--- a/source/MaterialXTest/Look.cpp
+++ b/source/MaterialXTest/Look.cpp
@@ -57,8 +57,22 @@ TEST_CASE("Look", "[look]")
     // Create a variant set.
     mx::VariantSetPtr variantSet = doc->addVariantSet("damageVars");
     mx::VariantPtr original = variantSet->addVariant("original");
+    mx::TokenPtr original_token1 = original->addToken("token1");
+    mx::InputPtr original_input1 = original->addInput("input1");
+    mx::ParameterPtr original_param1 = original->addParameter("param1");
     mx::VariantPtr damaged = variantSet->addVariant("damaged");
+    mx::TokenPtr damaged_token1 = damaged->addToken("token1");
+    mx::InputPtr damaged_input1 = damaged->addInput("input1");
+    mx::ParameterPtr damaged_param1 = damaged->addParameter("param1");
     REQUIRE(variantSet->getVariants().size() == 2);
+    mx::VariantAssignPtr variantAssign = look->addVariantAssign("assign_damageVars");
+    variantAssign->setVariantSetString("damageVars");
+    variantAssign->setVariantString("original");
+    REQUIRE(look->getActiveVariantAssigns().size() == 1);
+    mx::VariantAssignPtr variantAssign2 = matAssign1->addVariantAssign("assign_damageVars");
+    variantAssign2->setVariantSetString("damageVars");
+    variantAssign2->setVariantString("damaged");
+    REQUIRE(matAssign1->getActiveVariantAssigns().size() == 1);
 
     // Create a visibility element.
     mx::VisibilityPtr visibility = look->addVisibility();


### PR DESCRIPTION
Add equivalent utility methods to those on Look to allow for variant assignment setting on MaterialAssign
Elements.
