### PR TITLE
Scan for multiple roots for gen and render unit tests

### DIFF
--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -120,10 +120,14 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
 static void generateGLSLCode()
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
+    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    std::vector<mx::FilePath> testRootPaths;
+    testRootPaths.push_back(testRootPath);
+    testRootPaths.push_back(testRootPath2);
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genglsl_glsl400_generate_test.txt");
-    GlslShaderGeneratorTester tester(testRootPath, libSearchPath, srcSearchPath, logPath);
+    GlslShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath);
 
     const mx::GenOptions genOptions;
     tester.testGeneration(genOptions);

--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -121,7 +121,7 @@ static void generateGLSLCode()
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
     const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    std::vector<mx::FilePath> testRootPaths;
+    mx::FilePathVec testRootPaths;
     testRootPaths.push_back(testRootPath);
     testRootPaths.push_back(testRootPath2);
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");

--- a/source/MaterialXTest/GenGlsl.h
+++ b/source/MaterialXTest/GenGlsl.h
@@ -20,9 +20,9 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
   public:
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
-    GlslShaderGeneratorTester(const mx::FilePath& testRootPath, const mx::FilePath& libSearchPath,
+    GlslShaderGeneratorTester(const std::vector<mx::FilePath>& testRootPaths, const mx::FilePath& libSearchPath,
                               const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath) :
-        GenShaderUtil::ShaderGeneratorTester(testRootPath, libSearchPath, srcSearchPath, logFilePath)
+        GenShaderUtil::ShaderGeneratorTester(testRootPaths, libSearchPath, srcSearchPath, logFilePath)
     {}
 
     void createGenerator() override

--- a/source/MaterialXTest/GenGlsl.h
+++ b/source/MaterialXTest/GenGlsl.h
@@ -20,7 +20,7 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
   public:
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
-    GlslShaderGeneratorTester(const std::vector<mx::FilePath>& testRootPaths, const mx::FilePath& libSearchPath,
+    GlslShaderGeneratorTester(const mx::FilePathVec& testRootPaths, const mx::FilePath& libSearchPath,
                               const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath) :
         GenShaderUtil::ShaderGeneratorTester(testRootPaths, libSearchPath, srcSearchPath, logFilePath)
     {}

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -156,7 +156,7 @@ static void generateOSLCode()
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
     const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    std::vector<mx::FilePath> testRootPaths;
+    mx::FilePathVec testRootPaths;
     testRootPaths.push_back(testRootPath);
     testRootPaths.push_back(testRootPath2);
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -115,9 +115,9 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
   public:
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
-    OslShaderGeneratorTester(const mx::FilePath& testRootPath, const mx::FilePath& libSearchPath,
+    OslShaderGeneratorTester(const std::vector<mx::FilePath>& testRootPaths, const mx::FilePath& libSearchPath,
                                const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath) : 
-        GenShaderUtil::ShaderGeneratorTester(testRootPath, libSearchPath, srcSearchPath, logFilePath)
+        GenShaderUtil::ShaderGeneratorTester(testRootPaths, libSearchPath, srcSearchPath, logFilePath)
     {}
 
     void createGenerator() override
@@ -155,11 +155,15 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 static void generateOSLCode()
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
+    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    std::vector<mx::FilePath> testRootPaths;
+    testRootPaths.push_back(testRootPath);
+    testRootPaths.push_back(testRootPath2);
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/osl"));
     const mx::FilePath logPath("genosl_vanilla_generate_test.txt");
-    OslShaderGeneratorTester tester(testRootPath, libSearchPath, srcSearchPath, logPath);
+    OslShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath);
  
     const mx::GenOptions genOptions;
     tester.testGeneration(genOptions);

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -464,7 +464,10 @@ void ShaderGeneratorTester::testGeneration(const mx::GenOptions& generateOptions
     setTestStages();
 
     // Load in all documents to test
-    mx::loadDocuments(_testRootPath, _skipFiles, _documents, _documentPaths);
+    for (auto testRoot : _testRootPaths)
+    {
+        mx::loadDocuments(testRoot, _skipFiles, _documents, _documentPaths);
+    }
 
     // Scan each document for renderable elements and check code generation
     //

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -65,13 +65,13 @@ namespace GenShaderUtil
     class ShaderGeneratorTester
     {
     public:
-        ShaderGeneratorTester(const mx::FilePath& testRootPath, const mx::FilePath& libSearchPath, 
+        ShaderGeneratorTester(const std::vector<mx::FilePath>& testRootPaths, const mx::FilePath& libSearchPath,
                               const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath)
         {
             _logFilePath = logFilePath;
             _libSearchPath = libSearchPath;
             _srcSearchPath = srcSearchPath;
-            _testRootPath = testRootPath;
+            _testRootPaths = testRootPaths;
         }
 
         ~ShaderGeneratorTester()
@@ -120,7 +120,7 @@ namespace GenShaderUtil
         mx::FilePath _libSearchPath;
         mx::FileSearchPath _srcSearchPath;
 
-        mx::FilePath _testRootPath;
+        std::vector<mx::FilePath> _testRootPaths;
         mx::StringSet _skipFiles;
         std::vector<mx::DocumentPtr> _documents;
         mx::StringVec _documentPaths;

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -65,7 +65,7 @@ namespace GenShaderUtil
     class ShaderGeneratorTester
     {
     public:
-        ShaderGeneratorTester(const std::vector<mx::FilePath>& testRootPaths, const mx::FilePath& libSearchPath,
+        ShaderGeneratorTester(const mx::FilePathVec& testRootPaths, const mx::FilePath& libSearchPath,
                               const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath)
         {
             _logFilePath = logFilePath;
@@ -120,7 +120,7 @@ namespace GenShaderUtil
         mx::FilePath _libSearchPath;
         mx::FileSearchPath _srcSearchPath;
 
-        std::vector<mx::FilePath> _testRootPaths;
+        mx::FilePathVec _testRootPaths;
         mx::StringSet _skipFiles;
         std::vector<mx::DocumentPtr> _documents;
         mx::StringVec _documentPaths;

--- a/source/MaterialXTest/RenderGLSL.cpp
+++ b/source/MaterialXTest/RenderGLSL.cpp
@@ -433,7 +433,16 @@ void GlslShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList
 TEST_CASE("Render: GLSL TestSuite", "[renderglsl]")
 {
     GlslShaderRenderTester renderTester;
-    renderTester.validate();
+
+    mx::FilePathVec testRootPaths;
+    mx::FilePath testRoot = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
+    testRootPaths.push_back(testRoot);
+    const mx::FilePath testRoot2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    testRootPaths.push_back(testRoot2);
+
+    mx::FilePath optionsFilePath = testRoot / mx::FilePath("_options.mtlx");
+
+    renderTester.validate(testRootPaths, optionsFilePath);
 }
 
 #endif

--- a/source/MaterialXTest/RenderOSL.cpp
+++ b/source/MaterialXTest/RenderOSL.cpp
@@ -331,7 +331,16 @@ void OslShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList)
 TEST_CASE("Render: OSL TestSuite", "[renderosl]")
 {
     OslShaderRenderTester renderTester;
-    renderTester.validate();
+
+    mx::FilePathVec testRootPaths;
+    mx::FilePath testRoot = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
+    testRootPaths.push_back(testRoot);
+    const mx::FilePath testRoot2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    testRootPaths.push_back(testRoot2);
+
+    mx::FilePath optionsFilePath = testRoot / mx::FilePath("_options.mtlx");
+
+    renderTester.validate(testRootPaths, optionsFilePath);
 }
 
 #endif

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -328,8 +328,8 @@ bool ShaderRenderTester::validate()
 {
     // Test has been turned off so just do nothing.
     // Check for an option file
-    mx::FilePath path = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath optionsPath = path / mx::FilePath("_options.mtlx");
+    mx::FilePath testRoot = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
+    const mx::FilePath optionsPath = testRoot / mx::FilePath("_options.mtlx");
     RenderUtil::RenderTestOptions options;
     if (!options.readOptions(optionsPath))
     {
@@ -373,8 +373,9 @@ bool ShaderRenderTester::validate()
 
     RenderUtil::AdditiveScopedTimer ioTimer(profileTimes.ioTime, "Global I/O time");
     mx::FilePathVec dirs;
-    mx::FilePath baseDirectory = path;
-    dirs = baseDirectory.getSubDirectories();
+    dirs = testRoot.getSubDirectories();
+    const mx::FilePath standardSurfacePath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    dirs.push_back(standardSurfacePath);
 
     ioTimer.endTimer();
 

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -324,14 +324,12 @@ void ShaderRenderTester::printRunLog(const RenderProfileTimes &profileTimes,
     }
 }
 
-bool ShaderRenderTester::validate()
+bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath)
 {
     // Test has been turned off so just do nothing.
     // Check for an option file
-    mx::FilePath testRoot = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath optionsPath = testRoot / mx::FilePath("_options.mtlx");
     RenderUtil::RenderTestOptions options;
-    if (!options.readOptions(optionsPath))
+    if (!options.readOptions(optionsFilePath))
     {
         return false;
     }
@@ -373,9 +371,11 @@ bool ShaderRenderTester::validate()
 
     RenderUtil::AdditiveScopedTimer ioTimer(profileTimes.ioTime, "Global I/O time");
     mx::FilePathVec dirs;
-    dirs = testRoot.getSubDirectories();
-    const mx::FilePath standardSurfacePath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    dirs.push_back(standardSurfacePath);
+    for (auto testRoot : testRootPaths)
+    {
+        mx::FilePathVec testRootDirs = testRoot.getSubDirectories();
+        dirs.insert(std::end(dirs), std::begin(testRootDirs), std::end(testRootDirs));
+    }
 
     ioTimer.endTimer();
 

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -215,7 +215,7 @@ class ShaderRenderTester
   public:
     ShaderRenderTester() {};
     virtual ~ShaderRenderTester() {};
-    bool validate();
+    bool validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath);
 
   protected:
     // The shading language / target being tested

--- a/source/PyMaterialX/PyMaterialXRender/PyOiioImageLoader.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyOiioImageLoader.cpp
@@ -5,7 +5,7 @@
 
 #include <PyMaterialX/PyMaterialX.h>
 
-#include <MaterialXRender/Handlers/OiioImageLoader.h>
+#include <MaterialXRender/OiioImageLoader.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;


### PR DESCRIPTION
Scan for multiple roots for gen and render unit tests:
- By default the test suite directory + standard surface examples are scanned.
- Render tests validation API can take in test roots + options file now for more flexibility.
- Fix for ImageHandler path for OIIO Python wrapper.