### PR TITLE
Matrix33 OSL variable output fix

### DIFF
--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -192,6 +192,7 @@ namespace
 
         string getValue(const Value& value, bool uniform) const
         {   
+            Value::ScopedFloatFormatting fmt(Value::FloatFormatFixed, 3);
             vector<string> values = splitString(value.getValueString(), ",");
             return getValue(values, uniform);
         }
@@ -210,12 +211,12 @@ namespace
             for (size_t i = 0; i<values.size(); i++)
             {
                 ss << values[i] << ", ";
-                if (i % 3 == 0)
+                if ((i != 0) && (i % 3 == 0))
                 {
-                    ss << "0.0" << ", ";
+                    ss << "0.000" << ", ";
                 }
             }
-            static string ROW_4("0.0, 0.0, 0.0, 1.0");
+            static string ROW_4("0.000, 0.000, 0.000, 0.000, 1.000");
             ss << ROW_4 << ")";
 
             return ss.str();

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -520,7 +520,7 @@ bool elementRequiresShading(const TypedElementPtr element)
             colorClosures.count(elementType) > 0);
 }
 
-void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>& elements)
+void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>& elements, bool includeReferencedGraphs)
 {
     std::vector<NodeGraphPtr> nodeGraphs = doc->getNodeGraphs();
     std::vector<OutputPtr> outputList = doc->getOutputs();
@@ -549,12 +549,15 @@ void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>
                     }
 
                     // Find all bindinputs which reference outputs and outputgraphs
-                    for (auto bindInput : shaderRef->getBindInputs())
+                    if (!includeReferencedGraphs)
                     {
-                        OutputPtr outputPtr = bindInput->getConnectedOutput();
-                        if (outputPtr)
+                        for (auto bindInput : shaderRef->getBindInputs())
                         {
-                            shaderrefOutputs.insert(outputPtr);
+                            OutputPtr outputPtr = bindInput->getConnectedOutput();
+                            if (outputPtr)
+                            {
+                                shaderrefOutputs.insert(outputPtr);
+                            }
                         }
                     }
                 }
@@ -576,7 +579,7 @@ void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>
                     // For now we skip any outputs which are referenced elsewhere.
                     if (outputNode && 
                         outputNode->getType() != LIGHT_SHADER &&
-                        shaderrefOutputs.count(output) == 0)
+                        (!includeReferencedGraphs && shaderrefOutputs.count(output) == 0))
                     {                        
                         NodeDefPtr nodeDef = outputNode->getNodeDef();
                         if (!nodeDef)

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -62,7 +62,8 @@ bool elementRequiresShading(const TypedElementPtr element);
 /// Find any elements which may be renderable from within a document.
 /// This includes all outputs on node graphs and shader references which are not
 /// part of any included library. Light shaders are not considered to be renderable.
-void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>& elements);
+/// The option to include node graphs referened by shader references is disabled by default.
+void findRenderableElements(const DocumentPtr& doc, std::vector<TypedElementPtr>& elements, bool includeReferencedGraphs=false);
 
 /// Given a path to a element, find the corresponding element with the same name
 /// on an associated nodedef if it exists. A target string should be provided


### PR DESCRIPTION
- Fix for matrix33 as matrix output for OSL. Was inserting a 0.0 in the incorrect place. Also fixed up precision for output.
- Add in option to consider graphs connected to shader refers as renderable as an option as it's good for debugging inputs.