### PR TITLE
Fix pbrlib xml copyright notices.

### DIFF
--- a/documents/Libraries/pbrlib/pbrlib_defs.mtlx
+++ b/documents/Libraries/pbrlib/pbrlib_defs.mtlx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
   All rights reserved.  See LICENSE.txt for license.
@@ -5,7 +6,6 @@
   Declarations of standard data types and nodes included in the MaterialX specification.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <materialx version="1.36">
 
   <!-- D A T A  T Y P E S -->

--- a/documents/Libraries/pbrlib/pbrlib_ng.mtlx
+++ b/documents/Libraries/pbrlib/pbrlib_ng.mtlx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
   All rights reserved.  See LICENSE.txt for license.
@@ -5,7 +6,6 @@
   Declarations of standard data types and nodes included in the MaterialX specification.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <materialx version="1.36">
   <!-- <glossiness_anisotropy> -->
   <nodegraph name="IMP_glossiness_anisotropy" nodedef="ND_glossiness_anisotropy">


### PR DESCRIPTION
Move copyright noticed after <?xml> tag so that the doc is valid.
