### PR TITLE
Render module cleanup

### DIFF
--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
@@ -14,7 +14,7 @@ namespace MaterialX
 namespace
 {
     // Semantics used by OgsFx
-    static const std::unordered_map<string,string> OGSFX_DEFAULT_SEMANTICS_MAP =
+    static const StringMap OGSFX_DEFAULT_SEMANTICS_MAP =
     {
         { "i_position", "POSITION"},
         { "i_normal", "NORMAL" },
@@ -58,7 +58,7 @@ namespace
         { "u_time", "Time" }
     };
 
-    static const std::unordered_map<string, string> OGSFX_GET_LIGHT_DATA_MAP =
+    static const StringMap OGSFX_GET_LIGHT_DATA_MAP =
     {
         { "type", "mx_getLightType" },
         { "position", "mx_getLightPos" },

--- a/source/MaterialXGenOgsFx/OgsFxSyntax.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxSyntax.cpp
@@ -22,7 +22,7 @@ namespace
     public:
         OgsFxAggregateTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
             const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
-            const vector<string>& members = EMPTY_MEMBERS)
+            const StringVec& members = EMPTY_MEMBERS)
             : AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
         {}
 
@@ -38,7 +38,7 @@ namespace
             }
         }
 
-        string getValue(const vector<string>& values, bool uniform) const override
+        string getValue(const StringVec& values, bool uniform) const override
         {
             if (values.empty())
             {

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -571,7 +571,7 @@ bool requiresImplementation(const NodeDefPtr nodeDef)
 bool elementRequiresShading(const TypedElementPtr element)
 {
     string elementType(element->getType());
-    static std::set<string> colorClosures =
+    static StringSet colorClosures =
     {
         "surfaceshader", "volumeshader", "lightshader",
         "BSDF", "EDF", "VDF"

--- a/source/MaterialXRender/Handlers/GeometryHandler.h
+++ b/source/MaterialXRender/Handlers/GeometryHandler.h
@@ -30,7 +30,7 @@ class GeometryLoader
 
     /// Returns a list of supported extensions
     /// @return List of support extensions
-    const vector<string>& supportedExtensions()
+    const StringVec& supportedExtensions()
     {
         return _extensions;
     }

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -93,7 +93,7 @@ class ImageLoader
 
     /// Returns a list of supported extensions
     /// @return List of support extensions
-    const std::vector<std::string>& supportedExtensions()
+    const StringVec& supportedExtensions()
     {
         return _extensions;
     }
@@ -114,7 +114,7 @@ class ImageLoader
 
   protected:
     /// List of supported string extensions
-    std::vector<std::string> _extensions;
+    StringVec _extensions;
 };
 
 /// Shared pointer to an ImageHandler

--- a/source/MaterialXRender/Handlers/SampleObjLoader.cpp
+++ b/source/MaterialXRender/Handlers/SampleObjLoader.cpp
@@ -3,7 +3,7 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
-#include <MaterialXRender/Handlers/TestObjLoader.h>
+#include <MaterialXRender/Handlers/SampleObjLoader.h>
 #include <MaterialXCore/Util.h>
 
 #include <iostream>
@@ -15,7 +15,7 @@
 
 namespace MaterialX
 { 
-bool TestObjLoader::load(const std::string& fileName, MeshList& meshList)
+bool SampleObjLoader::load(const std::string& fileName, MeshList& meshList)
 {
     std::ifstream objfile;
     objfile.open(fileName);
@@ -155,7 +155,7 @@ bool TestObjLoader::load(const std::string& fileName, MeshList& meshList)
             {
                 if (vertices[i].size())
                 {
-                    std::vector<string> vertexParts = MaterialX::splitString(vertices[i], "/");
+                    StringVec vertexParts = MaterialX::splitString(vertices[i], "/");
                     if (vertexParts.size() == 3)
                     {
                         ipos[i] = std::stoi(vertexParts[0]);

--- a/source/MaterialXRender/Handlers/SampleObjLoader.h
+++ b/source/MaterialXRender/Handlers/SampleObjLoader.h
@@ -3,8 +3,8 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
-#ifndef MATERIALX_TESTOBJLOADER_H
-#define MATERIALX_TESTOBJLOADER_H
+#ifndef MATERIALX_SAMPLEOBJLOADER_H
+#define MATERIALX_SAMPLETOBJLOADER_H
 
 #include <string>
 #include <memory>
@@ -12,20 +12,20 @@
 
 namespace MaterialX
 {
-/// Shared pointer to an TestObjLoader
-using TestObjLoaderPtr = std::shared_ptr<class TestObjLoader>;
+/// Shared pointer to an SampleObjLoader
+using SampleObjLoaderPtr = std::shared_ptr<class SampleObjLoader>;
 
 /// @class TestObjHandler
 /// Utility geometry loader to read in OBJ files for unit testing.
 ///
-class TestObjLoader : public GeometryLoader
+class SampleObjLoader : public GeometryLoader
 {
   public:
     /// Static instance create function
-    static TestObjLoaderPtr create() { return std::make_shared<TestObjLoader>(); }
+    static SampleObjLoaderPtr create() { return std::make_shared<SampleObjLoader>(); }
 
     /// Default constructor
-    TestObjLoader() :
+    SampleObjLoader() :
         _readGroups(true),
         _debugDump(false)
     {
@@ -33,7 +33,7 @@ class TestObjLoader : public GeometryLoader
     }
     
     /// Default destructor
-    virtual ~TestObjLoader() {}
+    virtual ~SampleObjLoader() {}
 
     /// Load geometry from disk
     bool load(const std::string& fileName, MeshList& meshList) override;

--- a/source/MaterialXRender/Handlers/SampleObjLoader.h
+++ b/source/MaterialXRender/Handlers/SampleObjLoader.h
@@ -4,7 +4,7 @@
 //
 
 #ifndef MATERIALX_SAMPLEOBJLOADER_H
-#define MATERIALX_SAMPLETOBJLOADER_H
+#define MATERIALX_SAMPLEOBJLOADER_H
 
 #include <string>
 #include <memory>
@@ -15,7 +15,7 @@ namespace MaterialX
 /// Shared pointer to an SampleObjLoader
 using SampleObjLoaderPtr = std::shared_ptr<class SampleObjLoader>;
 
-/// @class TestObjHandler
+/// @class SampleObjLoader
 /// Utility geometry loader to read in OBJ files for unit testing.
 ///
 class SampleObjLoader : public GeometryLoader

--- a/source/MaterialXRender/ShaderValidators/ExceptionShaderValidationError.h
+++ b/source/MaterialXRender/ShaderValidators/ExceptionShaderValidationError.h
@@ -12,7 +12,7 @@ namespace MaterialX
 {
 
 /// Error string list type
-using ShaderValidationErrorList = vector<string>;
+using ShaderValidationErrorList = StringVec;
 
 /// @class @ExceptionShaderValidationError
 /// An exception that is thrown when shader validation fails.

--- a/source/MaterialXRender/ShaderValidators/ShaderValidator.h
+++ b/source/MaterialXRender/ShaderValidators/ShaderValidator.h
@@ -27,7 +27,7 @@ class ShaderValidator
 {
   public:
     /// A map with name and source code for each shader stage.
-    using StageMap = std::unordered_map<string, string>;
+    using StageMap = StringMap;
 
   public:
     /// Destructor

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -887,7 +887,7 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
     // Set world related matrices. World matrix is identity so
     // bind the same matrix to all locations
     //
-    std::vector<std::string> worldMatrixVariables =
+    StringVec worldMatrixVariables =
     {
         "u_worldMatrix",
         "u_worldInverseMatrix",
@@ -909,7 +909,7 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
 
     // Bind projection matrices
     //
-    std::vector<std::string> projectionMatrixVariables =
+    StringVec projectionMatrixVariables =
     {
         "u_projectionMatrix",
         "u_projectionTransposeMatrix",
@@ -944,7 +944,7 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
     }
 
     // Bind view related matrices
-    std::vector<std::string> viewMatrixVariables =
+    StringVec viewMatrixVariables =
     {
         "u_viewMatrix",
         "u_viewTransposeMatrix",
@@ -979,7 +979,7 @@ void GlslProgram::bindViewInformation(ViewHandlerPtr viewHandler)
     }
 
     // Bind combined matrices
-    std::vector<std::string> combinedMatrixVariables =
+    StringVec combinedMatrixVariables =
     {
         "u_viewProjectionMatrix",
         "u_worldViewProjectionMatrix"

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -246,7 +246,7 @@ class GlslProgram
   private:
     /// Stages used to create program
     /// Map of stage name and its source code
-    std::unordered_map<string, string> _stages;
+      StringMap _stages;
 
     /// Generated program. A non-zero number indicates a valid shader program.
     unsigned int _programId;

--- a/source/MaterialXRenderGlsl/GlslValidator.cpp
+++ b/source/MaterialXRenderGlsl/GlslValidator.cpp
@@ -6,7 +6,7 @@
 #include <MaterialXRenderGlsl/External/GLew/glew.h>
 #include <MaterialXRenderGlsl/GlslValidator.h>
 #include <MaterialXRender/Handlers/GeometryHandler.h>
-#include <MaterialXRender/Handlers/TestObjLoader.h>
+#include <MaterialXRender/Handlers/SampleObjLoader.h>
 
 #include <iostream>
 #include <algorithm>
@@ -42,7 +42,7 @@ GlslValidator::GlslValidator() :
 {
     _program = GlslProgram::create();
 
-    TestObjLoaderPtr loader = TestObjLoader::create();
+    SampleObjLoaderPtr loader = SampleObjLoader::create();
     _geometryHandler.addLoader(loader);
 
     _viewHandler = ViewHandler::create();

--- a/source/MaterialXRenderOsl/OslValidator.cpp
+++ b/source/MaterialXRenderOsl/OslValidator.cpp
@@ -211,7 +211,7 @@ void OslValidator::shadeOSL(const string& outputPath, const string& shaderName, 
     // The formatted string is "Output <outputName> to <outputFileName>".
     std::ifstream errorStream(errorFile);
     string result;
-    std::vector<string> results;
+    StringVec results;
     string line;
     string successfulOutputSubString("Output " + outputName + " to " +
                                            outputFileName);

--- a/source/MaterialXTest/File.cpp
+++ b/source/MaterialXTest/File.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Syntactic operations", "[file]")
 
 TEST_CASE("File system operations", "[file]")
 {
-    std::vector<std::string> filenames =
+    StringVec filenames =
     {
         "documents/Libraries/stdlib/stdlib_defs.mtlx",
         "documents/Examples/MaterialBasic.mtlx",
@@ -53,7 +53,7 @@ TEST_CASE("File search path operations", "[file]")
                              mx::PATH_LIST_SEPARATOR + 
                              "documents/Examples";
 
-    std::vector<std::string> filenames =
+    StringVec filenames =
     {
         "stdlib_defs.mtlx",
         "MaterialBasic.mtlx",

--- a/source/MaterialXTest/File.cpp
+++ b/source/MaterialXTest/File.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Syntactic operations", "[file]")
 
 TEST_CASE("File system operations", "[file]")
 {
-    StringVec filenames =
+    mx::StringVec filenames =
     {
         "documents/Libraries/stdlib/stdlib_defs.mtlx",
         "documents/Examples/MaterialBasic.mtlx",
@@ -53,7 +53,7 @@ TEST_CASE("File search path operations", "[file]")
                              mx::PATH_LIST_SEPARATOR + 
                              "documents/Examples";
 
-    StringVec filenames =
+    mx::StringVec filenames =
     {
         "stdlib_defs.mtlx",
         "MaterialBasic.mtlx",

--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -80,8 +80,8 @@ TEST_CASE("GLSL Implementation Check", "[genglsl]")
 {
     mx::GenContext context(mx::GlslShaderGenerator::create());
 
-    std::set<std::string> generatorSkipNodeTypes;
-    std::set<std::string> generatorSkipNodeDefs;
+    mx::StringSet generatorSkipNodeTypes;
+    mx::StringSet generatorSkipNodeDefs;
     generatorSkipNodeDefs.insert("ND_add_surfaceshader");
     generatorSkipNodeDefs.insert("ND_multiply_surfaceshaderF");
     generatorSkipNodeDefs.insert("ND_multiply_surfaceshaderC");

--- a/source/MaterialXTest/GenOgsfx.cpp
+++ b/source/MaterialXTest/GenOgsfx.cpp
@@ -66,8 +66,8 @@ TEST_CASE("OGSFX Implementation Check", "[genogsfx]")
 {
     mx::GenContext context(mx::OgsFxShaderGenerator::create());
 
-    std::set<std::string> generatorSkipNodeTypes;
-    std::set<std::string> generatorSkipNodeDefs;
+    mx::StringSet generatorSkipNodeTypes;
+    mx::StringSet generatorSkipNodeDefs;
     generatorSkipNodeDefs.insert("ND_add_surfaceshader");
     generatorSkipNodeDefs.insert("ND_multiply_surfaceshaderF");
     generatorSkipNodeDefs.insert("ND_multiply_surfaceshaderC");

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -86,12 +86,12 @@ TEST_CASE("OSL Implementation Check", "[genosl]")
 {
     mx::GenContext context(mx::OslShaderGenerator::create());
 
-    std::set<std::string> generatorSkipNodeTypes;
+    mx::StringSet generatorSkipNodeTypes;
     generatorSkipNodeTypes.insert("light");
     generatorSkipNodeTypes.insert("point_light");
     generatorSkipNodeTypes.insert("directional_light");
     generatorSkipNodeTypes.insert("spot_light");
-    std::set<std::string> generatorSkipNodeDefs;
+    mx::StringSet generatorSkipNodeDefs;
 
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs);
 }

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -208,7 +208,7 @@ public:
     MaterialX::StringVec overrideFiles;
 
     // Comma separated list of light setup files
-    StringVec lightFiles;
+    mx::StringVec lightFiles;
 
     // Set to true to always dump generated code to disk
     bool dumpGeneratedCode = false;
@@ -1122,7 +1122,7 @@ void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidT
 
         size_t skipCount = 0;
         profilingLog << "-- Possibly missed implementations ----" << std::endl;
-        StringVec whiteList =
+        mx::StringVec whiteList =
         {
             "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
             "volumeshader", "IM_constant_string_", "IM_constant_filename_", "IM_dot_string"

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -208,7 +208,7 @@ public:
     MaterialX::StringVec overrideFiles;
 
     // Comma separated list of light setup files
-    std::vector<std::string> lightFiles;
+    StringVec lightFiles;
 
     // Set to true to always dump generated code to disk
     bool dumpGeneratedCode = false;
@@ -1081,7 +1081,7 @@ bool getTestOptions(const std::string& optionFile, ShaderValidTestOptions& optio
 }
 
 void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidTestOptions& options,
-    std::set<std::string>& usedImpls, std::ostream& profilingLog, mx::DocumentPtr dependLib
+                mx::StringSet& usedImpls, std::ostream& profilingLog, mx::DocumentPtr dependLib
 #ifdef MATERIALX_BUILD_RENDEROSL
     , mx::GenContext& oslContext
 #endif
@@ -1122,7 +1122,7 @@ void printRunLog(const ShaderValidProfileTimes &profileTimes, const ShaderValidT
 
         size_t skipCount = 0;
         profilingLog << "-- Possibly missed implementations ----" << std::endl;
-        std::vector<std::string> whiteList =
+        StringVec whiteList =
         {
             "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
             "volumeshader", "IM_constant_string_", "IM_constant_filename_", "IM_dot_string"
@@ -1224,7 +1224,7 @@ TEST_CASE("Render TestSuite", "[render]")
     // For debugging, add files to this set to override
     // which files in the test suite are being tested.
     // Add only the test suite filename not the full path.
-    std::set<std::string> testfileOverride;
+    mx::StringSet testfileOverride;
 
     AdditiveScopedTimer ioTimer(profileTimes.ioTime, "Global I/O time");
     mx::FilePath path = mx::FilePath::getCurrentPath() / mx::FilePath("documents/TestSuite");
@@ -1258,7 +1258,7 @@ TEST_CASE("Render TestSuite", "[render]")
     // This will be imported in each test document below
     ioTimer.startTimer();
     mx::DocumentPtr dependLib = mx::createDocument();
-    std::set<std::string> excludeFiles;
+    mx::StringSet excludeFiles;
     if (!options.runGLSLTests && !options.runOGSFXTests)
     {
         excludeFiles.insert("stdlib_" + mx::GlslShaderGenerator::LANGUAGE + "_impl.mtlx");
@@ -1375,7 +1375,7 @@ TEST_CASE("Render TestSuite", "[render]")
     AdditiveScopedTimer validateTimer(profileTimes.validateTime, "Global validation time");
     AdditiveScopedTimer renderableSearchTimer(profileTimes.renderableSearchTime, "Global renderable search time");
 
-    std::set<std::string> usedImpls;
+    mx::StringSet usedImpls;
 
     const std::string MTLX_EXTENSION("mtlx");
     const std::string OPTIONS_FILENAME("_options.mtlx");


### PR DESCRIPTION
- Rename TestObjLoader to SampeObjLoader
- Cleanup to use built in StringVec, StringMap and StringSet.