### PR TITLE
Fix adjustment unit tests

### DIFF
--- a/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
@@ -16,50 +16,25 @@ Basic adjustment function tests each test is in a separate graph for each variat
 
 <?xml version="1.0"?>
 <materialx version="1.36">
-  <nodegraph name="rgbtohsv_color3" type="" xpos="6.05808" ypos="15.2766">
-    <rgbtohsv name="rgbtohsv1" type="color3" xpos="5.90819" ypos="6.67748">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="noise3d1" />
-    </rgbtohsv>
-    <output name="out" type="color3" nodename="rgbtohsv1" />
-    <noise3d name="noise3d1" type="color3" xpos="4.74597" ypos="7.02586">
-      <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-      <parameter name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" />
-    </noise3d>
-  </nodegraph>
-  <nodegraph name="rgbtohsv_color4" type="" xpos="7.04042" ypos="15.2612">
-    <rgbtohsv name="rgbtohsv1" type="color4" xpos="6.39423" ypos="5.84506">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="noise3d1" />
-    </rgbtohsv>
-    <noise3d name="noise3d1" type="color4" xpos="5.12814" ypos="5.89268">
-      <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-      <parameter name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" />
-    </noise3d>
-    <output name="out" type="color4" nodename="rgbtohsv1" />
-  </nodegraph>
-  <nodegraph name="hsvtorgb_color3" type="" xpos="6.03226" ypos="16.6616">
-    <hsvtorgb name="hsvtorgb1" type="color3" xpos="4.42069" ypos="7.5">
-      <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="noise3d1" />
-    </hsvtorgb>
-    <output name="out" type="color3" nodename="hsvtorgb1" />
-    <noise3d name="noise3d1" type="color3" xpos="3.24372" ypos="7.445">
-      <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-      <parameter name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" />
-    </noise3d>
-  </nodegraph>
-  <nodegraph name="hsvtorgb_color4" type="" xpos="7.0357" ypos="16.6575">
-    <hsvtorgb name="hsvtorgb1" type="color4" xpos="6.00513" ypos="6.8723">
-      <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" nodename="noise3d1" />
-    </hsvtorgb>
-    <noise3d name="noise3d1" type="color4" xpos="4.81417" ypos="6.80024">
-      <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-      <parameter name="pivot" type="float" value="0.0" />
-      <input name="position" type="vector3" value="0.0, 0.0, 0.0" />
-    </noise3d>
-    <output name="out" type="color4" nodename="hsvtorgb1" />
-  </nodegraph>
+   <nodegraph name="rgb_to_hsv_to_rgb_color3" type="" xpos="6.05808" ypos="15.2766">
+      <hsvtorgb name="hsvtorgb1" type="color3" xpos="4.42069" ypos="7.5">
+         <input name="in" type="color3" value="0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+      </hsvtorgb>
+      <rgbtohsv name="rgbtohsv1" type="color3" xpos="5.90819" ypos="6.67748">
+         <input name="in" type="color3" value="0.5, 0.5, 0.5" />
+      </rgbtohsv>
+      <output name="out" type="color3" nodename="hsvtorgb1" />
+   </nodegraph>
+   <nodegraph name="rgb_to_hsv_to_rgb_color4" type="" xpos="7.04042" ypos="15.2612">
+      <hsvtorgb name="hsvtorgb1" type="color4" xpos="6.00513" ypos="6.8723">
+         <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" nodename="rgbtohsv1" />
+      </hsvtorgb>
+      <rgbtohsv name="rgbtohsv1" type="color4" xpos="6.39423" ypos="5.84506">
+         <input name="in" type="color4" value="0.5, 0.5, 0.5, 1.0" />
+      </rgbtohsv>
+      <output name="out" type="color4" nodename="hsvtorgb1" />
+   </nodegraph>
+
   <nodegraph name="remap_float" type="" xpos="6.02734" ypos="17.9519">
     <remap name="remap1" type="float" xpos="5" ypos="10.24">
       <input name="in" type="float" value="0.2000" />

--- a/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/adjustment.mtlx
@@ -201,8 +201,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_color2" type="" xpos="7.06205" ypos="29.1176">
     <smoothstep name="smoothstep1" type="color2" xpos="5.75172" ypos="4.74">
       <input name="in" type="color2" value="0.6000, 0.5000" />
-      <parameter name="low" type="color2" value="0.2000, 0.5000" />
-      <parameter name="high" type="color2" value="0.8000, 0.5000" />
+      <parameter name="low" type="color2" value="0.2000, 0.2000" />
+      <parameter name="high" type="color2" value="0.8000, 0.8000" />
     </smoothstep>
     <output name="out" type="color2" nodename="smoothstep1" />
   </nodegraph>
@@ -217,8 +217,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_color3" type="" xpos="9.12894" ypos="29.1314">
     <smoothstep name="smoothstep1" type="color3" xpos="5.75172" ypos="4.74">
       <input name="in" type="color3" value="0.6000, 0.5000, 0.2000" />
-      <parameter name="low" type="color3" value="0.2000, 0.5000, 0.0" />
-      <parameter name="high" type="color3" value="0.8000, 0.5000, 1.0" />
+      <parameter name="low" type="color3" value="0.2000, 0.2000, 0.0" />
+      <parameter name="high" type="color3" value="0.8000, 0.8000, 1.0" />
     </smoothstep>
     <output name="out" type="color3" nodename="smoothstep1" />
   </nodegraph>
@@ -233,8 +233,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_color4" type="" xpos="8.10183" ypos="30.4116">
     <smoothstep name="smoothstep1" type="color4" xpos="5.75172" ypos="4.74">
       <input name="in" type="color4" value="0.6000, 0.5000, 0.2000, 1.0" />
-      <parameter name="low" type="color4" value="0.2000, 0.5000, 0.0, 0.0" />
-      <parameter name="high" type="color4" value="0.8000, 0.5000, 1.0, 1.0" />
+      <parameter name="low" type="color4" value="0.2000, 0.2000, 0.0, 0.0" />
+      <parameter name="high" type="color4" value="0.8000, 0.8000, 1.0, 1.0" />
     </smoothstep>
     <output name="out" type="color4" nodename="smoothstep1" />
   </nodegraph>
@@ -249,8 +249,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_vector2" type="" xpos="7.0691" ypos="31.7173">
     <smoothstep name="smoothstep1" type="vector2" xpos="5.75172" ypos="4.74">
       <input name="in" type="vector2" value="0.6000, 0.5000" />
-      <parameter name="low" type="vector2" value="0.2000, 0.5000" />
-      <parameter name="high" type="vector2" value="0.8000, 0.5000" />
+      <parameter name="low" type="vector2" value="0.2000, 0.2000" />
+      <parameter name="high" type="vector2" value="0.8000, 0.8000" />
     </smoothstep>
     <output name="out" type="vector2" nodename="smoothstep1" />
   </nodegraph>
@@ -265,8 +265,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_vector3" type="" xpos="9.14247" ypos="31.6569">
     <smoothstep name="smoothstep1" type="vector3" xpos="5.75172" ypos="4.74">
       <input name="in" type="vector3" value="0.6000, 0.5000, 0.2000" />
-      <parameter name="low" type="vector3" value="0.2000, 0.5000, 0.0" />
-      <parameter name="high" type="vector3" value="0.8000, 0.5000, 1.0" />
+      <parameter name="low" type="vector3" value="0.2000, 0.2000, 0.0" />
+      <parameter name="high" type="vector3" value="0.8000, 0.8000, 1.0" />
     </smoothstep>
     <output name="out" type="vector3" nodename="smoothstep1" />
   </nodegraph>
@@ -281,8 +281,8 @@ Basic adjustment function tests each test is in a separate graph for each variat
   <nodegraph name="smoothstep_vector4" type="" xpos="8.12072" ypos="32.9952">
     <smoothstep name="smoothstep1" type="vector4" xpos="5.75172" ypos="4.74">
       <input name="in" type="vector4" value="0.6000, 0.5000, 0.2000, 1.0" />
-      <parameter name="low" type="vector4" value="0.2000, 0.5000, 0.0, 0.0" />
-      <parameter name="high" type="vector4" value="0.8000, 0.5000, 1.0, 1.0" />
+      <parameter name="low" type="vector4" value="0.2000, 0.2000, 0.0, 0.0" />
+      <parameter name="high" type="vector4" value="0.8000, 0.8000, 1.0, 1.0" />
     </smoothstep>
     <output name="out" type="vector4" nodename="smoothstep1" />
   </nodegraph>


### PR DESCRIPTION
- Make hsv -> rgb test usable by performing rgb->hsv->rgb to make sure we get back the original value.
- Fix the smoothstep tests since they had 0 range values which would give undefined behaviour.
