### PR TITLE
Disallow generating / using shader names which are invalid for OSL.

### DIFF
--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -204,7 +204,7 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
     }
 
     // Emit shader name
-    shader.addStr(shader.getName() + "\n");
+    shader.addStr(createValidName(shader.getName(), '_') + "\n");
 
     shader.beginScope(Shader::Brackets::PARENTHESES);
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -204,7 +204,7 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
     }
 
     // Emit shader name
-    shader.addStr(createValidName(shader.getName(), '_') + "\n");
+    shader.addStr(createValidName(shader.getName()) + "\n");
 
     shader.beginScope(Shader::Brackets::PARENTHESES);
 

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -1521,6 +1521,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
                 if (nodeDef)
                 {
                     mx::string elementName = mx::replaceSubstrings(element->getNamePath(), pathMap);
+                    elementName = mx::createValidName(elementName);
 #ifdef MATERIALX_BUILD_GEN_GLSL
                     if (options.runGLSLTests)
                     {


### PR DESCRIPTION
- Make sure to use valid root shader name for OSL and generating corresponding consistent source files 
names to use for setting up scene files for testrender.
- Note that  GLSL generation always uses the name "main" as the root function so it's okay there.