### PR TITLE
Fix build error reported in Xcode

### DIFF
--- a/source/MaterialXRender/OpenGL/GLCocoaWrappers.m
+++ b/source/MaterialXRender/OpenGL/GLCocoaWrappers.m
@@ -179,7 +179,7 @@ void NSOpenGLDescribePixelFormat(void* pPixelFormat, int attrib, int* vals)
 void NSOpenGLGetInteger(void* pContext, int param, int* vals)
 {
   NSOpenGLContext* context = (NSOpenGLContext*)pContext;
-	[context getValues:vals forParameter:param];
+	[context getValues:vals forParameter:(NSOpenGLContextParameter)param];
 }
 
 void NSOpenGLUpdate(void* pContext)


### PR DESCRIPTION
in GLCocoaWrappers.m:182:39:
error: cannot initialize a parameter of type 'NSOpenGLContextParameter' with an lvalue of type 'int'
      [context getValues:vals forParameter:param];