### PR TITLE
Reverted the removal of option targetColorSpaceOverride

### DIFF
--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -1,6 +1,8 @@
 #ifndef MATERIALX_GENOPTIONS_H
 #define MATERIALX_GENOPTIONS_H
 
+#include <MaterialXCore/Library.h>
+
 namespace MaterialX
 {
 
@@ -42,6 +44,11 @@ class GenOptions
     /// code fragments will be generated for the shader and
     /// the surface will be fully opaque.
     bool hwTransparency;
+
+    /// An optional override for the target color space.
+    /// Shader fragments will be generated to transform
+    /// input values and textures into this color space.
+    string targetColorSpaceOverride;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -603,7 +603,8 @@ ShaderNode* ShaderGraph::addNode(const Node& node, ShaderGenerator& shadergen, c
     }
 
     ColorManagementSystemPtr colorManagementSystem = shadergen.getColorManagementSystem();
-    const string& targetColorSpace =_document->getActiveColorSpace();
+    const string& targetColorSpace = options.targetColorSpaceOverride.empty() ?
+        _document->getActiveColorSpace() : options.targetColorSpaceOverride;
 
     if (colorManagementSystem && !targetColorSpace.empty())
     {


### PR DESCRIPTION
Reverted the change to remove the targetColorSpaceOverride option, since it's used by the MaterialXView project.