### PR TITLE
Add relative path support for include files, images handlers and testrender scenes

### DIFF
--- a/documents/TestSuite/Utilities/closure_color_scene.xml
+++ b/documents/TestSuite/Utilities/closure_color_scene.xml
@@ -26,12 +26,14 @@
    <Quad corner="-100,100,0" edge_x="0,0,200" edge_y="200,0,0" is_light="yes"/>
 
    <!-- Shader graph for routing to output layer:
+   input_shader_parameter_overrides : are parameter overrides for the input shader
    %input_shader_type% : type of an input shader to feed into the output shader.
    %input_shader_output% : name of output argument on input shader.
    %output_shader_type%: type of the output shader used to render with
    %output_shader_input% : name of input argument on output shader.
    -->
    <ShaderGroup>
+      %input_shader_parameter_overrides%;
       shader %input_shader_type% inputShader;
       shader %output_shader_type% outputShader;
       connect inputShader.%input_shader_output% outputShader.%output_shader_input%;

--- a/documents/TestSuite/Utilities/constant_color_scene.xml
+++ b/documents/TestSuite/Utilities/constant_color_scene.xml
@@ -13,12 +13,14 @@
    <Background resolution="1024" />
    -->
    <!-- Shader graph for routing to output layer:
+   input_shader_parameter_overrides : are parameter overrides for the input shader
    %input_shader_type% : type of an input shader to feed into the output shader.
    %input_shader_output% : name of output argument on input shader.
    %output_shader_type%: type of the output shader used to render with
    %output_shader_input% : name of input argument on output shader.
    -->
    <ShaderGroup>
+      %input_shader_parameter_overrides%
       shader %input_shader_type% inputShader;
       shader %output_shader_type% outputShader;
       connect inputShader.%input_shader_output% outputShader.%output_shader_input%;

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -148,6 +148,16 @@ class FileSearchPath
         }
     }
 
+    /// Assign a search path from a standard string .
+    void assign(const string& searchPath, const string& sep = ";")
+    {
+        _paths.clear();
+        for (const string& path : splitString(searchPath, sep))
+        {
+            append(path);
+        }
+    }
+
     /// Append the given path to the sequence.
     void append(const FilePath& path)
     {
@@ -202,6 +212,22 @@ class FileSearchPath
             }
         }
         return filename;
+    }
+
+    /// Convert a path to a standard string.
+    operator string() const
+    {
+        return asString();
+    }
+
+    /// Return this path as a standard string with the given format.
+    string asString(const string& sep = ";") const
+    {
+        string returnString;
+        for (const FilePath& path : _paths)
+        {
+            returnString += path.asString() + sep;
+        }
     }
 
   private:

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -160,12 +160,6 @@ class FileSearchPath
         _paths.insert(_paths.begin(), path);
     }
     
-    /// Remove a given path from the sequence.
-    void remove(const FilePath& path)
-    {
-        std::remove(_paths.begin(), _paths.end(), path);
-    }
-
     /// Return the number of paths in the sequence.
     size_t size() const
     {

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -160,6 +160,12 @@ class FileSearchPath
         _paths.insert(_paths.begin(), path);
     }
     
+    /// Remove a given path from the sequence.
+    void remove(const FilePath& path)
+    {
+        std::remove(_paths.begin(), _paths.end(), path);
+    }
+
     /// Return the number of paths in the sequence.
     size_t size() const
     {

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -148,16 +148,6 @@ class FileSearchPath
         }
     }
 
-    /// Assign a search path from a standard string .
-    void assign(const string& searchPath, const string& sep = ";")
-    {
-        _paths.clear();
-        for (const string& path : splitString(searchPath, sep))
-        {
-            append(path);
-        }
-    }
-
     /// Append the given path to the sequence.
     void append(const FilePath& path)
     {
@@ -212,22 +202,6 @@ class FileSearchPath
             }
         }
         return filename;
-    }
-
-    /// Convert a path to a standard string.
-    operator string() const
-    {
-        return asString();
-    }
-
-    /// Return this path as a standard string with the given format.
-    string asString(const string& sep = ";") const
-    {
-        string returnString;
-        for (const FilePath& path : _paths)
-        {
-            returnString += path.asString() + sep;
-        }
     }
 
   private:

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -204,7 +204,9 @@ ShaderPtr OslShaderGenerator::generate(const string& shaderName, ElementPtr elem
     }
 
     // Emit shader name
-    shader.addStr(createValidName(shader.getName()) + "\n");
+    string emitShaderName = shader.getName();
+    getSyntax()->makeValidName(emitShaderName);
+    shader.addStr(emitShaderName + "\n");
 
     shader.beginScope(Shader::Brackets::PARENTHESES);
 

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -32,6 +32,7 @@ void CompoundNode::initialize(ElementPtr implementation, ShaderGenerator& shader
 
     _rootGraph = ShaderGraph::create(graph, shadergen, compoundOptions);
     _functionName = graph->getName();
+    shadergen.getSyntax()->makeValidName(_functionName);
 }
 
 void CompoundNode::createVariables(const ShaderNode& /*node*/, ShaderGenerator& shadergen, Shader& shader)

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -315,7 +315,9 @@ ShaderGraphPtr ShaderGraph::create(NodeGraphPtr nodeGraph, ShaderGenerator& shad
         throw ExceptionShaderGenError("Can't find nodedef '" + nodeGraph->getNodeDefString() + "' referenced by nodegraph '" + nodeGraph->getName() + "'");
     }
 
-    ShaderGraphPtr graph = std::make_shared<ShaderGraph>(nodeGraph->getName(), nodeGraph->getDocument());
+    string graphName = nodeGraph->getName();
+    shadergen.getSyntax()->makeValidName(graphName);
+    ShaderGraphPtr graph = std::make_shared<ShaderGraph>(graphName, nodeGraph->getDocument());
 
     // Clear classification
     graph->_classification = 0;

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -137,10 +137,8 @@ string Syntax::getSwizzledVariable(const string& srcName, const TypeDesc* srcTyp
 
 void Syntax::makeUnique(string& name, UniqueNameMap& uniqueNames) const
 {
-    if (_invalidTokens.size())
-    {
-        name = replaceSubstrings(name, _invalidTokens);
-    }
+    makeValidName(name);
+
     UniqueNameMap::iterator it = uniqueNames.find(name);
     if (it != uniqueNames.end())
     {
@@ -160,6 +158,19 @@ void Syntax::makeUnique(string& name, UniqueNameMap& uniqueNames) const
     }
 }
 
+static bool isInvalidChar(char c)
+{
+    return !isalnum(c) && c != '_';
+}
+
+void Syntax::makeValidName(string& name) const
+{
+    std::replace_if(name.begin(), name.end(), isInvalidChar, '_');
+    if (_invalidTokens.size())
+    {
+        name = replaceSubstrings(name, _invalidTokens);
+    }
+}
 
 const vector<string> TypeSyntax::EMPTY_MEMBERS;
 

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -102,6 +102,9 @@ public:
     /// on the name string if there is a name collision.
     virtual void makeUnique(string& name, UniqueNameMap& uniqueNames) const;
 
+    /// Modify the given name string to remote any invalid characters or tokens.
+    virtual void makeValidName(string& name) const;
+
 protected:
     /// Protected constructor
     Syntax();

--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -53,6 +53,8 @@ bool ImageHandler::saveImage(const std::string& fileName,
 
 bool ImageHandler::acquireImage(const FilePath& fileName, ImageDesc &imageDesc, bool generateMipMaps, const std::array<float, 4>* /*fallbackColor*/)
 {
+    FilePath filePath = findFile(fileName);
+
     std::pair <ImageLoaderMap::iterator, ImageLoaderMap::iterator> range;
     string extension = MaterialX::getFileExtension(fileName);
     range = _imageLoaders.equal_range(extension);
@@ -60,7 +62,7 @@ bool ImageHandler::acquireImage(const FilePath& fileName, ImageDesc &imageDesc, 
     ImageLoaderMap::iterator last= --range.first;
     for (auto it = first; it != last; --it)
     {
-        bool acquired = it->second->acquireImage(fileName, imageDesc, generateMipMaps);
+        bool acquired = it->second->acquireImage(filePath, imageDesc, generateMipMaps);
         if (acquired)
         {
             return true;

--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -33,6 +33,8 @@ void ImageHandler::addLoader(ImageLoaderPtr loader)
 bool ImageHandler::saveImage(const std::string& fileName,
                             const ImageDesc &imageDesc)
 {
+    FilePath filePath = findFile(fileName);
+
     std::pair <ImageLoaderMap::iterator, ImageLoaderMap::iterator> range;
     string extension = MaterialX::getFileExtension(fileName);
     range = _imageLoaders.equal_range(extension);
@@ -40,7 +42,7 @@ bool ImageHandler::saveImage(const std::string& fileName,
     ImageLoaderMap::iterator last = --range.first;
     for (auto it = first; it != last; --it)
     {
-        bool saved = it->second->saveImage(fileName, imageDesc);
+        bool saved = it->second->saveImage(filePath, imageDesc);
         if (saved)
         {
             return true;
@@ -49,7 +51,7 @@ bool ImageHandler::saveImage(const std::string& fileName,
     return false;
 }
 
-bool ImageHandler::acquireImage(const std::string& fileName, ImageDesc &imageDesc, bool generateMipMaps, const std::array<float, 4>* /*fallbackColor*/)
+bool ImageHandler::acquireImage(const FilePath& fileName, ImageDesc &imageDesc, bool generateMipMaps, const std::array<float, 4>* /*fallbackColor*/)
 {
     std::pair <ImageLoaderMap::iterator, ImageLoaderMap::iterator> range;
     string extension = MaterialX::getFileExtension(fileName);
@@ -109,5 +111,22 @@ const ImageDesc* ImageHandler::getCachedImage(const std::string& identifier)
     }
     return nullptr;
 }
+
+
+void ImageHandler::addSearchPath(const FilePath& path)
+{
+    _searchPath.append(path);
+}
+
+void ImageHandler::removeSearchPath(const FilePath& path)
+{
+    _searchPath.remove(path);
+}
+
+FilePath ImageHandler::findFile(const FilePath& filename)
+{
+    return _searchPath.find(filename);
+}
+
 
 }

--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -112,15 +112,9 @@ const ImageDesc* ImageHandler::getCachedImage(const std::string& identifier)
     return nullptr;
 }
 
-
-void ImageHandler::addSearchPath(const FilePath& path)
+void ImageHandler::setSearchPath(const FileSearchPath& path)
 {
-    _searchPath.append(path);
-}
-
-void ImageHandler::removeSearchPath(const FilePath& path)
-{
-    _searchPath.remove(path);
+    _searchPath = path;
 }
 
 FilePath ImageHandler::findFile(const FilePath& filename)

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -178,11 +178,8 @@ class ImageHandler
         _imageCache.clear();
     }
 
-    /// Add to the search path used for finding image files.
-    void addSearchPath(const FilePath& path);
-
-    /// Remove from the search path used for finding image files.
-    void removeSearchPath(const FilePath& path);
+    /// Set to the search path used for finding image files.
+    void setSearchPath(const FileSearchPath& path);
 
     /// Resolve a filename using the registered search paths.
     FilePath findFile(const FilePath& filename);

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -10,6 +10,8 @@
 #include <map>
 #include <array>
 
+#include <MaterialXFormat/File.h>
+
 namespace MaterialX
 {
 /// @class @ImageDesc
@@ -152,7 +154,7 @@ class ImageHandler
     /// @param fallbackColor Color of fallback image to use if failed to load.  If null is specified then
     /// no fallback image will be acquired.
     /// @return if load succeeded in loading image or created fallback image.
-    virtual bool acquireImage(const std::string& fileName, ImageDesc& desc, bool generateMipMaps, const std::array<float, 4>* fallbackColor);
+    virtual bool acquireImage(const FilePath& fileName, ImageDesc& desc, bool generateMipMaps, const std::array<float, 4>* fallbackColor);
 
     /// Utility to create a solid color color image 
     /// @param color Color to set
@@ -174,6 +176,21 @@ class ImageHandler
     virtual void clearImageCache()
     {
         _imageCache.clear();
+    }
+
+    /// Add to the search path used for finding image files.
+    void addSearchPath(const FilePath& path);
+
+    /// Remove from the search path used for finding image files.
+    void removeSearchPath(const FilePath& path);
+
+    /// Resolve a filename using the registered search paths.
+    FilePath findFile(const FilePath& filename);
+
+    /// Get the image search path
+    const FileSearchPath& searchPath()
+    {
+        return _searchPath;
     }
 
   protected:
@@ -207,6 +224,9 @@ class ImageHandler
     ImageLoaderMap _imageLoaders;
     /// Image description cache
     ImageDescCache _imageCache;
+
+    /// Filename search path
+    FileSearchPath _searchPath;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRender/OpenGL/GLTextureHandler.cpp
+++ b/source/MaterialXRender/OpenGL/GLTextureHandler.cpp
@@ -29,12 +29,12 @@ bool GLTextureHandler::createColorImage(const std::array<float,4>& color,
     return false;
 }
 
-bool GLTextureHandler::acquireImage(const std::string& fileName,
+bool GLTextureHandler::acquireImage(const FilePath& fileName,
                                     ImageDesc &imageDesc,
                                     bool generateMipMaps,
                                     const std::array<float,4>* fallbackColor)
 {
-    if (fileName.empty())
+    if (fileName.isEmpty())
     {
         return false;
     }

--- a/source/MaterialXRender/OpenGL/GLTextureHandler.h
+++ b/source/MaterialXRender/OpenGL/GLTextureHandler.h
@@ -52,7 +52,7 @@ class GLTextureHandler : public ImageHandler
     /// @param fallbackColor Color of fallback image to use if failed to load.  If null is specified then
     /// no fallback image will be acquired.
     /// @return if load succeeded in loading image or created fallback image.
-    bool acquireImage(const std::string& fileName, ImageDesc &imageDesc, bool generatateMipMaps, const std::array<float,4>* fallbackColor) override;
+    bool acquireImage(const FilePath& fileName, ImageDesc &imageDesc, bool generatateMipMaps, const std::array<float,4>* fallbackColor) override;
 
     /// Bind an image. This method will bind the texture to an active texture
     /// unit as defined by the corresponding image description. The method

--- a/source/MaterialXRender/OpenGL/GlslProgram.cpp
+++ b/source/MaterialXRender/OpenGL/GlslProgram.cpp
@@ -520,7 +520,7 @@ void GlslProgram::unbindTextures(ImageHandlerPtr imageHandler)
     checkErrors();
 }
 
-bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, const string& fileName,
+bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& fileName,
                               ImageHandlerPtr imageHandler, bool generateMipMaps,
                               const ImageSamplingProperties& samplingProperties)
 {
@@ -529,14 +529,13 @@ bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, con
         uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
     {
         ImageDesc imageDesc;
-        string identifier(fileName);
-        bool haveImage = imageHandler->acquireImage(identifier, imageDesc, generateMipMaps, &(samplingProperties.defaultColor));
+        bool haveImage = imageHandler->acquireImage(fileName, imageDesc, generateMipMaps, &(samplingProperties.defaultColor));
 
         if (haveImage)
         {
             // Map location to a texture unit
             glUniform1i(uniformLocation, imageDesc.resourceId);
-            textureBound = imageHandler->bindImage(identifier, samplingProperties);
+            textureBound = imageHandler->bindImage(fileName, samplingProperties);
         }
         checkErrors();
     }

--- a/source/MaterialXRender/OpenGL/GlslProgram.h
+++ b/source/MaterialXRender/OpenGL/GlslProgram.h
@@ -223,7 +223,7 @@ class GlslProgram
     /// @{
 
     /// Bind an individual texture to a program uniform location
-    bool bindTexture(unsigned int uniformType, int uniformLocation, const string& fileName,
+    bool bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& fileName,
                      ImageHandlerPtr imageHandler, bool generateMipMaps, const ImageSamplingProperties& imageProperties);
 
     /// Utility to check for OpenGL context errors.

--- a/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
@@ -105,6 +105,7 @@ void OslValidator::renderOSL(const string& outputPath, const string& shaderName,
     const string OUTPUT_SHADER_INPUT_STRING("%output_shader_input%");
     const string OUTPUT_SHADER_INPUT_VALUE_STRING("Cin");
     const string INPUT_SHADER_TYPE_STRING("%input_shader_type%");
+    const string INPUT_SHADER_PARAMETER_OVERRIDES("%input_shader_parameter_overrides%");
     const string INPUT_SHADER_OUTPUT_STRING("%input_shader_output%");
     const string BACKGROUND_COLOR_STRING("%background_color%");
     const string backgroundColor("0.0 0.0 0.0"); // TODO: Make this a user input
@@ -113,6 +114,12 @@ void OslValidator::renderOSL(const string& outputPath, const string& shaderName,
     replacementMap[OUTPUT_SHADER_TYPE_STRING] = outputShader;
     replacementMap[OUTPUT_SHADER_INPUT_STRING] = OUTPUT_SHADER_INPUT_VALUE_STRING;
     replacementMap[INPUT_SHADER_TYPE_STRING] = shaderName;
+    string overrideString;
+    for (auto param : _oslShaderParameterOverrides)
+    {
+        overrideString.append(param);
+    }
+    replacementMap[INPUT_SHADER_PARAMETER_OVERRIDES] = overrideString;
     replacementMap[INPUT_SHADER_OUTPUT_STRING] = outputName;
     replacementMap[BACKGROUND_COLOR_STRING] = backgroundColor;
     string sceneString = replaceSubstrings(sceneTemplateString, replacementMap);
@@ -148,6 +155,8 @@ void OslValidator::renderOSL(const string& outputPath, const string& shaderName,
         command += " -aa 4 "; // Images are very noisy without anti-aliasing
     }
     command += " > " + errorFile + redirectString;
+
+    std::cout << command << std::endl;
 
     int returnValue = std::system(command.c_str());
 
@@ -249,6 +258,8 @@ void OslValidator::compileOSL(const string& oslFileName)
         errorFile + redirectString;
 
     int returnValue = std::system(command.c_str());
+
+    std::cout << command << std::endl;
 
     std::ifstream errorStream(errorFile);
     string result;

--- a/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
+++ b/source/MaterialXRender/ShaderValidators/Osl/OslValidator.cpp
@@ -156,8 +156,6 @@ void OslValidator::renderOSL(const string& outputPath, const string& shaderName,
     }
     command += " > " + errorFile + redirectString;
 
-    std::cout << command << std::endl;
-
     int returnValue = std::system(command.c_str());
 
     std::ifstream errorStream(errorFile);
@@ -258,8 +256,6 @@ void OslValidator::compileOSL(const string& oslFileName)
         errorFile + redirectString;
 
     int returnValue = std::system(command.c_str());
-
-    std::cout << command << std::endl;
 
     std::ifstream errorStream(errorFile);
     string result;

--- a/source/MaterialXRender/ShaderValidators/Osl/OslValidator.h
+++ b/source/MaterialXRender/ShaderValidators/Osl/OslValidator.h
@@ -119,6 +119,13 @@ class OslValidator : public ShaderValidator
         _oslOutputFilePathString = filePathString;
     }
 
+    /// Set shader parameter strings to be added to the scene XML file. These
+    /// strings will set parameter overrides for the shader.
+    void setShaderParameterOverrides(const StringVec& parameterOverrides)
+    {
+        _oslShaderParameterOverrides = parameterOverrides;
+    }
+
     /// Set the OSL shader output. 
     /// This is used during render validation if "testshade" or "testrender" is executed.
     /// For testrender this value is used to replace the %shader_output% token in the
@@ -222,6 +229,8 @@ class OslValidator : public ShaderValidator
     string _oslTestRenderSceneTemplateFile;
     /// Name of shader. Used for rendering with "testrender"
     string _oslShaderName;
+    /// Set of strings containing parameter override settings for "testrender"
+    StringVec _oslShaderParameterOverrides;
     /// Name of output on the shader. Used for rendering with "testshade" and "testrender"
     string _oslShaderOutputName;
     /// MaterialX type of the output on the shader. Used for rendering with "testshade" and "testrender"

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -890,7 +890,11 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
                             filename = imageSearchPath.find(uniform->value->getValueString());
                         }
                         
-                        std::string overrideString("string " + uniformName + " \"" + filename.asString(mx::FilePath::FormatPosix) + "\";\n");
+                        std::string overrideString("string " + uniformName + " \"" + filename.asString() + "\";\n");
+                        mx::StringMap mapper;
+                        mapper["\\\\"] = "/";
+                        mapper["\\"] = "/";
+                        overrideString = mx::replaceSubstrings(overrideString, mapper);
                         overrides.push_back(overrideString);
                         std::cout << overrideString;
                     }

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -1437,7 +1437,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
             const std::string filename = filePath;
 
             mx::DocumentPtr doc = mx::createDocument();
-            readFromXmlFile(doc, filename);
+            mx::readFromXmlFile(doc, filename, dir);
 
             if (options.cmsFiles.size() && options.cmsFiles.count(file))
             {

--- a/source/MaterialXTest/ShaderValid.cpp
+++ b/source/MaterialXTest/ShaderValid.cpp
@@ -419,8 +419,9 @@ void getGenerationOptions(const ShaderValidTestOptions& testOptions, std::vector
 
 #ifdef MATERIALX_BUILD_GEN_OGSFX
 static void runOGSFXValidation(const std::string& shaderName, mx::TypedElementPtr element,
-    mx::OgsFxShaderGenerator& shaderGenerator, const mx::HwLightHandlerPtr lightHandler, mx::DocumentPtr doc,
-    std::ostream& log, const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, const std::string& outputPath = ".")
+                                mx::OgsFxShaderGenerator& shaderGenerator, const mx::HwLightHandlerPtr lightHandler, mx::DocumentPtr doc,
+                                std::ostream& log, const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, 
+                                const std::string& outputPath = ".")
 {
     AdditiveScopedTimer totalOgsFXTime(profileTimes.ogsfxTimes.totalTime, "OGSFX total time");
 
@@ -524,7 +525,8 @@ static void runOGSFXValidation(const std::string& shaderName, mx::TypedElementPt
 //
 static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr element, mx::GlslValidator& validator,
                               mx::GlslShaderGenerator& shaderGenerator, const mx::HwLightHandlerPtr lightHandler, mx::DocumentPtr doc,
-                              std::ostream& log, const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, const std::string& outputPath=".")
+                              std::ostream& log, const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, 
+                              const mx::FileSearchPath& imageSearchPath, const std::string& outputPath=".")
 {
     AdditiveScopedTimer totalGLSLTime(profileTimes.glslTimes.totalTime, "GLSL total time");
 
@@ -737,6 +739,7 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
                 {
                     {
                         AdditiveScopedTimer renderTimer(profileTimes.glslTimes.renderTime, "GLSL render time");
+                        validator.getImageHandler()->setSearchPath(imageSearchPath);
                         validator.validateRender(!isShader);
                     }
 
@@ -776,7 +779,8 @@ static void runGLSLValidation(const std::string& shaderName, mx::TypedElementPtr
 #ifdef MATERIALX_BUILD_GEN_OSL
 static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr element, mx::OslValidator& validator,
                              mx::OslShaderGenerator& shaderGenerator, mx::DocumentPtr doc, std::ostream& log,
-                             const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, const std::string& outputPath=".")
+                             const ShaderValidTestOptions& testOptions, ShaderValidProfileTimes& profileTimes, 
+                             const mx::FileSearchPath& imageSearchPath, const std::string& outputPath=".")
 {
     AdditiveScopedTimer totalOSLTime(profileTimes.oslTimes.totalTime, "OSL total time");
 
@@ -868,6 +872,30 @@ static void runOSLValidation(const std::string& shaderName, mx::TypedElementPtr 
 
                 if (testOptions.renderImages)
                 {
+                    // Look for textures and build parameter a override string for image
+                    // files.
+                    const mx::Shader::VariableBlock publicUniforms = 
+                        shader->getUniformBlock(mx::Shader::PIXEL_STAGE, mx::Shader::PUBLIC_UNIFORMS);
+                    mx::StringVec overrides;
+                    for (auto uniform : publicUniforms.variableOrder)
+                    {
+                        if (uniform->type != MaterialX::Type::FILENAME)
+                        {
+                            continue;
+                        }
+                        const std::string& uniformName = uniform->name;
+                        mx::FilePath filename;
+                        if (uniform->value)
+                        {
+                            filename = imageSearchPath.find(uniform->value->getValueString());
+                        }
+                        
+                        std::string overrideString("string " + uniformName + " \"" + filename.asString(mx::FilePath::FormatPosix) + "\";\n");
+                        overrides.push_back(overrideString);
+                        std::cout << overrideString;
+                    }
+                    validator.setShaderParameterOverrides(overrides);
+
                     if (shader->getOutputBlock().size() > 0)
                     {
                         const mx::Shader::Variable* output = shader->getOutputBlock()[0];
@@ -1505,6 +1533,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
             renderableSearchTimer.endTimer();
 
             std::string outputPath = mx::FilePath(dir) / mx::FilePath(mx::removeExtension(file));
+            mx::FileSearchPath imageSearchPath(dir);
             for (auto element : elements)
             {
                 mx::OutputPtr output = element->asA<mx::Output>();
@@ -1536,7 +1565,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
                                 mx::InterfaceElementPtr nodeGraphImpl = nodeGraph ? nodeGraph->getImplementation() : nullptr;
                                 usedImpls.insert(nodeGraphImpl ? nodeGraphImpl->getName() : impl->getName());
                             }
-                            runGLSLValidation(elementName, element, *glslValidator, *glslShaderGenerator, glslLightHandler, doc, glslLog, options, profileTimes, outputPath);
+                            runGLSLValidation(elementName, element, *glslValidator, *glslShaderGenerator, glslLightHandler, doc, glslLog, options, profileTimes, imageSearchPath, outputPath);
                         }
                     }
 #endif
@@ -1572,7 +1601,7 @@ TEST_CASE("MaterialX documents", "[shadervalid]")
                                 mx::InterfaceElementPtr nodeGraphImpl = nodeGraph ? nodeGraph->getImplementation() : nullptr;
                                 usedImpls.insert(nodeGraphImpl ? nodeGraphImpl->getName() : impl2->getName());
                             }
-                            runOSLValidation(elementName, element, *oslValidator, *oslShaderGenerator, doc, oslLog, options, profileTimes, outputPath);
+                            runOSLValidation(elementName, element, *oslValidator, *oslShaderGenerator, doc, oslLog, options, profileTimes, imageSearchPath, outputPath);
                         }
                     }
 #endif


### PR DESCRIPTION
- Allow for image handler to have search paths 
- Allow for XML scene template to accept parameter overrides 
- During shader validation 
-- When reading input document, also include search path for exec + current doc path.
-- The image handler for GLSL has search paths added. For now it's the exec path + the path of the materialx file. For app integration any paths can be added.
-- The Shader is parsed to find filepaths and if relative will be converted to absolute paths and added as parameter overrides during XML scene instantiation from template.
