### PR TITLE
 Improvements to handling of shader stages

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -578,7 +578,7 @@ void GlslShaderGenerator::emitFinalOutput(Shader& shader) const
     }
 }
 
-void GlslShaderGenerator::addNodeContextIDs(ShaderNode* node) const
+void GlslShaderGenerator::addContextIDs(ShaderNode* node) const
 {
     if (node->hasClassification(ShaderNode::Classification::BSDF))
     {
@@ -607,7 +607,7 @@ void GlslShaderGenerator::addNodeContextIDs(ShaderNode* node) const
     }
     else
     {
-        ParentClass::addNodeContextIDs(node);
+        ParentClass::addContextIDs(node);
     }
 }
 

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -91,9 +91,9 @@ class GlslShaderGenerator : public HwShaderGenerator
     /// Emit the final output expression
     void emitFinalOutput(Shader& shader) const override;
 
-    /// Add node contexts id's to the given node to control 
+    /// Add contexts id's to the given node to control 
     /// in which contexts this node should be used
-    void addNodeContextIDs(ShaderNode* node) const override;
+    void addContextIDs(ShaderNode* node) const override;
 
     /// Given a element attempt to remap a value to an enumeration which is accepted by
     /// the shader generator.

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -94,10 +94,10 @@ void LightCompoundNodeGlsl::emitFunctionDefinition(const ShaderNode& node, Shade
     // Emit function definitions for each context used by this compound node
     for (int id : node.getContextIDs())
     {
-        const GenContext* context = shadergen.getNodeContext(id);
+        const GenContext* context = shadergen.getContext(id);
         if (!context)
         {
-            throw ExceptionShaderGenError("Node '" + node.getName() + "' has an implementation context that is undefined for shader generator '" +
+            throw ExceptionShaderGenError("Node '" + node.getName() + "' has a context id that is undefined for shader generator '" +
                 shadergen.getLanguage() + "/" + shadergen.getTarget() + "'");
         }
 

--- a/source/MaterialXGenOgsFx/MayaGlslPluginShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/MayaGlslPluginShaderGenerator.cpp
@@ -15,7 +15,7 @@ MayaGlslPluginShader::MayaGlslPluginShader(const string& name)
 {
 }
 
-void MayaGlslPluginShader::createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
+void MayaGlslPluginShader::createUniform(const string& stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
 {
     // If no semantic is given and this is the view position uniform
     // we need to override its default semantic

--- a/source/MaterialXGenOgsFx/MayaGlslPluginShaderGenerator.h
+++ b/source/MaterialXGenOgsFx/MayaGlslPluginShaderGenerator.h
@@ -17,7 +17,7 @@ class MayaGlslPluginShader : public OgsFxShader
 public:
     MayaGlslPluginShader(const string& name);
 
-    void createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& path = EMPTY_STRING, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
+    void createUniform(const string& stage, const string& block, const TypeDesc* type, const string& name, const string& path = EMPTY_STRING, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
     void createAppData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
     void createVertexData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
 };

--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
@@ -64,17 +64,20 @@ namespace
     };
 }
 
+
+const string OgsFxShader::FINAL_FX_STAGE = "finalfx";
+
 OgsFxShader::OgsFxShader(const string& name) 
     : ParentClass(name)
 {
-    _stages.push_back(Stage("FinalFx"));
+    createStage(FINAL_FX_STAGE);
 
     // Create default uniform blocks for final fx stage
     createUniformBlock(FINAL_FX_STAGE, PRIVATE_UNIFORMS, "prvUniform");
     createUniformBlock(FINAL_FX_STAGE, PUBLIC_UNIFORMS, "pubUniform");
 }
 
-void OgsFxShader::createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
+void OgsFxShader::createUniform(const string& stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
 {
     // If no semantic is given check if we have 
     // an OgsFx semantic that should be used
@@ -254,7 +257,7 @@ ShaderPtr OgsFxShaderGenerator::generate(const string& shaderName, ElementPtr el
     // Assemble the final effects shader
     //
 
-    shader.setActiveStage(size_t(OgsFxShader::FINAL_FX_STAGE));
+    shader.setActiveStage(OgsFxShader::FINAL_FX_STAGE);
 
     // Add version directive
     shader.addLine("#version " + getVersion(), false);

--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.h
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.h
@@ -18,15 +18,12 @@ class OgsFxShader : public HwShader
 
 public:
     /// Identifier for final effects stage
-    static const size_t FINAL_FX_STAGE = HwShader::NUM_STAGES;
-    static const size_t NUM_STAGES = HwShader::NUM_STAGES + 1;
+    static const string FINAL_FX_STAGE;
 
 public:
     OgsFxShader(const string& name);
 
-    size_t numStages() const override { return NUM_STAGES; }
-
-    void createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& path = EMPTY_STRING, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
+    void createUniform(const string& stage, const string& block, const TypeDesc* type, const string& name, const string& path = EMPTY_STRING, const string& semantic = EMPTY_STRING, ValuePtr value = nullptr) override;
     void createAppData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
     void createVertexData(const TypeDesc* type, const string& name, const string& semantic = EMPTY_STRING) override;
 };

--- a/source/MaterialXGenShader/HwShader.cpp
+++ b/source/MaterialXGenShader/HwShader.cpp
@@ -4,6 +4,7 @@
 namespace MaterialX
 {
 
+const string HwShader::VERTEX_STAGE = "vertex";
 const string HwShader::LIGHT_DATA_BLOCK = "LightData";
 
 HwShader::HwShader(const string& name) 
@@ -11,7 +12,8 @@ HwShader::HwShader(const string& name)
     , _vertexData("VertexData", "vd")
     , _transparency(false)
 {
-    _stages.push_back(Stage("Vertex"));
+    // Create the vertex stage
+    createStage(VERTEX_STAGE);
 
     // Create default uniform blocks for vertex stage
     createUniformBlock(VERTEX_STAGE, PRIVATE_UNIFORMS, "prvUniform");

--- a/source/MaterialXGenShader/HwShader.h
+++ b/source/MaterialXGenShader/HwShader.h
@@ -15,8 +15,7 @@ class HwShader : public Shader
 
 public:
     /// Identifier for additional vertex shader stage
-    static const size_t VERTEX_STAGE = Shader::NUM_STAGES;
-    static const size_t NUM_STAGES = Shader::NUM_STAGES + 1;
+    static const string VERTEX_STAGE;
 
     /// Identifier for light data uniform block.
     static const string LIGHT_DATA_BLOCK;
@@ -29,9 +28,6 @@ public:
     /// @param shadergen The shader generator instance.
     /// @param options Generation options
     void initialize(ElementPtr element, ShaderGenerator& shadergen, const GenOptions& options) override;
-
-    /// Return the number of shader stages for this shader.
-    size_t numStages() const override { return NUM_STAGES; }
 
     /// Create a new variable for vertex data. This creates an 
     /// output from the vertex stage and and input to the pixel stage.

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -62,10 +62,10 @@ void CompoundNode::emitFunctionDefinition(const ShaderNode& node, ShaderGenerato
     // Emit function definitions for each context used by this compound node
     for (int id : node.getContextIDs())
     {
-        const GenContext* context = shadergen.getNodeContext(id);
+        const GenContext* context = shadergen.getContext(id);
         if (!context)
         {
-            throw ExceptionShaderGenError("Node '" + node.getName() + "' has an implementation context that is undefined for shader generator '" + 
+            throw ExceptionShaderGenError("Node '" + node.getName() + "' has a context id that is undefined for shader generator '" + 
                 shadergen.getLanguage() + "/" +shadergen.getTarget() + "'");
         }
 

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -12,17 +12,19 @@
 namespace MaterialX
 {
 
+const string Shader::PIXEL_STAGE = "pixel";
 const string Shader::PRIVATE_UNIFORMS = "PrivateUniforms";
 const string Shader::PUBLIC_UNIFORMS = "PublicUniforms";
 
 Shader::Shader(const string& name)
     : _name(name)
     , _rootGraph(nullptr)
-    , _activeStage(PIXEL_STAGE)
     , _appData("AppData", "ad")
     , _outputs("Outputs", "op")
 {
-    _stages.push_back(Stage("Pixel"));
+    // Create pixel stage and make it the active stage
+    StagePtr pixelStage = createStage(PIXEL_STAGE);
+    _activeStage = pixelStage.get();
 
     // Create default uniform blocks for pixel stage
     createUniformBlock(PIXEL_STAGE, PRIVATE_UNIFORMS, "prvUniform");
@@ -82,64 +84,96 @@ void Shader::initialize(ElementPtr element, ShaderGenerator& shadergen, const Ge
     }
 }
 
+Shader::StagePtr Shader::createStage(const string& name)
+{
+    StagePtr s = std::make_shared<Stage>(name);
+    _stages[name] = s;
+    return s;
+}
+
+Shader::Stage* Shader::getStage(const string& name)
+{
+    auto it = _stages.find(name);
+    if (it == _stages.end())
+    {
+        throw ExceptionShaderGenError("Stage '" + name + "' doesn't exist in shader '" + getName() + "'");
+    }
+    return it->second.get();
+}
+
+const Shader::Stage* Shader::getStage(const string& name) const
+{
+    return const_cast<Shader*>(this)->getStage(name);
+}
+
+void Shader::getStageNames(StringVec& stages)
+{
+    stages.reserve(_stages.size());
+    for (auto it : _stages)
+    {
+        stages.push_back(it.first);
+    }
+}
+
+void Shader::setActiveStage(const string& name)
+{
+    _activeStage = getStage(name);
+}
+
 void Shader::beginScope(Brackets brackets)
 {
-    Stage& s = stage();
-        
     switch (brackets) {
     case Brackets::BRACES:
         indent();
-        s.code += "{\n";
+        _activeStage->code += "{\n";
         break;
     case Brackets::PARENTHESES:
         indent();
-        s.code += "(\n";
+        _activeStage->code += "(\n";
         break;
     case Brackets::SQUARES:
         indent();
-        s.code += "[\n";
+        _activeStage->code += "[\n";
         break;
     case Brackets::NONE:
         break;
     }
 
-    ++s.indentations;
-    s.scopes.push(brackets);
+    ++_activeStage->indentations;
+    _activeStage->scopes.push(brackets);
 }
 
 void Shader::endScope(bool semicolon, bool newline)
 {
-    Stage& s = stage();
-
-    if (s.scopes.empty())
+    if (_activeStage->scopes.empty())
     {
         throw ExceptionShaderGenError("End scope called with no scope active, please check your beginScope/endScope calls");
     }
 
-    Brackets brackets = s.scopes.back();
-    s.scopes.pop();
-    --s.indentations;
+    Brackets brackets = _activeStage->scopes.back();
+    _activeStage->scopes.pop();
+    --_activeStage->indentations;
 
     switch (brackets) {
     case Brackets::BRACES:
         indent();
-        s.code += "}";
+        _activeStage->code += "}";
         break;
     case Brackets::PARENTHESES:
         indent();
-        s.code += ")";
+        _activeStage->code += ")";
         break;
     case Brackets::SQUARES:
         indent();
-        s.code += "]";
+        _activeStage->code += "]";
         break;
     case Brackets::NONE:
         break;
     }
     if (semicolon)
-        s.code += ";";
+        _activeStage->code += ";";
     if (newline)
-        s.code += "\n";
+        _activeStage->code += "\n";
 }
 
 void Shader::beginLine()
@@ -149,30 +183,30 @@ void Shader::beginLine()
 
 void Shader::endLine(bool semicolon)
 {
-    stage().code += semicolon ? ";\n" : "\n";
+    _activeStage->code += semicolon ? ";\n" : "\n";
 }
 
 void Shader::newLine()
 {
-    stage().code += "\n";
+    _activeStage->code += "\n";
 }
 
 void Shader::addStr(const string& str)
 {
-    stage().code += str;
+    _activeStage->code += str;
 }
 
 void Shader::addLine(const string& str, bool semicolon)
 {
     beginLine();
-    stage().code += str;
+    _activeStage->code += str;
     endLine(semicolon);
 }
 
 void Shader::addComment(const string& str)
 {
     beginLine();
-    stage().code += "// " + str;
+    _activeStage->code += "// " + str;
     endLine(false);
 }
 
@@ -210,11 +244,10 @@ void Shader::addBlock(const string& str, ShaderGenerator& shadergen)
 
 void Shader::addFunctionDefinition(ShaderNode* node, ShaderGenerator& shadergen)
 {
-    Stage& s = stage();
     ShaderNodeImpl* impl = node->getImplementation();
-    if (s.definedFunctions.find(impl) == s.definedFunctions.end())
+    if (_activeStage->definedFunctions.find(impl) == _activeStage->definedFunctions.end())
     {
-        s.definedFunctions.insert(impl);
+        _activeStage->definedFunctions.insert(impl);
         impl->emitFunctionDefinition(*node, shadergen, *this);
     }
 }
@@ -229,15 +262,14 @@ void Shader::addInclude(const string& file, ShaderGenerator& shadergen)
 {
     const string path = shadergen.findSourceCode(file);
 
-    Stage& s = stage();
-    if (s.includes.find(path) == s.includes.end())
+    if (_activeStage->includes.find(path) == _activeStage->includes.end())
     {
         string content;
         if (!readFile(path, content))
         {
             throw ExceptionShaderGenError("Could not find include file: '" + file + "'");
         }
-        s.includes.insert(path);
+        _activeStage->includes.insert(path);
         addBlock(content, shadergen);
     }
 }
@@ -246,45 +278,48 @@ void Shader::indent()
 {
     // Use 4 spaces as default indentation
     static const string INDENTATION = "    ";
-    Stage& s = stage();
-    for (int i = 0; i < s.indentations; ++i)
+    for (int i = 0; i < _activeStage->indentations; ++i)
     {
-        s.code += INDENTATION;
+        _activeStage->code += INDENTATION;
     }
 }
 
-void Shader::createConstant(size_t stage, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
+void Shader::createConstant(const string& stage, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
 {
-    Stage& s = _stages[stage];
-    if (s.constants.variableMap.find(name) == s.constants.variableMap.end())
+    Stage* s = getStage(stage);
+    if (s->constants.variableMap.find(name) == s->constants.variableMap.end())
     {
         VariablePtr variablePtr = Variable::create(type, name, path, semantic, value);
-        s.constants.variableMap[name] = variablePtr;
-        s.constants.variableOrder.push_back(variablePtr.get());
+        s->constants.variableMap[name] = variablePtr;
+        s->constants.variableOrder.push_back(variablePtr.get());
     }
 }
 
-const Shader::VariableBlock& Shader::getConstantBlock(size_t stage) const
+const Shader::VariableBlock& Shader::getConstantBlock(const string& stage) const
 {
-    const Stage& s = _stages[stage];
-    return s.constants;
+    return getStage(stage)->constants;
 }
 
-void Shader::createUniformBlock(size_t stage, const string& block, const string& instance)
+const Shader::VariableBlockMap& Shader::getUniformBlocks(const string& stage) const
 {
-    Stage& s = _stages[stage];
-    auto it = s.uniforms.find(block);
-    if (it == s.uniforms.end())
+    return getStage(stage)->uniforms;
+}
+
+void Shader::createUniformBlock(const string& stage, const string& block, const string& instance)
+{
+    Stage* s = getStage(stage);
+    auto it = s->uniforms.find(block);
+    if (it == s->uniforms.end())
     {
-        s.uniforms[block] = std::make_shared<VariableBlock>(block, instance);
+        s->uniforms[block] = std::make_shared<VariableBlock>(block, instance);
     }
 }
 
-void Shader::createUniform(size_t stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
+void Shader::createUniform(const string& stage, const string& block, const TypeDesc* type, const string& name, const string& path, const string& semantic, ValuePtr value)
 {
-    const Stage& s = _stages[stage];
-    auto it = s.uniforms.find(block);
-    if (it == s.uniforms.end())
+    Stage* s = getStage(stage);
+    auto it = s->uniforms.find(block);
+    if (it == s->uniforms.end())
     {
         throw ExceptionShaderGenError("No uniform block named '" + block + "' exists for shader '" + getName() + "'");
     }
@@ -297,11 +332,11 @@ void Shader::createUniform(size_t stage, const string& block, const TypeDesc* ty
     }
 }
 
-const Shader::VariableBlock& Shader::getUniformBlock(size_t stage, const string& block) const
+const Shader::VariableBlock& Shader::getUniformBlock(const string& stage, const string& block) const
 {
-    const Stage& s = _stages[stage];
-    auto it = s.uniforms.find(block);
-    if (it == s.uniforms.end())
+    const Stage* s = getStage(stage);
+    auto it = s->uniforms.find(block);
+    if (it == s->uniforms.end())
     {
         throw ExceptionShaderGenError("No uniform block named '" + block + "' exists for shader '" + getName() + "'");
     }

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -185,12 +185,12 @@ void ShaderGenerator::emitOutput(const GenContext& context, const ShaderOutput* 
     }
 }
 
-void ShaderGenerator::addNodeContextIDs(ShaderNode* node) const
+void ShaderGenerator::addContextIDs(ShaderNode* node) const
 {
     node->addContextID(CONTEXT_DEFAULT);
 }
 
-const GenContext* ShaderGenerator::getNodeContext(int id) const
+const GenContext* ShaderGenerator::getContext(int id) const
 {
     auto it = _contexts.find(id);
     return it != _contexts.end() ? it->second.get() : nullptr;

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -71,13 +71,13 @@ public:
     /// Return the syntax object for the language used by the code generator
     const Syntax* getSyntax() const { return _syntax.get(); }
 
-    /// Add node contexts id's to the given node to control
+    /// Add context id's to the given node to control
     /// in which contexts this node should be used.
-    virtual void addNodeContextIDs(ShaderNode* node) const;
+    virtual void addContextIDs(ShaderNode* node) const;
 
-    /// Return the node context corresponding to the given id,
+    /// Return the context corresponding to the given id,
     /// or nullptr if no such context is found.
-    const GenContext* getNodeContext(int id) const;
+    const GenContext* getContext(int id) const;
 
     template<class T>
     using CreatorFunction = shared_ptr<T>(*)();

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -303,7 +303,7 @@ ShaderNodePtr ShaderNode::create(const string& name, const NodeDef& nodeDef, Sha
     newNode->_classification |= groupClassification;
 
     // Let the shader generator assign in which contexts to use this node
-    shadergen.addNodeContextIDs(newNode.get());
+    shadergen.addContextIDs(newNode.get());
 
     return newNode;
 }
@@ -395,7 +395,7 @@ ShaderNodePtr ShaderNode::createColorTransformNode(const string& name, ShaderNod
         throw ExceptionShaderGenError("Invalid type specified to createColorTransform: '" + type->getName() + "'");
     }
     newNode->addOutput("out", type);
-    shadergen.addNodeContextIDs(newNode.get());
+    shadergen.addContextIDs(newNode.get());
     return newNode;
 }
 

--- a/source/MaterialXRender/OpenGL/GlslProgram.h
+++ b/source/MaterialXRender/OpenGL/GlslProgram.h
@@ -44,19 +44,13 @@ class GlslProgram
 
     /// Set the code stages based on a list of stage strings.
     /// Refer to the ordering of stages as defined by a HwShader.
-    /// @param stages List of shader code strings.
-    void setStages(const std::vector<std::string>& stages);
+    /// @param stage Name of the shader stage.
+    /// @param sourcCode Source code of the shader stage.
+    void addStage(const string& stage, const string& sourcCode);
 
-    /// Get code string for a given stage
+    /// Get source code string for a given stage.
     /// @return Shader stage string. String is empty if not found.
-    const std::string getStage(size_t stage) const;
-
-    /// Get the number of stages
-    /// @return Stage count
-    size_t numStages() const
-    {
-        return HwShader::NUM_STAGES;
-    }
+    const string& getStageSourceCode(const string& stage) const;
 
     /// Clear out any existing stages
     void clearStages();
@@ -232,12 +226,6 @@ class GlslProgram
     bool bindTexture(unsigned int uniformType, int uniformLocation, const string& fileName,
                      ImageHandlerPtr imageHandler, bool generateMipMaps, const ImageSamplingProperties& imageProperties);
 
-    /// Internal cleanup of stages and OpenGL constructs
-    void cleanup();
-
-    /// Check if there is a valid set of stages to build program from
-    bool haveValidStages() const;
-
     /// Utility to check for OpenGL context errors.
     /// Will throw an ExceptionShaderValidationError exception which will list of the errors found
     /// if any errors encountered.
@@ -250,7 +238,8 @@ class GlslProgram
 
   private:
     /// Stages used to create program
-    std::string _stages[HwShader::NUM_STAGES];
+    /// Map of stage name and its source code
+    std::unordered_map<string, string> _stages;
 
     /// Generated program. A non-zero number indicates a valid shader program.
     unsigned int _programId;

--- a/source/MaterialXRender/ShaderValidators/Glsl/GlslValidator.cpp
+++ b/source/MaterialXRender/ShaderValidators/Glsl/GlslValidator.cpp
@@ -62,7 +62,7 @@ GlslValidator::~GlslValidator()
 void GlslValidator::initialize()
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OpenGL utilities initialization.");
+    const string errorType("OpenGL utilities initialization.");
 
     if (!_initialized)
     {
@@ -132,7 +132,7 @@ void GlslValidator::deleteTarget()
 bool GlslValidator::createTarget()
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OpenGL target creation failure.");
+    const string errorType("OpenGL target creation failure.");
 
     if (!_context)
     {
@@ -200,7 +200,7 @@ bool GlslValidator::createTarget()
         glDeleteFramebuffers(1, &_frameBuffer);
         _frameBuffer = MaterialX::GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
 
-        std::string errorMessage("Frame buffer object setup failed: ");
+        string errorMessage("Frame buffer object setup failed: ");
         switch (status) {
         case GL_FRAMEBUFFER_COMPLETE:
             errorMessage += "GL_FRAMEBUFFER_COMPLETE";
@@ -275,7 +275,7 @@ bool GlslValidator::bindTarget(bool bind)
 void GlslValidator::validateCreation(const ShaderPtr shader)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("GLSL program creation error.");
+    const string errorType("GLSL program creation error.");
 
     if (!_context)
     {
@@ -293,10 +293,10 @@ void GlslValidator::validateCreation(const ShaderPtr shader)
     _program->build();    
 }
 
-void GlslValidator::validateCreation(const std::vector<std::string>& stages)
+void GlslValidator::validateCreation(const std::unordered_map<string, string>& stages)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("GLSL program creation error.");
+    const string errorType("GLSL program creation error.");
 
     if (!_context)
     {
@@ -310,14 +310,17 @@ void GlslValidator::validateCreation(const std::vector<std::string>& stages)
         throw ExceptionShaderValidationError(errorType, errors);
     }
 
-    _program->setStages(stages);
+    for (auto it : stages)
+    {
+        _program->addStage(it.first, it.second);
+    }
     _program->build();
 }
 
 void GlslValidator::validateInputs()
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("GLSL program input error.");
+    const string errorType("GLSL program input error.");
 
     if (!_context)
     {
@@ -399,7 +402,7 @@ void GlslValidator::validateRender(bool orthographicView)
     _orthographicView = orthographicView;
 
     ShaderValidationErrorList errors;
-    const std::string errorType("GLSL rendering error.");
+    const string errorType("GLSL rendering error.");
 
     if (!_context)
     {
@@ -480,10 +483,10 @@ void GlslValidator::validateRender(bool orthographicView)
     bindTarget(false);
 }
 
-void GlslValidator::save(const std::string& fileName, bool floatingPoint)
+void GlslValidator::save(const string& fileName, bool floatingPoint)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("GLSL image save error.");
+    const string errorType("GLSL image save error.");
 
     if (!_imageHandler)
     {

--- a/source/MaterialXRender/ShaderValidators/Glsl/GlslValidator.h
+++ b/source/MaterialXRender/ShaderValidators/Glsl/GlslValidator.h
@@ -59,7 +59,7 @@ class GlslValidator : public ShaderValidator
 
     /// Validate creation of program based input shader stage strings
     /// @param shader Input stages List of stage string
-    void validateCreation(const std::vector<std::string>& stages) override;
+    void validateCreation(const std::unordered_map<string, string>& stages) override;
 
     /// Validate inputs for the program 
     void validateInputs() override;
@@ -76,7 +76,7 @@ class GlslValidator : public ShaderValidator
     /// Save the current contents the offscreen hardware buffer to disk.
     /// @param fileName Name of file to save rendered image to.
     /// @param floatingPoint Format of output image is floating point.
-    void save(const std::string& fileName, bool floatingPoint) override;
+    void save(const string& fileName, bool floatingPoint) override;
     
     /// Return the GLSL program wrapper class
     MaterialX::GlslProgramPtr program()

--- a/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
@@ -11,7 +11,7 @@ namespace MaterialX
 {
 
 // Statics
-std::string OslValidator::OSL_CLOSURE_COLOR_STRING("closure color");
+string OslValidator::OSL_CLOSURE_COLOR_STRING("closure color");
 
 //
 // Creator
@@ -34,7 +34,7 @@ OslValidator::~OslValidator()
 void OslValidator::initialize()
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OSL initialization error.");
+    const string errorType("OSL initialization error.");
     if (_oslIncludePathString.empty())
     {
         errors.push_back("OSL validation include path is empty.");
@@ -47,10 +47,10 @@ void OslValidator::initialize()
     }
 }
 
-void OslValidator::renderOSL(const std::string& outputPath, const std::string& shaderName, const std::string& outputName)
+void OslValidator::renderOSL(const string& outputPath, const string& shaderName, const string& outputName)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OSL rendering error.");
+    const string errorType("OSL rendering error.");
 
     // If command options missing, skip testing.
     if (_oslTestRenderExecutable.empty() || _oslIncludePathString.empty() ||
@@ -76,37 +76,37 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     // Determine the shader path from output path and shader name
     FilePath shaderFilePath(outputPath);
     shaderFilePath = shaderFilePath / shaderName;
-    std::string shaderPath = shaderFilePath.asString();
+    string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    std::string outputFileName = shaderPath + "_osl.png";
+    string outputFileName = shaderPath + "_osl.png";
 
     // Use a known error file name to check
-    std::string errorFile(shaderPath + "_render_errors.txt");
-    const std::string redirectString(" 2>&1");
+    string errorFile(shaderPath + "_render_errors.txt");
+    const string redirectString(" 2>&1");
 
     // Read in scene template and replace the applicable tokens to have a valid ShaderGroup.
     // Write to local file to use as input for rendering.
     //
     std::ifstream sceneTemplateStream(_oslTestRenderSceneTemplateFile);
-    std::string sceneTemplateString;
+    string sceneTemplateString;
     sceneTemplateString.assign(std::istreambuf_iterator<char>(sceneTemplateStream),
         std::istreambuf_iterator<char>());
 
     // Get final output to use in the shader
-    const std::string CLOSURE_PASSTHROUGH_SHADER_STRING("closure_passthrough");
-    const std::string CONSTANT_COLOR_SHADER_STRING("constant_color");
-    const std::string CONSTANT_COLOR_SHADER_PREFIX_STRING("constant_");
-    std::string outputShader = isColorClosure ? CLOSURE_PASSTHROUGH_SHADER_STRING :
+    const string CLOSURE_PASSTHROUGH_SHADER_STRING("closure_passthrough");
+    const string CONSTANT_COLOR_SHADER_STRING("constant_color");
+    const string CONSTANT_COLOR_SHADER_PREFIX_STRING("constant_");
+    string outputShader = isColorClosure ? CLOSURE_PASSTHROUGH_SHADER_STRING :
         (isRemappable ? CONSTANT_COLOR_SHADER_PREFIX_STRING + _oslShaderOutputType : CONSTANT_COLOR_SHADER_STRING);
 
     // Perform token replacement
-    const std::string OUTPUT_SHADER_TYPE_STRING("%output_shader_type%");
-    const std::string OUTPUT_SHADER_INPUT_STRING("%output_shader_input%");
-    const std::string OUTPUT_SHADER_INPUT_VALUE_STRING("Cin");
-    const std::string INPUT_SHADER_TYPE_STRING("%input_shader_type%");
-    const std::string INPUT_SHADER_OUTPUT_STRING("%input_shader_output%");
-    const std::string BACKGROUND_COLOR_STRING("%background_color%");
+    const string OUTPUT_SHADER_TYPE_STRING("%output_shader_type%");
+    const string OUTPUT_SHADER_INPUT_STRING("%output_shader_input%");
+    const string OUTPUT_SHADER_INPUT_VALUE_STRING("Cin");
+    const string INPUT_SHADER_TYPE_STRING("%input_shader_type%");
+    const string INPUT_SHADER_OUTPUT_STRING("%input_shader_output%");
+    const string BACKGROUND_COLOR_STRING("%background_color%");
     const string backgroundColor("0.0 0.0 0.0"); // TODO: Make this a user input
 
     StringMap replacementMap;
@@ -115,7 +115,7 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     replacementMap[INPUT_SHADER_TYPE_STRING] = shaderName;
     replacementMap[INPUT_SHADER_OUTPUT_STRING] = outputName;
     replacementMap[BACKGROUND_COLOR_STRING] = backgroundColor;
-    std::string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);
+    string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);
     if ((sceneString == sceneTemplateString) || sceneTemplateString.empty())
     {
         errors.push_back("Scene template file: " + _oslTestRenderSceneTemplateFile +
@@ -124,7 +124,7 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     }
 
     // Write scene file
-    const std::string sceneFileName(shaderPath + "_scene.xml");
+    const string sceneFileName(shaderPath + "_scene.xml");
     std::ofstream shaderFileStream;
     shaderFileStream.open(sceneFileName);
     if (shaderFileStream.is_open())
@@ -134,12 +134,12 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     }
 
     // Set oso file paths
-    std::string osoPaths(_oslUtilityOSOPath);
+    string osoPaths(_oslUtilityOSOPath);
     osoPaths += ";" + outputPath;
 
     // Build and run render command
     //
-    std::string command(_oslTestRenderExecutable);
+    string command(_oslTestRenderExecutable);
     command += " " + sceneFileName;
     command += " " + outputFileName;
     command += " -r 512 512 --path " + osoPaths;
@@ -152,7 +152,7 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     int returnValue = std::system(command.c_str());
 
     std::ifstream errorStream(errorFile);
-    std::string result;
+    string result;
     result.assign(std::istreambuf_iterator<char>(errorStream),
         std::istreambuf_iterator<char>());
 
@@ -166,7 +166,7 @@ void OslValidator::renderOSL(const std::string& outputPath, const std::string& s
     }
 }
 
-void OslValidator::shadeOSL(const std::string& outputPath, const std::string& shaderName, const std::string& outputName)
+void OslValidator::shadeOSL(const string& outputPath, const string& shaderName, const string& outputName)
 {
     // If no command and include path specified then skip checking.
     if (_oslTestShadeExecutable.empty() || _oslIncludePathString.empty())
@@ -176,16 +176,16 @@ void OslValidator::shadeOSL(const std::string& outputPath, const std::string& sh
 
     FilePath shaderFilePath(outputPath);
     shaderFilePath = shaderFilePath / shaderName;
-    std::string shaderPath = shaderFilePath.asString();
+    string shaderPath = shaderFilePath.asString();
 
     // Set output image name.
-    std::string outputFileName = shaderPath + ".testshade.png";
+    string outputFileName = shaderPath + ".testshade.png";
 
     // Use a known error file name to check
-    std::string errorFile(shaderPath + "_shade_errors.txt");
-    const std::string redirectString(" 2>&1");
+    string errorFile(shaderPath + "_shade_errors.txt");
+    const string redirectString(" 2>&1");
 
-    std::string command(_oslTestShadeExecutable);
+    string command(_oslTestShadeExecutable);
     command += " " + shaderPath;
     command += " -o " + outputName + " " + outputFileName;
     command += " -g 256 256";
@@ -199,15 +199,15 @@ void OslValidator::shadeOSL(const std::string& outputPath, const std::string& sh
     // modifies this then this hard-coded string must also be modified.
     // The formatted string is "Output <outputName> to <outputFileName>".
     std::ifstream errorStream(errorFile);
-    std::string result;
-    std::vector<std::string> results;
-    std::string line;
-    std::string successfulOutputSubString("Output " + outputName + " to " +
+    string result;
+    std::vector<string> results;
+    string line;
+    string successfulOutputSubString("Output " + outputName + " to " +
                                            outputFileName);
     while (std::getline(errorStream, line))
     {
         if (!line.empty() &&
-            line.find(successfulOutputSubString) == std::string::npos)
+            line.find(successfulOutputSubString) == string::npos)
         {
             results.push_back(line);
         }
@@ -215,7 +215,7 @@ void OslValidator::shadeOSL(const std::string& outputPath, const std::string& sh
 
     if (!results.empty())
     {
-        const std::string errorType("OSL rendering error.");
+        const string errorType("OSL rendering error.");
         ShaderValidationErrorList errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
@@ -228,7 +228,7 @@ void OslValidator::shadeOSL(const std::string& outputPath, const std::string& sh
     }
 }
 
-void OslValidator::compileOSL(const std::string& oslFileName)
+void OslValidator::compileOSL(const string& oslFileName)
 {
     // If no command and include path specified then skip checking.
     if (_oslCompilerExecutable.empty() || _oslIncludePathString.empty())
@@ -237,27 +237,27 @@ void OslValidator::compileOSL(const std::string& oslFileName)
     }
 
     // Remove .osl and add .oso extension for output.
-    std::string outputFileName = removeExtension(oslFileName);
+    string outputFileName = removeExtension(oslFileName);
     outputFileName += ".oso";
 
     // Use a known error file name to check
-    std::string errorFile(oslFileName + "_compile_errors.txt");
-    const std::string redirectString(" 2>&1");
+    string errorFile(oslFileName + "_compile_errors.txt");
+    const string redirectString(" 2>&1");
 
     // Run the command and get back the result. If non-empty string throw exception with error
-    std::string command = _oslCompilerExecutable + " -q -I\"" + _oslIncludePathString + "\" " + oslFileName + " -o " + outputFileName + " > " +
+    string command = _oslCompilerExecutable + " -q -I\"" + _oslIncludePathString + "\" " + oslFileName + " -o " + outputFileName + " > " +
         errorFile + redirectString;
 
     int returnValue = std::system(command.c_str());
 
     std::ifstream errorStream(errorFile);
-    std::string result;
+    string result;
     result.assign(std::istreambuf_iterator<char>(errorStream),
                   std::istreambuf_iterator<char>());
 
     if (!result.empty())
     {
-        const std::string errorType("OSL compilation error.");
+        const string errorType("OSL compilation error.");
         ShaderValidationErrorList errors;
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
@@ -269,17 +269,17 @@ void OslValidator::compileOSL(const std::string& oslFileName)
 
 void OslValidator::validateCreation(const ShaderPtr shader)
 {
-    std::vector<std::string> stages;
-    stages.push_back(shader->getSourceCode());
+    std::unordered_map<string, string> stages;
+    stages[Shader::PIXEL_STAGE] = shader->getSourceCode(Shader::PIXEL_STAGE);
 
     validateCreation(stages);
 }
 
-void OslValidator::validateCreation(const std::vector<std::string>& stages)
+void OslValidator::validateCreation(const std::unordered_map<string, string>& stages)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OSL compilation error.");
-    if (stages.empty() || stages[0].empty())
+    const string errorType("OSL compilation error.");
+    if (stages.empty() || stages.begin()->second.empty())
     {
         errors.push_back("No shader code to validate");
         throw ExceptionShaderValidationError(errorType, errors);
@@ -295,7 +295,7 @@ void OslValidator::validateCreation(const std::vector<std::string>& stages)
     // Dump string to disk. For OSL assume shader is in stage 0 slot.
     FilePath filePath(_oslOutputFilePathString);
     filePath = filePath  / _oslShaderName;
-    std::string fileName = filePath.asString();
+    string fileName = filePath.asString();
     if (fileName.empty())
     {
         fileName = "_osl_temp.osl";
@@ -309,7 +309,7 @@ void OslValidator::validateCreation(const std::vector<std::string>& stages)
     // Thus we replace all instances of "object" with "world" to avoid issues.
     StringMap spaceMap;
     spaceMap["\"object\""] = "\"world\"";
-    std::string oslCode = replaceSubstrings(stages[0], spaceMap);
+    string oslCode = replaceSubstrings(stages.begin()->second, spaceMap);
 
     std::ofstream file;
     file.open(fileName);
@@ -323,7 +323,7 @@ void OslValidator::validateCreation(const std::vector<std::string>& stages)
 void OslValidator::validateInputs()
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OSL validation error.");
+    const string errorType("OSL validation error.");
 
     errors.push_back("OSL input validation is not supported at this time.");
     throw ExceptionShaderValidationError(errorType, errors);
@@ -332,7 +332,7 @@ void OslValidator::validateInputs()
 void OslValidator::validateRender(bool /*orthographicView*/)
 {
     ShaderValidationErrorList errors;
-    const std::string errorType("OSL rendering error.");
+    const string errorType("OSL rendering error.");
 
     if (_oslOutputFilePathString.empty())
     {
@@ -363,7 +363,7 @@ void OslValidator::validateRender(bool /*orthographicView*/)
     }
 }
 
-void OslValidator::save(const std::string& /*fileName*/, bool /*floatingPoint*/)
+void OslValidator::save(const string& /*fileName*/, bool /*floatingPoint*/)
 {
     // No-op: image save is done as part of rendering.
 }

--- a/source/MaterialXRender/ShaderValidators/Osl/OslValidator.h
+++ b/source/MaterialXRender/ShaderValidators/Osl/OslValidator.h
@@ -33,7 +33,7 @@ class OslValidator : public ShaderValidator
     virtual ~OslValidator();
 
     /// Color closure OSL string
-    static std::string OSL_CLOSURE_COLOR_STRING;
+    static string OSL_CLOSURE_COLOR_STRING;
 
     /// @name Setup
     /// @{
@@ -63,7 +63,7 @@ class OslValidator : public ShaderValidator
     /// Validate creation of an OSL program based upon a shader string for a given
     /// shader "stage". There is only one shader stage for OSL thus
     /// @param stages List of shader strings. Only first string in list is examined.
-    void validateCreation(const std::vector<std::string>& stages) override;
+    void validateCreation(const std::unordered_map<string, string>& stages) override;
 
     /// Validate inputs for the compiled OSL program. 
     /// Note: Currently no validation has been implemented.
@@ -89,7 +89,7 @@ class OslValidator : public ShaderValidator
     /// execution.
     /// @param fileName Name of file to save rendered image to.
     /// @param floatingPoint Format of output image is floating point.
-    void save(const std::string& fileName, bool floatingPoint) override;
+    void save(const string& fileName, bool floatingPoint) override;
     
     /// @}
     /// @name Compilation settings
@@ -98,7 +98,7 @@ class OslValidator : public ShaderValidator
     /// Set the OSL executable path string. Note that it is assumed that this
     /// references the location of the oslc executable.
     /// @param executable Full path to OSL compiler executable
-    void setOslCompilerExecutable(const std::string& executable)
+    void setOslCompilerExecutable(const string& executable)
     {
         _oslCompilerExecutable = executable;
     }
@@ -106,7 +106,7 @@ class OslValidator : public ShaderValidator
     /// Set the OSL include path string. 
     /// @param includePathString Include path(s) for the OSL compiler. This should include the
     /// path to stdosl.h    
-    void setOslIncludePath(const std::string& includePathString)
+    void setOslIncludePath(const string& includePathString)
     {
         _oslIncludePathString = includePathString;
     }
@@ -115,7 +115,7 @@ class OslValidator : public ShaderValidator
     /// During compiler checking an OSL file of the given output name will be used if it
     /// is not empty. If temp then OSL will be written to a temporary file.
     /// @param filePathString Full path name
-    void setOslOutputFilePath(const std::string& filePathString)
+    void setOslOutputFilePath(const string& filePathString)
     {
         _oslOutputFilePathString = filePathString;
     }
@@ -126,7 +126,7 @@ class OslValidator : public ShaderValidator
     /// input scene file.
     /// @param outputName Name of shader output
     /// @param outputName The MaterialX type of the output
-    void setOslShaderOutput(const std::string& outputName, const std::string& outputType)
+    void setOslShaderOutput(const string& outputName, const string& outputType)
     {
         _oslShaderOutputName = outputName;
         _oslShaderOutputType = outputType;
@@ -135,7 +135,7 @@ class OslValidator : public ShaderValidator
     /// Set the OSL shading tester path string. Note that it is assumed that this
     /// references the location of the "testshade" executable.
     /// @param executable Full path to OSL "testshade" executable
-    void setOslTestShadeExecutable(const std::string& executable)
+    void setOslTestShadeExecutable(const string& executable)
     {
         _oslTestShadeExecutable = executable;
     }
@@ -143,7 +143,7 @@ class OslValidator : public ShaderValidator
     /// Set the OSL rendering tester path string. Note that it is assumed that this
     /// references the location of the "testrender" executable.
     /// @param executable Full path to OSL "testrender" executable
-    void setOslTestRenderExecutable(const std::string& executable)
+    void setOslTestRenderExecutable(const string& executable)
     {
         _oslTestRenderExecutable = executable;
     }
@@ -153,7 +153,7 @@ class OslValidator : public ShaderValidator
     ///     - %shader% : which will be replaced with the name of the shader to use
     ///     - %shader_output% : which will be replace with the name of the shader output to use
     /// @param templateFileName Scene file name
-    void setOslTestRenderSceneTemplateFile(const std::string& templateFileName)
+    void setOslTestRenderSceneTemplateFile(const string& templateFileName)
     {
         _oslTestRenderSceneTemplateFile = templateFileName;
     }
@@ -161,7 +161,7 @@ class OslValidator : public ShaderValidator
     /// Set the name of the shader to be used for the input XML scene file.
     /// The value is used to replace the %shader% token in the file.
     /// @param shaderName Name of shader
-    void setOslShaderName(const std::string& shaderName)
+    void setOslShaderName(const string& shaderName)
     {
         _oslShaderName = shaderName;
     }
@@ -169,7 +169,7 @@ class OslValidator : public ShaderValidator
     /// Set the search path for dependent shaders (.oso files) which are used
     /// when rendering with testrender. 
     /// @param osoPath Path to .oso files.
-    void setOslUtilityOSOPath(const std::string& osoPath)
+    void setOslUtilityOSOPath(const string& osoPath)
     {
         _oslUtilityOSOPath = osoPath;
     }
@@ -185,7 +185,7 @@ class OslValidator : public ShaderValidator
     ///
     /// Compile OSL code stored in a file. Will throw an exception if an error occurs.
     /// @param oslFileName Name of OSL file
-    void compileOSL(const std::string& oslFileName);
+    void compileOSL(const string& oslFileName);
 
     /// @}
 
@@ -195,40 +195,40 @@ class OslValidator : public ShaderValidator
     /// @param outputPath Path to input .oso file.
     /// @param shaderName Name of OSL shader. A corresponding .oso file is assumed to exist in the output path folder.
     /// @param outputName Name of OSL shader output to use.
-    void shadeOSL(const std::string& outputPath, const std::string& shaderName, const std::string& outputName);
+    void shadeOSL(const string& outputPath, const string& shaderName, const string& outputName);
 
     ///
     /// Render using OSO input file. Will throw an exception if an error occurs.
     /// @param outputPath Path to input .oso file.
     /// @param shaderName Name of OSL shader. A corresponding .oso file is assumed to exist in the output path folder.
     /// @param outputName Name of OSL shader output to use.
-    void renderOSL(const std::string& outputPath, const std::string& shaderName, const std::string& outputName);
+    void renderOSL(const string& outputPath, const string& shaderName, const string& outputName);
 
     /// Constructor
     OslValidator();
 
   private:
     /// "oslc" executable name`
-    std::string _oslCompilerExecutable;
+    string _oslCompilerExecutable;
     /// OSL include path name
-    std::string _oslIncludePathString;
+    string _oslIncludePathString;
     /// Output file path. File name does not include an extension
-    std::string _oslOutputFilePathString;
+    string _oslOutputFilePathString;
 
     /// "testshade" executable name
-    std::string _oslTestShadeExecutable;
+    string _oslTestShadeExecutable;
     /// "testrender" executable name
-    std::string _oslTestRenderExecutable;
+    string _oslTestRenderExecutable;
     /// Template scene XML file used for "testrender"
-    std::string _oslTestRenderSceneTemplateFile;
+    string _oslTestRenderSceneTemplateFile;
     /// Name of shader. Used for rendering with "testrender"
-    std::string _oslShaderName;
+    string _oslShaderName;
     /// Name of output on the shader. Used for rendering with "testshade" and "testrender"
-    std::string _oslShaderOutputName;
+    string _oslShaderOutputName;
     /// MaterialX type of the output on the shader. Used for rendering with "testshade" and "testrender"
-    std::string _oslShaderOutputType;
+    string _oslShaderOutputType;
     /// Path for utility shaders (.oso) used when rendering with "testrender"
-    std::string _oslUtilityOSOPath;
+    string _oslUtilityOSOPath;
     /// Use "testshade" or "testender" for render validation
     bool _useTestRender;
 };

--- a/source/MaterialXRender/ShaderValidators/ShaderValidator.h
+++ b/source/MaterialXRender/ShaderValidators/ShaderValidator.h
@@ -90,7 +90,7 @@ class ShaderValidator
 
     /// Validate creation of program based input shader stage strings
     /// @param shader Input stages List of stage string
-    virtual void validateCreation(const std::vector<std::string>& stages) = 0;
+    virtual void validateCreation(const std::unordered_map<string, string>& stages) = 0;
 
     /// Validate inputs for the program 
     virtual void validateInputs() = 0;


### PR DESCRIPTION
- Using strings for shader stage identifiers instead of hard coded integer ids
- Made stage creation and access more flexible
- Renamed some context methods for consistency
- Some additional clean ups
