### PR TITLE
ShaderX test suite updates.

### DIFF
--- a/documents/TestSuite/_options.mtlx
+++ b/documents/TestSuite/_options.mtlx
@@ -24,10 +24,10 @@
         <!-- Set to true to enable execution of OGSFX tests. Default is false.
              Currently only shader generation testing is performed.
         -->
-        <parameter name="runOGSFXTests" type="boolean" value="false" />
+        <parameter name="runOGSFXTests" type="boolean" value="true" />
 
         <!-- Check the count of number of implementations used. Default is true.
-             If this option si set then runOSLTests and runGLSLTests will also
+             If this option is set then runOSLTests, runGLSLTests and runOGSFXTests will also
              be enabled to ensure a proper set of implementations to check.
         -->
         <parameter name="checkImplCount" type="boolean" value="true" />

--- a/documents/TestSuite/stdlib/application/viewdirection.mtlx
+++ b/documents/TestSuite/stdlib/application/viewdirection.mtlx
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <nodegraph name="viewDirectionGraph" type="" xpos="8.5931" ypos="20.52">
+    <viewdirection name="viewdirection1" type="vector3" xpos="3.51724" ypos="7.38" />
+    <output name="out" type="vector3" nodename="viewdirection1" />
+  </nodegraph>
+</materialx>

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -128,16 +128,20 @@ bool readFile(const string& filename, string& contents)
     {
         string buffer;
         file.seekg(0, std::ios::end);
-        buffer.resize(size_t(file.tellg()));
-        file.seekg(0, std::ios::beg);
-        file.read(&buffer[0], buffer.size());
-        file.close();
-        if (buffer.length() > 0)
+        std::streamsize bufferSize = file.tellg();
+        if (bufferSize > 0)
         {
-            size_t pos = buffer.find_last_not_of('\0');
-            contents = buffer.substr(0, pos + 1);
+            buffer.resize(size_t(bufferSize));
+            file.seekg(0, std::ios::beg);
+            file.read(&buffer[0], bufferSize);
+            file.close();
+            if (buffer.length() > 0)
+            {
+                size_t pos = buffer.find_last_not_of('\0');
+                contents = buffer.substr(0, pos + 1);
+            }
+            result = true;
         }
-        result = true;
     }
 #if defined(_WIN32)
     _set_fmode(oldMode ? oldMode : _O_TEXT);

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -973,12 +973,13 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
             options.saveImages = false;
         }
 
-        // If implementation count check is required, then at a minimum OSL and GLSL
-        // code generation must execute to be able to check implementation usage.
+        // If implementation count check is required, then OSL and GLSL/OGSFX
+        // code generation must be executed to be able to check implementation usage.
         if (options.checkImplCount)
         {
             options.runGLSLTests = true;
             options.runOSLTests = true;
+            options.runOGSFXTests = true;
         }
         return true;
     }


### PR DESCRIPTION
- Turn on OGSFX by default and force on if impl count checking is turned since there are OGSFX impl variants for GLSL
- Add in viewdirection test
- Add in code to address Codacy warning for ifstream::read().
"Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)"