### PR TITLE
Added loading of material from source code.

### DIFF
--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -190,6 +190,30 @@ bool Material::generateConstantShader(mx::GenContext& context,
     return _glShader->init(shaderName, vertexShader, pixelShader);
 }
 
+bool Material::loadSource(const mx::FilePath& vertexShaderFile, const mx::FilePath& pixelShaderFile, const std::string& shaderName, bool hasTransparency)
+{
+    _hasTransparency = hasTransparency;
+
+    if (!_glShader)
+    {
+        _glShader = std::make_shared<ng::GLShader>();
+    }
+
+    std::string vertexShader;
+    if (!mx::readFile(vertexShaderFile, vertexShader))
+    {
+        return false;
+    }
+
+    std::string pixelShader;
+    if (!mx::readFile(pixelShaderFile, pixelShader))
+    {
+        return false;
+    }
+
+    return _glShader->init(shaderName, vertexShader, pixelShader);
+}
+
 mx::ShaderPtr Material::generateSource(mx::GenContext& context, mx::ElementPtr elem)
 {
     if (!elem)

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -73,6 +73,9 @@ class Material
         _udim = val;
     }
 
+    /// Load shader source from file.
+    bool loadSource(const mx::FilePath& vertexStage, const mx::FilePath& pixelStage, const std::string& shaderName, bool hasTransparency);
+
     /// Generate shader source for a given element and generation context.
     mx::ShaderPtr generateSource(mx::GenContext& context, mx::ElementPtr elem);
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -741,6 +741,32 @@ void Viewer::saveActiveMaterialSource()
     }
 }
 
+void Viewer::loadActiveMaterialSource()
+{
+    try
+    {
+        MaterialPtr material = getSelectedMaterial();
+        mx::TypedElementPtr elem = material ? material->getElement() : nullptr;
+        if (elem)
+        {
+            std::string baseName = elem->getName();
+            std::string vertexShaderFile = _searchPath[0] / (baseName + "_vs.glsl");
+            std::string pixelShaderFile = _searchPath[0] / (baseName + "_ps.glsl");
+            // Ignore transparency for now as we can't know from the source code 
+            // if the shader is transparent or not.
+            if (material->loadSource(vertexShaderFile, pixelShaderFile, baseName, false))
+            {
+                assignMaterial(material, _geometryList[_selectedGeom]);
+            }
+        }
+    }
+    catch (std::exception& e)
+    {
+        new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Cannot load source for material", e.what());
+    }
+}
+
+
 bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
 {
     if (Screen::keyboardEvent(key, scancode, action, modifiers))
@@ -787,6 +813,15 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
     if (key == GLFW_KEY_S && action == GLFW_PRESS)
     {
         saveActiveMaterialSource();
+        return true;
+    }
+
+    // Load a material previously saved to file.
+    // Editing the source files before loading gives a way to debug
+    // and experiment with shader source code.
+    if (key == GLFW_KEY_L && action == GLFW_PRESS)
+    {
+        loadActiveMaterialSource();
         return true;
     }
 

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -61,6 +61,7 @@ class Viewer : public ng::Screen
     void setupLights(mx::DocumentPtr doc, const std::string& envRadiancePath, const std::string& envIrradiancePath);
     void initializeDocument(mx::DocumentPtr libraries);
     void saveActiveMaterialSource();
+    void loadActiveMaterialSource();
 
     /// Assign the given material to a geometry, or to all geometries if no
     /// target is specified.


### PR DESCRIPTION
This change list adds a way to load in source code that was previously saved to file. This gives a simple way for debugging or experimenting with shader source code directly in the viewer, by editing the source before loading it in again.

To use this load in a material from .mtlx file and save out the generated source by pressing S-key as usual. Then find the produced source code files and start editing them. Pressing L-key will load in these edited source code files. Now you can iterate on the source by editing the files and pressing L-key to view the result in the viewer.