### PR TITLE
Make image buffer deallocation explicitly controlled

### DIFF
--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -16,6 +16,22 @@ string ImageDesc::BASETYPE_FLOAT = "FLOAT";
 
 string ImageDesc::IMAGETYPE_2D = "IMAGE2D";
 
+void ImageDesc::freeResourceBuffer()
+{
+    if (resourceBuffer)
+    {
+        if (resourceBufferDeallocator)
+        {
+            resourceBufferDeallocator(resourceBuffer);
+        }
+        else
+        {
+            free(resourceBuffer);
+        }
+        resourceBuffer = nullptr;
+    }
+}
+
 string ImageLoader::BMP_EXTENSION = "bmp";
 string ImageLoader::EXR_EXTENSION = "exr";
 string ImageLoader::GIF_EXTENSION = "gif";

--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -137,8 +137,7 @@ bool ImageHandler::createColorImage(const Color4& color,
     desc.computeMipCount();
     desc.resourceBufferDeallocator = [](void *buffer)
     {
-        std::cout << "Deallocate generated color image" << std::endl;
-        delete[] buffer;
+        delete[] static_cast<float*>(buffer);
     };
     return true;
 }

--- a/source/MaterialXRender/Handlers/ImageHandler.cpp
+++ b/source/MaterialXRender/Handlers/ImageHandler.cpp
@@ -8,8 +8,6 @@
 #include <MaterialXRender/Handlers/ImageHandler.h>
 #include <cmath>
 
-#include <iostream>
-
 namespace MaterialX
 {
 string ImageDesc::BASETYPE_UINT8 = "UINT8";
@@ -191,7 +189,6 @@ void ImageHandler::clearImageCache()
 {
     for (auto iter : _imageCache)
     {
-        std::cout << "Free resources for image: " << iter.first << std::endl;
         deleteImage(iter.second);
     }
     _imageCache.clear();

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -79,21 +79,7 @@ class ImageDesc
     }
 
     /// Free any resource buffer memory
-    void freeResourceBuffer()
-    {
-        if (resourceBuffer)
-        {
-            if (resourceBufferDeallocator)
-            {
-                resourceBufferDeallocator(resourceBuffer);
-            }
-            else
-            {
-                free(resourceBuffer);
-            }
-            resourceBuffer = nullptr;
-        }
-    }
+    void freeResourceBuffer();
 };
 
 /// Structure containing harware image description restrictions

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -19,11 +19,19 @@
 
 namespace MaterialX
 {
+/// A function to perform image buffer deallaction
+using ImageBufferDeallocator = std::function<void(void*)>;
+
 /// @class ImageDesc
 /// Interface to describe an image. Images are assumed to be float type.
 class ImageDesc
 {
   public:
+    ~ImageDesc()
+    {
+        freeResourceBuffer();
+    }
+
     /// Image base type identifier
     using BaseType = string;
     /// Set of base type identifiers
@@ -56,11 +64,32 @@ class ImageDesc
     ImageType imageType = IMAGETYPE_2D;
     /// Hardware target dependent resource identifier. May be undefined.
     unsigned int resourceId = 0;
+    /// Deallocator to free resource buffer memory. If not defined then malloc() is
+    /// assumed to have been used to allocate the buffer and corresponding free() is
+    /// used to deallocate.
+    ImageBufferDeallocator resourceBufferDeallocator = nullptr;
 
     /// Compute the number of mip map levels based on size of the image
     void computeMipCount()
     {
         mipCount = (unsigned int)std::log2(std::max(width, height)) + 1;
+    }
+
+    /// Free any resource buffer memory
+    void freeResourceBuffer()
+    {
+        if (resourceBuffer)
+        {
+            if (resourceBufferDeallocator)
+            {
+                resourceBufferDeallocator(resourceBuffer);
+            }
+            else
+            {
+                free(resourceBuffer);
+            }
+            resourceBuffer = nullptr;
+        }
     }
 };
 
@@ -182,7 +211,10 @@ class ImageHandler
     void addLoader(ImageLoaderPtr loader);
     
     /// Default destructor
-    virtual ~ImageHandler() { };
+    virtual ~ImageHandler() 
+    {
+        clearImageCache();
+    };
 
     /// Get a list of extensions supported by the handler
     void supportedExtensions(StringSet& extensions);
@@ -223,10 +255,7 @@ class ImageHandler
     /// Clear the contents of the image cache.
     /// deleteImage() will be called for each cache description to 
     /// allow derived classes to clean up any associated resources.
-    virtual void clearImageCache()
-    {
-        _imageCache.clear();
-    }
+    virtual void clearImageCache();
 
     /// Set to the search path used for finding image files.
     void setSearchPath(const FileSearchPath& path);

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -19,7 +19,7 @@
 
 namespace MaterialX
 {
-/// A function to perform image buffer deallaction
+/// A function to perform image buffer deallocation
 using ImageBufferDeallocator = std::function<void(void*)>;
 
 /// @class ImageDesc

--- a/source/MaterialXRender/Handlers/ImageHandler.h
+++ b/source/MaterialXRender/Handlers/ImageHandler.h
@@ -67,7 +67,10 @@ class ImageDesc
     /// Deallocator to free resource buffer memory. If not defined then malloc() is
     /// assumed to have been used to allocate the buffer and corresponding free() is
     /// used to deallocate.
-    ImageBufferDeallocator resourceBufferDeallocator = nullptr;
+    ImageBufferDeallocator resourceBufferDeallocator = [](void *buffer)
+    {
+        free(buffer);
+    };
 
     /// Compute the number of mip map levels based on size of the image
     void computeMipCount()

--- a/source/MaterialXRender/Handlers/OiioImageLoader.cpp
+++ b/source/MaterialXRender/Handlers/OiioImageLoader.cpp
@@ -145,6 +145,11 @@ bool OiioImageLoader::acquireImage(const FilePath& filePath,
         if (imageInput->read_image(imageSpec.format, imageBuf))
         {
             imageDesc.resourceBuffer = imageBuf;
+            imageDesc.resourceBufferDeallocator = [](void* buffer)
+            {
+                std::cout << "Free OIIO image\n";
+                free(buffer);
+            };
             read = true;
         }
     }

--- a/source/MaterialXRender/Handlers/OiioImageLoader.cpp
+++ b/source/MaterialXRender/Handlers/OiioImageLoader.cpp
@@ -147,7 +147,6 @@ bool OiioImageLoader::acquireImage(const FilePath& filePath,
             imageDesc.resourceBuffer = imageBuf;
             imageDesc.resourceBufferDeallocator = [](void* buffer)
             {
-                std::cout << "Free OIIO image\n";
                 free(buffer);
             };
             read = true;

--- a/source/MaterialXRender/Handlers/StbImageLoader.cpp
+++ b/source/MaterialXRender/Handlers/StbImageLoader.cpp
@@ -145,6 +145,7 @@ bool StbImageLoader::acquireImage(const FilePath& filePath, ImageDesc &imageDesc
         imageDesc.height = iheight;
         imageDesc.channelCount = ichannelCount;
         imageDesc.computeMipCount();
+        imageDesc.resourceBufferDeallocator = &stbi_image_free;
     }
     return (imageDesc.resourceBuffer != nullptr);
 }

--- a/source/MaterialXRender/Handlers/StbImageLoader.cpp
+++ b/source/MaterialXRender/Handlers/StbImageLoader.cpp
@@ -145,6 +145,7 @@ bool StbImageLoader::acquireImage(const FilePath& filePath, ImageDesc &imageDesc
         imageDesc.height = iheight;
         imageDesc.channelCount = ichannelCount;
         imageDesc.computeMipCount();
+        // Set the deallocator to be the one provided with the library
         imageDesc.resourceBufferDeallocator = &stbi_image_free;
     }
     return (imageDesc.resourceBuffer != nullptr);

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -35,7 +35,6 @@ bool GLTextureHandler::createColorImage(const Color4& color,
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, imageDesc.width, imageDesc.height, 0, GL_RGBA, GL_FLOAT, imageDesc.resourceBuffer);
         glGenerateMipmap(GL_TEXTURE_2D);
         glBindTexture(GL_TEXTURE_2D, 0);
-
         return true;
     }
     return false;
@@ -129,7 +128,6 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
         glBindTexture(GL_TEXTURE_2D, 0);
 
         imageDesc.freeResourceBuffer();
-
         cacheImage(filePath, imageDesc);
         textureLoaded = true;
     }
@@ -143,6 +141,7 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
         desc.height = 1;
         desc.baseType = ImageDesc::BASETYPE_FLOAT;
         createColorImage(*fallbackColor, desc);
+        desc.freeResourceBuffer();
         cacheImage(filePath, desc);
         textureLoaded = true;
     }

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -128,8 +128,7 @@ bool GLTextureHandler::acquireImage(const FilePath& filePath,
         }
         glBindTexture(GL_TEXTURE_2D, 0);
 
-        free(imageDesc.resourceBuffer);
-        imageDesc.resourceBuffer = nullptr;
+        imageDesc.freeResourceBuffer();
 
         cacheImage(filePath, imageDesc);
         textureLoaded = true;
@@ -231,11 +230,6 @@ int GLTextureHandler::mapFilterTypeToGL(int filterTypeEnum)
 
 void GLTextureHandler::clearImageCache()
 {
-    ImageDescCache& cache = getImageCache();
-    for (auto iter : cache)
-    {
-        deleteImage(iter.second);
-    }
     ParentClass::clearImageCache();
 }
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -228,11 +228,6 @@ int GLTextureHandler::mapFilterTypeToGL(int filterTypeEnum)
     return filterType;
 }
 
-void GLTextureHandler::clearImageCache()
-{
-    ParentClass::clearImageCache();
-}
-
 void GLTextureHandler::deleteImage(MaterialX::ImageDesc& imageDesc)
 {
     if (!glActiveTexture)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -71,9 +71,6 @@ class GLTextureHandler : public ImageHandler
     /// Utility to map a filter type enumeration to an OpenGL filter type
     static int mapFilterTypeToGL(int filterTypeEnum);
 
-    /// Clear image cache
-    void clearImageCache() override;
-
   protected:
     /// Delete an image
     /// @param imageDesc Image description indicate which image to delete.

--- a/source/MaterialXRenderGlsl/GlslValidator.cpp
+++ b/source/MaterialXRenderGlsl/GlslValidator.cpp
@@ -529,6 +529,8 @@ void GlslValidator::save(const FilePath& filePath, bool floatingPoint)
     desc.channelCount = 4;
     desc.resourceBuffer = buffer;
     bool saved = _imageHandler->saveImage(filePath, desc);
+
+    desc.resourceBuffer = nullptr;
     delete[] buffer;
 
     if (!saved)

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -1182,6 +1182,8 @@ void testImageHandler(ImageHandlerTestOptions& options)
             const mx::FilePath filePath = imagePath / file;
             mx::ImageDesc desc;
             bool loaded = options.imageHandler->acquireImage(filePath, desc, false, nullptr);
+            desc.freeResourceBuffer();
+            CHECK(!desc.resourceBuffer);
             if (options.logFile)
             {
                 *(options.logFile) << "Loaded image: " << filePath.asString() << ". Loaded: " << loaded << std::endl;
@@ -1202,12 +1204,25 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
     bool imagesLoaded = false;
     try
     {
+        // Create a stock color image
+        mx::ImageHandlerPtr imageHandler = mx::ImageHandler::create(nullptr);
+        mx::Color4 color(1.0f, 0.0f, 0.0f, 1.0f);
+        mx::ImageDesc desc;
+        bool createdColorImage = imageHandler->createColorImage(color, desc);
+        CHECK(!createdColorImage);
+        desc.width = 1;
+        desc.height = 1;
+        desc.channelCount = 3;
+        createdColorImage = imageHandler->createColorImage(color, desc);
+        CHECK(createdColorImage);
+        desc.freeResourceBuffer();
+        CHECK(!desc.resourceBuffer);
+
         ImageHandlerTestOptions options;
         options.logFile = &imageHandlerLog;
 
         imageHandlerLog << "** Test STB image loader **" << std::endl;
         mx::StbImageLoaderPtr stbLoader = mx::StbImageLoader::create();
-        mx::ImageHandlerPtr imageHandler = mx::ImageHandler::create(nullptr);
         imageHandler->addLoader(stbLoader);
         options.testExtensions = stbLoader->supportedExtensions();
         options.imageHandler = imageHandler;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -973,6 +973,7 @@ void Viewer::drawContents()
             desc.resourceBuffer = buffer;
             desc.baseType = mx::ImageDesc::BASETYPE_UINT8;
             saved = _imageHandler->saveImage(_captureFrameFileName, desc, true);
+            desc.resourceBuffer = nullptr;
             delete[] buffer;
         }
         _captureFrame = false;

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -122,6 +122,8 @@ class PyImageHandler : public mx::ImageHandler
 
 void bindPyImageHandler(py::module& mod)
 {
+    py::class_<mx::ImageBufferDeallocator>(mod, "ImageBufferDeallocator");
+
     py::class_<mx::ImageDesc>(mod, "ImageDesc")
         .def_readwrite("width", &mx::ImageDesc::width)
         .def_readwrite("height", &mx::ImageDesc::height)
@@ -130,7 +132,9 @@ void bindPyImageHandler(py::module& mod)
         .def_readwrite("resourceBuffer", &mx::ImageDesc::resourceBuffer)
         .def_readwrite("baseType", &mx::ImageDesc::baseType)
         .def_readwrite("resourceId", &mx::ImageDesc::resourceId)
-        .def("computeMipCount", &mx::ImageDesc::computeMipCount);
+        .def_readwrite("resourceBufferDeallocator ", &mx::ImageDesc::resourceBufferDeallocator)
+        .def("computeMipCount", &mx::ImageDesc::computeMipCount)
+        .def("freeResourceBuffer", &mx::ImageDesc::freeResourceBuffer);
 
     py::class_<mx::ImageSamplingProperties>(mod, "ImageSamplingProperties")
         .def_readwrite("uaddressMode", &mx::ImageSamplingProperties::uaddressMode)


### PR DESCRIPTION
- Add in ImageBufferDeallocator function storage on an ImageDesc to allow for custom memory deallocation
- Fix up ImageHandler, derived ImageLoader classes and procedural constant color image generation to use this appropriately.
- Update Render tests to ensure calls. Was leaking memory before since CPU buffer deletion was not being called.
 