### PR TITLE
ShaderX Unit Test Updates

### DIFF
--- a/documents/Libraries/pbrlib/genglsl/mx_sheenbrdf.glsl
+++ b/documents/Libraries/pbrlib/genglsl/mx_sheenbrdf.glsl
@@ -1,7 +1,7 @@
 #include "pbrlib/genglsl/lib/mx_bsdfs.glsl"
 
 // Fake with simple diffuse reflection for now
-void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, out BSDF result)
+void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF bsdf, out BSDF result)
 {
     float NdotL = dot(L, normal);
     if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
@@ -18,7 +18,7 @@ void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float rou
 }
 
 // Fake with simple diffuse reflection for now
-void mx_sheenbrdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, out vec3 result)
+void mx_sheenbrdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF bsdf, out vec3 result)
 {
     if (weight < M_FLOAT_EPS)
     {

--- a/documents/Libraries/pbrlib/genglsl/mx_sheenbrdf.glsl
+++ b/documents/Libraries/pbrlib/genglsl/mx_sheenbrdf.glsl
@@ -1,7 +1,7 @@
 #include "pbrlib/genglsl/lib/mx_bsdfs.glsl"
 
 // Fake with simple diffuse reflection for now
-void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF bsdf, out BSDF result)
+void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF base, out BSDF result)
 {
     float NdotL = dot(L, normal);
     if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
@@ -18,7 +18,7 @@ void mx_sheenbrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, float rou
 }
 
 // Fake with simple diffuse reflection for now
-void mx_sheenbrdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF bsdf, out vec3 result)
+void mx_sheenbrdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, BSDF base, out vec3 result)
 {
     if (weight < M_FLOAT_EPS)
     {

--- a/documents/Libraries/pbrlib/genglsl/mx_subsurfacebrdf.glsl
+++ b/documents/Libraries/pbrlib/genglsl/mx_subsurfacebrdf.glsl
@@ -13,7 +13,21 @@ void mx_subsurfacebrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3
 }
 
 // Fake with simple diffuse transmission
-void mx_subsurfacebrdf_transmission(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out vec3 result)
+void mx_subsurfacebrdf_transmission(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, BSDF bsdf, out vec3 result)
+{
+    if (weight < M_FLOAT_EPS)
+    {
+        result = vec3(0.0);
+        return;
+    }
+
+    // Invert normal since we're transmitting light from the other side
+    vec3 Li = mx_environment_irradiance(-normal);
+    result = Li * color * weight;
+}
+
+// Fake with simple diffuse transmission
+void mx_subsurfacebrdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out vec3 result)
 {
     if (weight < M_FLOAT_EPS)
     {

--- a/documents/Libraries/pbrlib/genglsl/mx_subsurfacebrdf.glsl
+++ b/documents/Libraries/pbrlib/genglsl/mx_subsurfacebrdf.glsl
@@ -13,20 +13,6 @@ void mx_subsurfacebrdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3
 }
 
 // Fake with simple diffuse transmission
-void mx_subsurfacebrdf_transmission(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, BSDF bsdf, out vec3 result)
-{
-    if (weight < M_FLOAT_EPS)
-    {
-        result = vec3(0.0);
-        return;
-    }
-
-    // Invert normal since we're transmitting light from the other side
-    vec3 Li = mx_environment_irradiance(-normal);
-    result = Li * color * weight;
-}
-
-// Fake with simple diffuse transmission
 void mx_subsurfacebrdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out vec3 result)
 {
     if (weight < M_FLOAT_EPS)

--- a/documents/Libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/documents/Libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -37,9 +37,6 @@
   <!-- <uniformedf> -->
   <implementation name="IM_uniformedf_genglsl" nodedef="ND_uniformedf" file="pbrlib/genglsl/mx_uniformedf.glsl" function="mx_uniformedf" language="genglsl"/>
 
-  <!-- <conicaledf> -->
-  <implementation name="IM_conicaledf_genglsl" nodedef="ND_conicaledf" file="pbrlib/genglsl/mx_conicaledf.glsl" function="mx_conicaledf" language="genglsl"/>
-
   <!-- <mixedf> -->
   <implementation name="IM_mixedf_genglsl" nodedef="ND_mixedf" file="pbrlib/genglsl/mx_mixedf.glsl" function="mx_mixedf" language="genglsl"/>
 

--- a/documents/Libraries/pbrlib/genosl/mx_mixsurface.osl
+++ b/documents/Libraries/pbrlib/genosl/mx_mixsurface.osl
@@ -1,4 +1,4 @@
-void mx_layeredsurface(surfaceshader in1, surfaceshader in2, float weight, output surfaceshader result)
+void mx_mixsurface(surfaceshader in1, surfaceshader in2, float weight, output surfaceshader result)
 {
     float w = clamp(weight, 0.0, 1.0);
     result = in1 * (1.0 - w) + in2 * w;

--- a/documents/Libraries/pbrlib/genosl/mx_sheenbrdf.osl
+++ b/documents/Libraries/pbrlib/genosl/mx_sheenbrdf.osl
@@ -1,5 +1,5 @@
 void mx_sheenbrdf(float weight, color _color, float roughness, vector _normal, BSDF base, output BSDF result)
 {
     // TODO: implement this properly
-    result = _color * weight * oren_nayar(normal, roughness);
+    result = _color * weight * oren_nayar(_normal, roughness);
 }

--- a/documents/Libraries/pbrlib/genosl/mx_sheenbrdf.osl
+++ b/documents/Libraries/pbrlib/genosl/mx_sheenbrdf.osl
@@ -1,5 +1,5 @@
-void mx_sheenbrdf(float weight, color _color, float rougness, vector _normal, BSDF base, output BSDF result)
+void mx_sheenbrdf(float weight, color _color, float roughness, vector _normal, BSDF base, output BSDF result)
 {
     // TODO: implement this properly
-    result = _color * weight * oren_nayar({{normal}}, {{roughness}})
+    result = _color * weight * oren_nayar(normal, roughness);
 }

--- a/documents/Libraries/stdlib/osl/stdlib_osl_impl.mtlx
+++ b/documents/Libraries/stdlib/osl/stdlib_osl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
   TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
   All rights reserved.  See LICENSE.txt for license.
 
@@ -357,7 +357,7 @@
   <implementation name="IM_modulo_color4_osl" nodedef="ND_modulo_color4" file="stdlib/osl/mx_modulo_color4.osl" function="mx_modulo_color4" language="osl"/>
   <implementation name="IM_modulo_color4FA_osl" nodedef="ND_modulo_color4FA" file="stdlib/osl/mx_modulo_float_color4.osl" function="mx_modulo_float_color4" language="osl"/>
   <implementation name="IM_modulo_vector2_osl" nodedef="ND_modulo_vector2" file="stdlib/osl/mx_modulo_vector2.osl" function="mx_modulo_vector2" language="osl"/>
-  <implementation name="IM_modulo_vector2FA" nodedef="ND_modulo_vector2FA" file="stdlib/osl/mx_modulo_float_vector2.osl" function="mx_modulo_float_vector2" language="osl"/>
+  <implementation name="IM_modulo_vector2FA_osl" nodedef="ND_modulo_vector2FA" file="stdlib/osl/mx_modulo_float_vector2.osl" function="mx_modulo_float_vector2" language="osl"/>
   <implementation name="IM_modulo_vector3_osl" nodedef="ND_modulo_vector3" file="stdlib/osl/mx_modulo_vector.osl" function="mx_modulo_vector" language="osl"/>
   <implementation name="IM_modulo_vector3FA_osl" nodedef="ND_modulo_vector3FA" file="stdlib/osl/mx_modulo_float_vector.osl" function="mx_modulo_float_vector" language="osl"/>
   <implementation name="IM_modulo_vector4_osl" nodedef="ND_modulo_vector4" file="stdlib/osl/mx_modulo_vector4.osl" function="mx_modulo_vector4" language="osl"/>

--- a/documents/TestSuite/pbrlib/materials/shader_ops.mtlx
+++ b/documents/TestSuite/pbrlib/materials/shader_ops.mtlx
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib/stdlib_defs.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib/stdlib_ng.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl/cm_genglsl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl/stdlib_genglsl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl\ogsfx/stdlib_genglsl_ogsfx_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genosl/cm_genosl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genosl/stdlib_genosl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\osl/stdlib_osl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib/pbrlib_defs.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib/pbrlib_ng.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib\genglsl/pbrlib_genglsl_impl.mtlx" />
+  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib\genosl/pbrlib_genosl_impl.mtlx" />
+  <nodegraph name="nodegraph1" type="" xpos="7.69655" ypos="20.7914">
+    <add name="add_surface_shader" type="surfaceshader" xpos="6.91469" ypos="-0.75844">
+      <input name="in1" type="surfaceshader" value="" nodename="multiply_surface_shaderFloat" />
+      <input name="in2" type="surfaceshader" value="" nodename="multiply_surface_shaderColor" />
+    </add>
+    <multiply name="multiply_surface_shaderFloat" type="surfaceshader" xpos="4.69913" ypos="-2.3342">
+      <input name="in1" type="surfaceshader" value="" nodename="standard_surface1" />
+      <input name="in2" type="float" value="0.4000" />
+    </multiply>
+    <multiply name="multiply_surface_shaderColor" type="surfaceshader" xpos="5.90591" ypos="3.93576">
+      <input name="in1" type="surfaceshader" value="" nodename="mix_surface_shader" />
+      <input name="in2" type="color3" value="1.0000, 0.0, 0.0" />
+    </multiply>
+    <mix name="mix_surface_shader" type="surfaceshader" xpos="4.04492" ypos="4.06008">
+      <input name="fg" type="surfaceshader" value="" nodename="standard_surface1" />
+      <input name="bg" type="surfaceshader" value="" nodename="standard_surface2" />
+      <input name="mix" type="float" value="0.5000" />
+    </mix>
+    <standard_surface name="standard_surface1" type="surfaceshader" xpos="1.40457" ypos="-3.27944">
+      <input name="base" type="float" value="0.8" />
+      <input name="base_color" type="color3" value="1, 1, 1" />
+      <input name="diffuse_roughness" type="float" value="0" />
+      <input name="specular" type="float" value="1" />
+      <input name="specular_color" type="color3" value="1, 1, 1" />
+      <input name="specular_roughness" type="float" value="0.1" />
+      <input name="specular_IOR" type="float" value="1.52" />
+      <input name="specular_anisotropy" type="float" value="0" />
+      <input name="specular_rotation" type="float" value="0" />
+      <input name="metalness" type="float" value="0" />
+      <input name="transmission" type="float" value="0" />
+      <input name="transmission_color" type="color3" value="1, 1, 1" />
+      <input name="transmission_depth" type="float" value="0" />
+      <input name="transmission_scatter" type="color3" value="0, 0, 0" />
+      <input name="transmission_scatter_anisotropy" type="float" value="0" />
+      <input name="transmission_dispersion" type="float" value="0" />
+      <input name="transmission_extra_roughness" type="float" value="0" />
+      <input name="subsurface" type="float" value="0" />
+      <input name="subsurface_color" type="color3" value="1, 1, 1" />
+      <input name="subsurface_radius" type="color3" value="1, 1, 1" />
+      <input name="subsurface_scale" type="float" value="1" />
+      <input name="thin_walled" type="boolean" value="false" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="coat" type="float" value="0" />
+      <input name="coat_color" type="color3" value="1, 1, 1" />
+      <input name="coat_roughness" type="float" value="0.1" />
+      <input name="coat_IOR" type="float" value="1.5" />
+      <input name="coat_normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="sheen" type="float" value="0" />
+      <input name="sheen_color" type="color3" value="1, 1, 1" />
+      <input name="sheen_roughness" type="float" value="0.3" />
+      <input name="thin_film_thickness" type="float" value="0" />
+      <input name="thin_film_IOR" type="float" value="1.5" />
+      <input name="emission" type="float" value="0" />
+      <input name="emission_color" type="color3" value="1, 1, 1" />
+      <input name="opacity" type="color3" value="1, 1, 1" />
+      <input name="caustics" type="boolean" value="false" />
+      <input name="internal_reflections" type="boolean" value="true" />
+      <input name="exit_to_background" type="boolean" value="false" />
+      <input name="indirect_diffuse" type="float" value="1" />
+      <input name="indirect_specular" type="float" value="1" />
+    </standard_surface>
+    <standard_surface name="standard_surface2" type="surfaceshader" xpos="2.74737" ypos="8.81556">
+      <input name="base" type="float" value="0.8" />
+      <input name="base_color" type="color3" value="1, 1, 1" />
+      <input name="diffuse_roughness" type="float" value="0" />
+      <input name="specular" type="float" value="1" />
+      <input name="specular_color" type="color3" value="1, 1, 1" />
+      <input name="specular_roughness" type="float" value="0.1" />
+      <input name="specular_IOR" type="float" value="1.52" />
+      <input name="specular_anisotropy" type="float" value="0" />
+      <input name="specular_rotation" type="float" value="0" />
+      <input name="metalness" type="float" value="0" />
+      <input name="transmission" type="float" value="0" />
+      <input name="transmission_color" type="color3" value="1, 1, 1" />
+      <input name="transmission_depth" type="float" value="0" />
+      <input name="transmission_scatter" type="color3" value="0, 0, 0" />
+      <input name="transmission_scatter_anisotropy" type="float" value="0" />
+      <input name="transmission_dispersion" type="float" value="0" />
+      <input name="transmission_extra_roughness" type="float" value="0" />
+      <input name="subsurface" type="float" value="0" />
+      <input name="subsurface_color" type="color3" value="1, 1, 1" />
+      <input name="subsurface_radius" type="color3" value="1, 1, 1" />
+      <input name="subsurface_scale" type="float" value="1" />
+      <input name="thin_walled" type="boolean" value="false" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="coat" type="float" value="0" />
+      <input name="coat_color" type="color3" value="1, 1, 1" />
+      <input name="coat_roughness" type="float" value="0.1" />
+      <input name="coat_IOR" type="float" value="1.5" />
+      <input name="coat_normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="sheen" type="float" value="0" />
+      <input name="sheen_color" type="color3" value="1, 1, 1" />
+      <input name="sheen_roughness" type="float" value="0.3" />
+      <input name="thin_film_thickness" type="float" value="0" />
+      <input name="thin_film_IOR" type="float" value="1.5" />
+      <input name="emission" type="float" value="0" />
+      <input name="emission_color" type="color3" value="1, 1, 1" />
+      <input name="opacity" type="color3" value="1, 1, 1" />
+      <input name="caustics" type="boolean" value="false" />
+      <input name="internal_reflections" type="boolean" value="true" />
+      <input name="exit_to_background" type="boolean" value="false" />
+      <input name="indirect_diffuse" type="float" value="1" />
+      <input name="indirect_specular" type="float" value="1" />
+    </standard_surface>
+    <output name="out" type="surfaceshader" nodename="add_surface_shader" />
+  </nodegraph>
+</materialx>

--- a/documents/TestSuite/pbrlib/materials/shader_ops.mtlx
+++ b/documents/TestSuite/pbrlib/materials/shader_ops.mtlx
@@ -1,17 +1,5 @@
 <?xml version="1.0"?>
 <materialx version="1.36">
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib/stdlib_defs.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib/stdlib_ng.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl/cm_genglsl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl/stdlib_genglsl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genglsl\ogsfx/stdlib_genglsl_ogsfx_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genosl/cm_genosl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\genosl/stdlib_genosl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/stdlib\osl/stdlib_osl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib/pbrlib_defs.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib/pbrlib_ng.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib\genglsl/pbrlib_genglsl_impl.mtlx" />
-  <xi:include href="D:/Work/materialx/BlackSky/build/bin/Libraries/pbrlib\genosl/pbrlib_genosl_impl.mtlx" />
   <nodegraph name="nodegraph1" type="" xpos="7.69655" ypos="20.7914">
     <add name="add_surface_shader" type="surfaceshader" xpos="6.91469" ypos="-0.75844">
       <input name="in1" type="surfaceshader" value="" nodename="multiply_surface_shaderFloat" />

--- a/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
+++ b/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
@@ -1,54 +1,54 @@
 <?xml version="1.0"?>
 <materialx version="1.36" require="">
   <nodegraph name="nodegraph1" type="" xpos="6.44334" ypos="16.5914">
-    <roughness_dual name="roughness_dual1" type="roughnessinfo" xpos="3.58352" ypos="15.2781">
+    <roughness_dual name="roughness_dual1" type="roughnessinfo" xpos="3.37737" ypos="12.2247">
       <input name="roughnessX" type="float" value="0.2000" />
       <input name="roughnessY" type="float" value="0.4000" />
     </roughness_dual>
-    <subsurfacebrdf name="subsurfacebrdf1" type="BSDF" xpos="1.49655" ypos="13">
+    <subsurfacebrdf name="subsurfacebrdf1" type="BSDF" xpos="2.0363" ypos="14.2553">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" value="0.18, 0.18, 0.18" />
       <input name="radius" type="vector3" value="1.0, 1.0, 1.0" />
       <input name="anisotropy" type="float" value="0.0" />
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
     </subsurfacebrdf>
-    <sheenbrdf name="sheenbrdf1" type="BSDF" xpos="1.49655" ypos="18.58">
+    <sheenbrdf name="sheenbrdf1" type="BSDF" xpos="2.02026" ypos="20.1608">
       <input name="weight" type="float" value="1.0" />
       <input name="color" type="color3" value="1.0, 1.0, 1.0" />
       <input name="roughness" type="float" value="0.3" />
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="base" type="BSDF" value="" />
     </sheenbrdf>
-    <mixedf name="mixedf1" type="EDF" xpos="4.32414" ypos="1.48">
-      <input name="in1" type="EDF" value=""  nodename="Emission_EDF" />
+    <mixedf name="mixedf1" type="EDF" xpos="4.84828" ypos="-0.84">
+      <input name="in1" type="EDF" value="" nodename="Emission_EDF" />
       <input name="in2" type="EDF" value="" />
       <input name="weight" type="float" value="0.5000" />
     </mixedf>
-    <mixsurface name="mixsurface1" type="surfaceshader" xpos="7.46207" ypos="8.28">
-      <input name="in1" type="surfaceshader" value=""  nodename="surface1" />
-      <input name="in2" type="surfaceshader" value=""  nodename="surface2" />
+    <mixsurface name="mixsurface1" type="surfaceshader" xpos="7.98621" ypos="5.96">
+      <input name="in1" type="surfaceshader" value="" nodename="surface1" />
+      <input name="in2" type="surfaceshader" value="" nodename="surface2" />
       <input name="weight" type="float" value="0.5000" />
     </mixsurface>
-    <mixbsdf name="mixbsdf1" type="BSDF" xpos="3.939" ypos="20.4878">
-      <input name="in1" type="BSDF" value=""  nodename="sheenbrdf1" />
-      <input name="in2" type="BSDF" value=""  nodename="subsurfacebrdf1" />
+    <mixbsdf name="mixbsdf1" type="BSDF" xpos="3.57026" ypos="16.8768">
+      <input name="in1" type="BSDF" value="" nodename="sheenbrdf1" />
+      <input name="in2" type="BSDF" value="" nodename="subsurfacebrdf1" />
       <input name="weight" type="float" value="0.5000" />
     </mixbsdf>
-    <surface name="surface1" type="surfaceshader" xpos="5.97931" ypos="4.54">
-      <input name="bsdf" type="BSDF" value=""  nodename="conductorbrdf1" />
-      <input name="edf" type="EDF" value=""  nodename="mixedf1" />
+    <surface name="surface1" type="surfaceshader" xpos="6.50345" ypos="2.22">
+      <input name="bsdf" type="BSDF" value="" nodename="conductorbrdf1" />
+      <input name="edf" type="EDF" value="" nodename="mixedf1" />
       <input name="opacity" type="float" value="1.0000" />
     </surface>
-    <surface name="surface2" type="surfaceshader" xpos="6.67156" ypos="12.7289">
-      <input name="bsdf" type="BSDF" value=""  nodename="SchlickBRDF" />
-      <input name="edf" type="EDF" value=""  nodename="Emission_EDF" />
+    <surface name="surface2" type="surfaceshader" xpos="6.50345" ypos="11.58">
+      <input name="bsdf" type="BSDF" value="" nodename="SchlickBRDF" />
+      <input name="edf" type="EDF" value="" nodename="Emission_EDF" />
       <input name="opacity" type="float" value="1.0" />
     </surface>
-    <uniformedf name="Emission_EDF" type="EDF" xpos="2.53793" ypos="12.04">
+    <uniformedf name="Emission_EDF" type="EDF" xpos="3.06207" ypos="9.72">
       <input name="intensity" type="color3" value="0.2000, 1.0, 0.2000" />
     </uniformedf>
-    <output name="out" type="surfaceshader"  nodename="mixsurface1" />
-    <conductorbrdf name="conductorbrdf1" type="BSDF" xpos="4.32414" ypos="5.8">
+    <output name="out" type="surfaceshader" nodename="mixsurface1" />
+    <conductorbrdf name="conductorbrdf1" type="BSDF" xpos="4.84828" ypos="3.48">
       <input name="weight" type="float" value="1.0" />
       <input name="reflectivity" type="color3" value="0.944 0.776 0.373" />
       <input name="edgecolor" type="color3" value="0.998 0.981 0.751" />
@@ -57,7 +57,7 @@
       <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="distribution" type="string" value="ggx" />
     </conductorbrdf>
-    <generalizedschlickbrdf name="SchlickBRDF" type="BSDF" xpos="5.53558" ypos="16.5087">
+    <generalizedschlickbrdf name="SchlickBRDF" type="BSDF" xpos="4.84828" ypos="10.32">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
@@ -66,7 +66,7 @@
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="distribution" type="string" value="ggx" />
-      <input name="base" type="BSDF" value="" />
+      <input name="base" type="BSDF" value="" nodename="mixbsdf1" />
     </generalizedschlickbrdf>
   </nodegraph>
 </materialx>

--- a/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
+++ b/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
@@ -66,7 +66,7 @@
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
       <input name="distribution" type="string" value="ggx" />
-      <input name="base" type="BSDF" value=""  nodename="" />
+      <input name="base" type="BSDF" value="" />
     </generalizedschlickbrdf>
   </nodegraph>
 </materialx>

--- a/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
+++ b/documents/TestSuite/pbrlib/materials/surface_ops.mtlx
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<materialx version="1.36" require="">
+  <nodegraph name="nodegraph1" type="" xpos="6.44334" ypos="16.5914">
+    <roughness_dual name="roughness_dual1" type="roughnessinfo" xpos="3.58352" ypos="15.2781">
+      <input name="roughnessX" type="float" value="0.2000" />
+      <input name="roughnessY" type="float" value="0.4000" />
+    </roughness_dual>
+    <subsurfacebrdf name="subsurfacebrdf1" type="BSDF" xpos="1.49655" ypos="13">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.18, 0.18, 0.18" />
+      <input name="radius" type="vector3" value="1.0, 1.0, 1.0" />
+      <input name="anisotropy" type="float" value="0.0" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+    </subsurfacebrdf>
+    <sheenbrdf name="sheenbrdf1" type="BSDF" xpos="1.49655" ypos="18.58">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="roughness" type="float" value="0.3" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="base" type="BSDF" value="" />
+    </sheenbrdf>
+    <mixedf name="mixedf1" type="EDF" xpos="4.32414" ypos="1.48">
+      <input name="in1" type="EDF" value=""  nodename="Emission_EDF" />
+      <input name="in2" type="EDF" value="" />
+      <input name="weight" type="float" value="0.5000" />
+    </mixedf>
+    <mixsurface name="mixsurface1" type="surfaceshader" xpos="7.46207" ypos="8.28">
+      <input name="in1" type="surfaceshader" value=""  nodename="surface1" />
+      <input name="in2" type="surfaceshader" value=""  nodename="surface2" />
+      <input name="weight" type="float" value="0.5000" />
+    </mixsurface>
+    <mixbsdf name="mixbsdf1" type="BSDF" xpos="3.939" ypos="20.4878">
+      <input name="in1" type="BSDF" value=""  nodename="sheenbrdf1" />
+      <input name="in2" type="BSDF" value=""  nodename="subsurfacebrdf1" />
+      <input name="weight" type="float" value="0.5000" />
+    </mixbsdf>
+    <surface name="surface1" type="surfaceshader" xpos="5.97931" ypos="4.54">
+      <input name="bsdf" type="BSDF" value=""  nodename="conductorbrdf1" />
+      <input name="edf" type="EDF" value=""  nodename="mixedf1" />
+      <input name="opacity" type="float" value="1.0000" />
+    </surface>
+    <surface name="surface2" type="surfaceshader" xpos="6.67156" ypos="12.7289">
+      <input name="bsdf" type="BSDF" value=""  nodename="SchlickBRDF" />
+      <input name="edf" type="EDF" value=""  nodename="Emission_EDF" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <uniformedf name="Emission_EDF" type="EDF" xpos="2.53793" ypos="12.04">
+      <input name="intensity" type="color3" value="0.2000, 1.0, 0.2000" />
+    </uniformedf>
+    <output name="out" type="surfaceshader"  nodename="mixsurface1" />
+    <conductorbrdf name="conductorbrdf1" type="BSDF" xpos="4.32414" ypos="5.8">
+      <input name="weight" type="float" value="1.0" />
+      <input name="reflectivity" type="color3" value="0.944 0.776 0.373" />
+      <input name="edgecolor" type="color3" value="0.998 0.981 0.751" />
+      <input name="roughness" type="roughnessinfo" value="" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="distribution" type="string" value="ggx" />
+    </conductorbrdf>
+    <generalizedschlickbrdf name="SchlickBRDF" type="BSDF" xpos="5.53558" ypos="16.5087">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="roughness" type="roughnessinfo" value="" nodename="roughness_dual1" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
+      <input name="distribution" type="string" value="ggx" />
+      <input name="base" type="BSDF" value=""  nodename="" />
+    </generalizedschlickbrdf>
+  </nodegraph>
+</materialx>

--- a/documents/TestSuite/stdlib/math/transform.mtlx
+++ b/documents/TestSuite/stdlib/math/transform.mtlx
@@ -67,6 +67,17 @@ Basic transform function tests each test is in a separate graph for each variati
     <output name="out" type="vector3" nodename="transformvector1" />
   </nodegraph>
   -->
+  <nodegraph name="transformvector_vector3" type="" xpos="6.27714" ypos="26.3972">
+      <position name="position1" type="vector3" xpos="4.87243" ypos="6.7323">
+        <parameter name="space" type="string" value="object" />
+      </position>
+      <transformvector name="transformvector1" type="vector3" xpos="6.25413" ypos="7.13256">
+      <input name="in" type="vector3" nodename="position1" />
+      <input name="fromspace" type="string" value="object"/>
+      <input name="tospace" type="string" value="world"/>
+    </transformvector>
+    <output name="out" type="vector3" nodename="transformvector1" />
+  </nodegraph>
   <nodegraph name="transform_vector_vector4M">
     <transformvector name="transformvector1" type="vector4">
 	    <input name="in" type="vector4" value="1.0, 0.5, 0.0, 1.0"/>
@@ -107,4 +118,3 @@ Basic transform function tests each test is in a separate graph for each variati
     <output name="out" type="vector4" nodename="transformnormal1" />
   </nodegraph>
 </materialx>
-

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -114,40 +114,20 @@ void getFilesInDirectory(const std::string& directory, StringVec& files, const s
 
 bool readFile(const string& filename, string& contents)
 {
-#if defined(_WIN32)
-    // Protection in case someone sets fmode to binary
-    int oldMode;
-    _get_fmode(&oldMode);
-    _set_fmode(_O_TEXT);
-#endif
-
-    bool result = false;
-
-    std::ifstream file(filename, std::ios::in );
+    std::ifstream file(filename, std::ios::in | std::ios::binary);
     if (file)
     {
-        string buffer;
-        file.seekg(0, std::ios::end);
-        std::streamsize bufferSize = file.tellg();
-        if (bufferSize > 0)
+        std::stringstream stream;
+        stream << file.rdbuf();
+        file.close();
+        if (stream)
         {
-            buffer.resize(size_t(bufferSize));
-            file.seekg(0, std::ios::beg);
-            file.read(&buffer[0], bufferSize);
-            file.close();
-            if (buffer.length() > 0)
-            {
-                size_t pos = buffer.find_last_not_of('\0');
-                contents = buffer.substr(0, pos + 1);
-            }
-            result = true;
+            contents = stream.str();
+            return (contents.size() > 0);
         }
+        return false;
     }
-#if defined(_WIN32)
-    _set_fmode(oldMode ? oldMode : _O_TEXT);
-#endif
-
-    return result;
+    return false;
 }
 
 string getFileExtension(const string& filename)

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -1119,8 +1119,7 @@ void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidT
         }
         size_t libraryCount = libraryImpls.size();
         profilingLog << "Tested: " << implementationUseCount << " out of: " << libraryCount << " library implementations." << std::endl;
-        // TODO: Add a CHECK when all implementations have been tested using unit tests.
-        // CHECK(implementationUseCount == libraryCount);
+        CHECK(implementationUseCount == libraryCount);
     }
 }
 

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -1041,7 +1041,7 @@ void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidT
             "geomattrvalue_integer", "geomattrvalue_boolean", "geomattrvalue_string", "constant_matrix33", "add_matrix33FA",
             "add_matrix33", "subtract_matrix33FA", "subtract_matrix33", "multiply_matrix33", "divide_matrix33", "invert_matrix33",
             "transpose_matrix33", "transformvector_vector3M", "transformnormal_vector3M", "transformpoint_vector3M",
-            "determinant_matrix33"
+            "determinant_matrix33", "IM_dot_"
         };
         const std::string OSL_STRING("osl");
         const std::string GEN_OSL_STRING(mx::OslShaderGenerator::LANGUAGE);

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -1041,7 +1041,7 @@ void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidT
             "geomattrvalue_integer", "geomattrvalue_boolean", "geomattrvalue_string", "constant_matrix33", "add_matrix33FA",
             "add_matrix33", "subtract_matrix33FA", "subtract_matrix33", "multiply_matrix33", "divide_matrix33", "invert_matrix33",
             "transpose_matrix33", "transformvector_vector3M", "transformnormal_vector3M", "transformpoint_vector3M",
-            "determinant_matrix33", "IM_dot_"
+            "determinant_matrix33", "IM_dot_", "IM_constant_string_", "IM_constant_filename_"
         };
         const std::string OSL_STRING("osl");
         const std::string GEN_OSL_STRING(mx::OslShaderGenerator::LANGUAGE);


### PR DESCRIPTION
- Add more whitelisting for nodes like "dot", and string/filename constants
- Fix up some PBR library implementations:
   - Add in missing surface and surface_shader tests
   - Remove obsolete conicaledf implementation reference.

 