### PR TITLE
Migrate suitable options from Render* to Gen* unit tests

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -10,7 +10,7 @@
    can also be performed depending on the options enabled.
 -->
 <materialx version="1.36">
-   <nodedef name="RenderTestOptions">
+   <nodedef name="TestSuiteOptions">
 
       <!-- List of comma separated file names acts as a filter to only test documents with these names -->
       <parameter name="overrideFiles" type="string" value="" />

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -43,14 +43,15 @@ bool readFile(const string& filename, string& contents)
     return false;
 }
 
-void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, 
+void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const StringSet& includeFiles,
                    vector<DocumentPtr>& documents, StringVec& documentsPaths)
 {
     for (const FilePath& dir : rootPath.getSubDirectories())
     {
         for (const FilePath& file : dir.getFilesInDirectory(MTLX_EXTENSION))
         {
-            if (!skipFiles.count(file))
+            if (!skipFiles.count(file) && 
+               (includeFiles.empty() || includeFiles.count(file)))
             {
                 DocumentPtr doc = createDocument();
                 const FilePath filePath = dir / file;

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -29,9 +29,9 @@ string removeExtension(const string& filename);
 bool readFile(const string& filename, string& content);
 
 /// Scans for all documents under a root path and returns documents which can be loaded
-/// Optionally can test and log errors if the document is not considered to be valid.
-void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles,
-    vector<DocumentPtr>& documents, StringVec& documentsPaths);
+void loadDocuments(const FilePath& rootPath, 
+                   const StringSet& skipFiles, const StringSet& includeFiles,
+                   vector<DocumentPtr>& documents, StringVec& documentsPaths);
 
 /// Returns true if the given element is a surface shader with the potential
 /// of beeing transparent. This can be used by HW shader generators to determine

--- a/source/MaterialXTest/GenArnold.cpp
+++ b/source/MaterialXTest/GenArnold.cpp
@@ -57,7 +57,8 @@ static void generateArnoldOslCode()
     OslShaderGeneratorTester tester(mx::ArnoldShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
  
     const mx::GenOptions genOptions;
-    tester.testGeneration(genOptions);
+    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    tester.validate(genOptions, optionsFilePath);
 }
 
 TEST_CASE("GenShader: Arnold Shader Generation", "[genosl]")

--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -131,7 +131,8 @@ static void generateGlslCode()
     GlslShaderGeneratorTester tester(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
 
     const mx::GenOptions genOptions;
-    tester.testGeneration(genOptions);
+    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    tester.validate(genOptions, optionsFilePath);
 }
 
 TEST_CASE("GenShader: GLSL Shader Generation", "[genglsl]")

--- a/source/MaterialXTest/GenGlsl.h
+++ b/source/MaterialXTest/GenGlsl.h
@@ -35,6 +35,17 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
         GenShaderUtil::loadLibrary(lightDir / mx::FilePath("lightcompoundtest.mtlx"), _dependLib);
         GenShaderUtil::loadLibrary(lightDir / mx::FilePath("light_rig.mtlx"), _dependLib);
     }
+
+  protected:
+    void getImplementationWhiteList(mx::StringSet& whiteList) override
+    {
+        whiteList =
+        {
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
+            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_light_genglsl",
+            "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl"
+        };
+    }
 };
 
 #endif // GENGLSL_H

--- a/source/MaterialXTest/GenOgsfx.cpp
+++ b/source/MaterialXTest/GenOgsfx.cpp
@@ -118,7 +118,8 @@ static void generateOgsFxCode()
     OgsFxShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath);
 
     const mx::GenOptions genOptions;
-    tester.testGeneration(genOptions);
+    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    tester.validate(genOptions, optionsFilePath);
 }
 
 TEST_CASE("GenShader: OGSFX Shader Generation", "[genogsfx]")

--- a/source/MaterialXTest/GenOgsfx.cpp
+++ b/source/MaterialXTest/GenOgsfx.cpp
@@ -83,7 +83,7 @@ TEST_CASE("GenShader: OGSFX Unique Names", "[genogsfx]")
 
 class OgsFxShaderGeneratorTester : public GlslShaderGeneratorTester
 {
-public:
+  public:
     OgsFxShaderGeneratorTester(const mx::FilePathVec& testRootPaths, const mx::FilePath& libSearchPath,
                                  const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath) :
             GlslShaderGeneratorTester(mx::OgsFxShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logFilePath)
@@ -92,6 +92,17 @@ public:
     void setTestStages() override
     {
         _testStages.push_back(mx::Stage::EFFECT);
+    }
+
+  protected:
+    void getImplementationWhiteList(mx::StringSet& whiteList) override
+    {
+        whiteList =
+        {
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
+            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_light_genglsl",
+            "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl"
+        };
     }
 };
 

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -125,7 +125,8 @@ static void generateOslCode()
     OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
  
     const mx::GenOptions genOptions;
-    tester.testGeneration(genOptions);
+    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    tester.validate(genOptions, optionsFilePath);
 }
 
 TEST_CASE("GenShader: OSL Shader Generation", "[genosl]")

--- a/source/MaterialXTest/GenOsl.h
+++ b/source/MaterialXTest/GenOsl.h
@@ -16,7 +16,7 @@ namespace mx = MaterialX;
 
 class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 {
-public:
+  public:
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
     OslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const std::vector<mx::FilePath>& testRootPaths,
@@ -48,6 +48,16 @@ public:
     // No direct lighting to register for OSL
     void registerLights(mx::DocumentPtr /*doc*/, const std::vector<mx::NodePtr>& /*lights*/, mx::GenContext& /*context*/) override
     {
+    }
+
+  protected:
+    void getImplementationWhiteList(mx::StringSet& whiteList) override
+    {
+        whiteList =
+        {
+            "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
+            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue"
+        };
     }
 };
 

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -24,126 +24,218 @@ namespace mx = MaterialX;
 
 namespace GenShaderUtil
 {
-    //
-    // Load in a library. Sets the URI before import
-    //
-    void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc);
+//
+// Load in a library. Sets the URI before import
+//
+void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc);
 
-    //
-    // Loads all the MTLX files below a given library path
-    //
-    void loadLibraries(const mx::StringVec& libraryNames,
-                       const mx::FilePath& searchPath,
-                       mx::DocumentPtr doc,
-                       const mx::StringSet* excludeFiles = nullptr);
+//
+// Loads all the MTLX files below a given library path
+//
+void loadLibraries(const mx::StringVec& libraryNames,
+                    const mx::FilePath& searchPath,
+                    mx::DocumentPtr doc,
+                    const mx::StringSet* excludeFiles = nullptr);
     
-    //
-    // Get source content, source path and resolved paths for
-    // an implementation
-    //
-    bool getShaderSource(mx::GenContext& context, 
-                         const mx::ImplementationPtr implementation,
-                         mx::FilePath& sourcePath,
-                         mx::FilePath& resolvedPath,
-                         std::string& sourceContents);
+//
+// Get source content, source path and resolved paths for
+// an implementation
+//
+bool getShaderSource(mx::GenContext& context, 
+                        const mx::ImplementationPtr implementation,
+                        mx::FilePath& sourcePath,
+                        mx::FilePath& resolvedPath,
+                        std::string& sourceContents);
 
-    // Test code generation for a given element
-    bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
-                      std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
+// Test code generation for a given element
+bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
+                    std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
 
-    // Check that implementations exist for all nodedefs supported per generator
-    void checkImplementations(mx::GenContext& context,
-                              const mx::StringSet& generatorSkipNodeTypes,
-                              const mx::StringSet& generatorSkipNodeDefs,
-                              unsigned int expectedSkipCount);
+// Check that implementations exist for all nodedefs supported per generator
+void checkImplementations(mx::GenContext& context,
+                            const mx::StringSet& generatorSkipNodeTypes,
+                            const mx::StringSet& generatorSkipNodeDefs,
+                            unsigned int expectedSkipCount);
 
-    // Utility test to  check unique name generation on a shader generator
-    void testUniqueNames(mx::GenContext& context, const std::string& stage);
+// Utility test to  check unique name generation on a shader generator
+void testUniqueNames(mx::GenContext& context, const std::string& stage);
 
-    // Utility class to handle testing of shader generators.
-    // Currently only tests source code generation.
-    class ShaderGeneratorTester
+//
+// Render validation options. Reflects the _options.mtlx
+// file in the test suite area.
+//
+class TestSuiteOptions
+{
+  public:
+    // Print out options
+    void print(std::ostream& output) const;
+
+    // Option options from an options file
+    bool readOptions(const std::string& optionFile);
+
+    // Filter list of files to only run validation on.
+    mx::StringVec overrideFiles;
+
+    // List of language,target pair identifier storage as
+    // strings in the form <language>_<target>.
+    mx::StringSet languageAndTargets;
+
+    // Comma separated list of light setup files
+    mx::StringVec lightFiles;
+
+    // Set to true to always dump generated code to disk
+    bool dumpGeneratedCode = false;
+
+    // Check the count of number of implementations used
+    bool checkImplCount = true;
+
+    // Run using a set of interfaces:
+    // - 3 = run complete + reduced.
+    // - 2 = run complete only (default)
+    // - 1 = run reduced only.
+    int shaderInterfaces = 2;
+
+    // Validate element before attempting to generate code. Default is false.
+    bool validateElementToRender = false;
+
+    // Perform source code compilation validation test
+    bool compileCode = true;
+
+    // Perform rendering validation test
+    bool renderImages = true;
+
+    // Perform saving of image.
+    bool saveImages = true;
+
+    // Set this to be true if it is desired to dump out uniform and attribut information to the logging file.
+    bool dumpUniformsAndAttributes = true;
+
+    // Non-shaded geometry file
+    MaterialX::FilePath unShadedGeometry;
+
+    // Shaded geometry file
+    MaterialX::FilePath shadedGeometry;
+
+    // Amount to scale geometry. 
+    float geometryScale;
+
+    // Enable direct lighting. Default is true. 
+    bool enableDirectLighting;
+
+    // Enable indirect lighting. Default is true. 
+    bool enableIndirectLighting;
+
+    // Method for specular environment sampling (only used for HW rendering):
+    //   0 : Prefiltered - Use a radiance IBL texture that has been prefiltered with the BRDF.
+    //   1 : Filtered Importance Sampling - Use FIS to sample the IBL texture according to the BRDF in runtime.
+    // Default value is 1.
+    int specularEnvironmentMethod;
+
+    // Radiance IBL file.
+    mx::FilePath radianceIBLPath;
+
+    // Irradiance IBL file.
+    mx::FilePath irradianceIBLPath;
+
+    // Transforms UVs of loaded geometry
+    MaterialX::Matrix44 transformUVs;
+};
+
+// Utility class to handle testing of shader generators.
+// Currently only tests source code generation.
+class ShaderGeneratorTester
+{
+  public:
+    ShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
+                            const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
+                            const mx::FilePath& logFilePath) :
+        _shaderGenerator(shaderGenerator),
+        _languageTargetString(shaderGenerator->getLanguage() + "_" + shaderGenerator->getTarget()),
+        _testRootPaths(testRootPaths),
+        _libSearchPath(libSearchPath),
+        _srcSearchPath(srcSearchPath),
+        _logFilePath(logFilePath)
     {
-    public:
-        ShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
-                              const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                              const mx::FilePath& logFilePath) :
-            _shaderGenerator(shaderGenerator),
-            _testRootPaths(testRootPaths),
-            _libSearchPath(libSearchPath),
-            _srcSearchPath(srcSearchPath),
-            _logFilePath(logFilePath)
-        {
-        }
+    }
 
-        ~ShaderGeneratorTester()
-        {
-        }
+    ~ShaderGeneratorTester()
+    {
+    }
 
-        // Stages to test is required from derived class
-        virtual void setTestStages() = 0;
+    // Check if testing should be performed based in input options
+    virtual bool runTest(const TestSuiteOptions& testOptions)
+    {
+        return (testOptions.languageAndTargets.count(_languageTargetString) > 0);
+    }
 
-        // Add files in to not examine
-        virtual void addSkipFiles();
+    // Stages to test is required from derived class
+    virtual void setTestStages() = 0;
 
-        // Add nodedefs to not examine
-        virtual void addSkipNodeDefs();
+    // Add files in to not examine
+    virtual void addSkipFiles();
 
-        // Add color management
-        virtual void addColorManagement();
+    // Add nodedefs to not examine
+    virtual void addSkipNodeDefs();
 
-        // Load in dependent libraries
-        virtual void setupDependentLibraries();
+    // Add color management
+    virtual void addColorManagement();
 
-        // From a set of nodes, create a mapping of nodedef identifiers to numbers
-        virtual void mapNodeDefToIdentiers(const std::vector<mx::NodePtr>& nodes,
-                                           std::unordered_map<std::string, unsigned int>& ids);
+    // Load in dependent libraries
+    virtual void setupDependentLibraries();
 
-        // Find lights to use based on an input document
-        virtual void findLights(mx::DocumentPtr doc, std::vector<mx::NodePtr>& lights);
+    // From a set of nodes, create a mapping of nodedef identifiers to numbers
+    virtual void mapNodeDefToIdentiers(const std::vector<mx::NodePtr>& nodes,
+                                        std::unordered_map<std::string, unsigned int>& ids);
 
-        // Register light node definitions and light count with a given generation context
-        virtual void registerLights(mx::DocumentPtr doc, const std::vector<mx::NodePtr>& lights, mx::GenContext& context);
+    // Find lights to use based on an input document
+    virtual void findLights(mx::DocumentPtr doc, std::vector<mx::NodePtr>& lights);
 
-        // Generate source code for a given element and check that code was produced.
-        bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
-                          std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
+    // Register light node definitions and light count with a given generation context
+    virtual void registerLights(mx::DocumentPtr doc, const std::vector<mx::NodePtr>& lights, mx::GenContext& context);
 
-        // Run test for source code generation
-        void testGeneration(const mx::GenOptions& generateOptions);
+    // Generate source code for a given element and check that code was produced.
+    bool generateCode(mx::GenContext& context, const std::string& shaderName, mx::TypedElementPtr element,
+                        std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
 
-    protected:
-        // Check to see that all implemenations have been tested for a given
-        // language.
-        void checkImplementationUsage(mx::StringSet& usedImpls,
-                                      mx::GenContext& context,
-                                      std::ostream& stream);
+    // Run test for source code generation
+    void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);
 
-        // Get implemenation "whitelist" for those implementations that have
-        // been skipped for checking
-        virtual void getImplementationWhiteList(mx::StringSet& whiteList) = 0;
+  protected:
+    // Check to see that all implemenations have been tested for a given
+    // language.
+    void checkImplementationUsage(mx::StringSet& usedImpls,
+                                    mx::GenContext& context,
+                                    std::ostream& stream);
 
-        mx::ShaderGeneratorPtr _shaderGenerator;
-        mx::DefaultColorManagementSystemPtr _colorManagementSystem;
-        mx::DocumentPtr _dependLib;
+    // Get implemenation "whitelist" for those implementations that have
+    // been skipped for checking
+    virtual void getImplementationWhiteList(mx::StringSet& whiteList) = 0;
 
-        const mx::FilePathVec _testRootPaths;
-        const mx::FilePath _libSearchPath;
-        const mx::FileSearchPath _srcSearchPath;
-        const mx::FilePath _logFilePath;
+    mx::ShaderGeneratorPtr _shaderGenerator;
+    const std::string _languageTargetString;
+    mx::DefaultColorManagementSystemPtr _colorManagementSystem;
+    mx::DocumentPtr _dependLib;
 
-        mx::StringSet _skipFiles;
-        std::vector<mx::DocumentPtr> _documents;
-        mx::StringVec _documentPaths;
-        std::ofstream _logFile;
-        mx::StringSet _skipNodeDefs;
-        mx::StringVec _testStages;
+    const mx::FilePathVec _testRootPaths;
+    const mx::FilePath _libSearchPath;
+    const mx::FileSearchPath _srcSearchPath;
+    const mx::FilePath _logFilePath;
 
-        std::vector<mx::NodePtr> _lights;
-        std::unordered_map<std::string, unsigned int> _lightIdentifierMap;
+    mx::StringSet _skipFiles;
+    std::vector<mx::DocumentPtr> _documents;
+    mx::StringVec _documentPaths;
+    std::ofstream _logFile;
+    mx::StringSet _skipNodeDefs;
+    mx::StringVec _testStages;
 
-        mx::StringSet _usedImplementations;
-    };
-}
+    std::vector<mx::NodePtr> _lights;
+    std::unordered_map<std::string, unsigned int> _lightIdentifierMap;
+
+    mx::StringSet _usedImplementations;
+};
+
+
+
+} // namespace GenShaderUtil
 
 #endif

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -113,6 +113,16 @@ namespace GenShaderUtil
         void testGeneration(const mx::GenOptions& generateOptions);
 
     protected:
+        // Check to see that all implemenations have been tested for a given
+        // language.
+        void checkImplementationUsage(mx::StringSet& usedImpls,
+                                      mx::GenContext& context,
+                                      std::ostream& stream);
+
+        // Get implemenation "whitelist" for those implementations that have
+        // been skipped for checking
+        virtual void getImplementationWhiteList(mx::StringSet& whiteList) = 0;
+
         mx::ShaderGeneratorPtr _shaderGenerator;
         mx::DefaultColorManagementSystemPtr _colorManagementSystem;
         mx::DocumentPtr _dependLib;
@@ -131,6 +141,8 @@ namespace GenShaderUtil
 
         std::vector<mx::NodePtr> _lights;
         std::unordered_map<std::string, unsigned int> _lightIdentifierMap;
+
+        mx::StringSet _usedImplementations;
     };
 }
 

--- a/source/MaterialXTest/RenderArnold.cpp
+++ b/source/MaterialXTest/RenderArnold.cpp
@@ -39,8 +39,6 @@ class ArnoldShaderRenderTester : public RenderUtil::ShaderRenderTester
                       RenderUtil::RenderProfileTimes& profileTimes,
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
-
-    void getImplementationWhiteList(mx::StringSet& whiteList) override;
 };
 
 void ArnoldShaderRenderTester::createValidator(std::ostream& /*log*/)
@@ -138,16 +136,6 @@ bool ArnoldShaderRenderTester::runValidator(const std::string& shaderName,
 
     return true;
 }
-
-void ArnoldShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList)
-{
-    whiteList =
-    {
-        "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
-        "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue"
-    };
-}
-
 
 TEST_CASE("Render: Arnold TestSuite", "[renderosl]")
 {

--- a/source/MaterialXTest/RenderArnold.cpp
+++ b/source/MaterialXTest/RenderArnold.cpp
@@ -35,7 +35,7 @@ class ArnoldShaderRenderTester : public RenderUtil::ShaderRenderTester
                       mx::GenContext& context,
                       mx::DocumentPtr doc,
                       std::ostream& log,
-                      const RenderUtil::RenderTestOptions& testOptions,
+                      const GenShaderUtil::TestSuiteOptions& testOptions,
                       RenderUtil::RenderProfileTimes& profileTimes,
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
@@ -50,7 +50,7 @@ bool ArnoldShaderRenderTester::runValidator(const std::string& shaderName,
                                             mx::GenContext& context,
                                             mx::DocumentPtr doc,
                                             std::ostream& log,
-                                            const RenderUtil::RenderTestOptions& testOptions,
+                                            const GenShaderUtil::TestSuiteOptions& testOptions,
                                             RenderUtil::RenderProfileTimes& profileTimes,
                                             const mx::FileSearchPath& /*imageSearchPath*/,
                                             const std::string& outputPath)

--- a/source/MaterialXTest/RenderGLSL.cpp
+++ b/source/MaterialXTest/RenderGLSL.cpp
@@ -61,8 +61,6 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
 
-    void getImplementationWhiteList(mx::StringSet& whiteList) override;
-
     mx::GlslValidatorPtr _validator;
     mx::LightHandlerPtr _lightHandler;
 };
@@ -499,16 +497,6 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
         }
     }
     return true;
-}
-
-void GlslShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList)
-{
-    whiteList =
-    {
-        "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
-        "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_light_genglsl",
-        "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl"
-    };
 }
 
 TEST_CASE("Render: GLSL TestSuite", "[renderglsl]")

--- a/source/MaterialXTest/RenderGLSL.cpp
+++ b/source/MaterialXTest/RenderGLSL.cpp
@@ -42,9 +42,9 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
 
   protected:
     void loadLibraries(mx::DocumentPtr document,
-                       RenderUtil::RenderTestOptions& options) override;
+                       GenShaderUtil::TestSuiteOptions& options) override;
 
-    void registerLights(mx::DocumentPtr document, const RenderUtil::RenderTestOptions &options, 
+    void registerLights(mx::DocumentPtr document, const GenShaderUtil::TestSuiteOptions &options, 
                         mx::GenContext& context) override;
 
     void createValidator(std::ostream& log) override;
@@ -56,7 +56,7 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
                       mx::GenContext& context,
                       mx::DocumentPtr doc,
                       std::ostream& log,
-                      const RenderUtil::RenderTestOptions& testOptions,
+                      const GenShaderUtil::TestSuiteOptions& testOptions,
                       RenderUtil::RenderProfileTimes& profileTimes,
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
@@ -70,7 +70,7 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
 // compound light type and a set of lights in a "light rig" are loaded in to a given
 // document.
 void GlslShaderRenderTester::loadLibraries(mx::DocumentPtr document,
-                                           RenderUtil::RenderTestOptions& options)
+                                           GenShaderUtil::TestSuiteOptions& options)
 {
     mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
     for (auto lightFile : options.lightFiles)
@@ -81,7 +81,7 @@ void GlslShaderRenderTester::loadLibraries(mx::DocumentPtr document,
 
 // Create a light handler and populate it based on lights found in a given document
 void GlslShaderRenderTester::registerLights(mx::DocumentPtr document,
-                                            const RenderUtil::RenderTestOptions &options,
+                                            const GenShaderUtil::TestSuiteOptions &options,
                                             mx::GenContext& context)
 {
     _lightHandler = mx::LightHandler::create();
@@ -227,7 +227,7 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
                                           mx::GenContext& context,
                                           mx::DocumentPtr doc,
                                           std::ostream& log,
-                                          const RenderUtil::RenderTestOptions& testOptions,
+                                          const GenShaderUtil::TestSuiteOptions& testOptions,
                                           RenderUtil::RenderProfileTimes& profileTimes,
                                           const mx::FileSearchPath& imageSearchPath,
                                           const std::string& outputPath)

--- a/source/MaterialXTest/RenderOSL.cpp
+++ b/source/MaterialXTest/RenderOSL.cpp
@@ -39,8 +39,6 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
 
-    void getImplementationWhiteList(mx::StringSet& whiteList) override;
-
     mx::OslValidatorPtr _validator;
 };
 
@@ -305,16 +303,6 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
 
     return true;
 }
-
-void OslShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList)
-{
-    whiteList =
-    {
-        "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
-        "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue"
-    };
-}
-
 
 TEST_CASE("Render: OSL TestSuite", "[renderosl]")
 {

--- a/source/MaterialXTest/RenderOSL.cpp
+++ b/source/MaterialXTest/RenderOSL.cpp
@@ -34,7 +34,7 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
                       mx::GenContext& context,
                       mx::DocumentPtr doc,
                       std::ostream& log,
-                      const RenderUtil::RenderTestOptions& testOptions,
+                      const GenShaderUtil::TestSuiteOptions& testOptions,
                       RenderUtil::RenderProfileTimes& profileTimes,
                       const mx::FileSearchPath& imageSearchPath,
                       const std::string& outputPath = ".") override;
@@ -99,7 +99,7 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
                                          mx::GenContext& context,
                                          mx::DocumentPtr doc,
                                          std::ostream& log,
-                                         const RenderUtil::RenderTestOptions& testOptions,
+                                         const GenShaderUtil::TestSuiteOptions& testOptions,
                                          RenderUtil::RenderProfileTimes& profileTimes,
                                          const mx::FileSearchPath& imageSearchPath,
                                          const std::string& outputPath)

--- a/source/MaterialXTest/RenderOgsFx.cpp
+++ b/source/MaterialXTest/RenderOgsFx.cpp
@@ -25,9 +25,9 @@ public:
 
 protected:
     void loadLibraries(mx::DocumentPtr document,
-                       RenderUtil::RenderTestOptions& options) override;
+                       GenShaderUtil::TestSuiteOptions& options) override;
 
-    void registerLights(mx::DocumentPtr document, const RenderUtil::RenderTestOptions &options,
+    void registerLights(mx::DocumentPtr document, const GenShaderUtil::TestSuiteOptions &options,
                         mx::GenContext& context) override;
 
     void createValidator(std::ostream& log) override;
@@ -37,7 +37,7 @@ protected:
         mx::GenContext& context,
         mx::DocumentPtr doc,
         std::ostream& log,
-        const RenderUtil::RenderTestOptions& testOptions,
+        const GenShaderUtil::TestSuiteOptions& testOptions,
         RenderUtil::RenderProfileTimes& profileTimes,
         const mx::FileSearchPath& imageSearchPath,
         const std::string& outputPath = ".") override;
@@ -50,7 +50,7 @@ protected:
 // compound light type and a set of lights in a "light rig" are loaded in to a given
 // document.
 void OgsFxShaderRenderTester::loadLibraries(mx::DocumentPtr document,
-    RenderUtil::RenderTestOptions& options)
+    GenShaderUtil::TestSuiteOptions& options)
 {
     mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
     for (auto lightFile : options.lightFiles)
@@ -61,7 +61,7 @@ void OgsFxShaderRenderTester::loadLibraries(mx::DocumentPtr document,
 
 // Create a light handler and populate it based on lights found in a given document
 void OgsFxShaderRenderTester::registerLights(mx::DocumentPtr document,
-    const RenderUtil::RenderTestOptions &options,
+    const GenShaderUtil::TestSuiteOptions &options,
     mx::GenContext& context)
 {
     _lightHandler = mx::LightHandler::create();
@@ -78,7 +78,7 @@ bool OgsFxShaderRenderTester::runValidator(const std::string& shaderName,
                                            mx::GenContext& context,
                                            mx::DocumentPtr doc,
                                            std::ostream& log,
-                                           const RenderUtil::RenderTestOptions& testOptions,
+                                           const GenShaderUtil::TestSuiteOptions& testOptions,
                                            RenderUtil::RenderProfileTimes& profileTimes,
                                            const mx::FileSearchPath& /*imageSearchPath*/,
                                            const std::string& outputPath)
@@ -184,6 +184,5 @@ TEST_CASE("Render: OgsFx TestSuite", "[renderglsl]")
     testRootPaths.push_back(testRoot2);
 
     mx::FilePath optionsFilePath = testRoot / mx::FilePath("_options.mtlx");
-
     renderTester.validate(testRootPaths, optionsFilePath);
 }

--- a/source/MaterialXTest/RenderOgsFx.cpp
+++ b/source/MaterialXTest/RenderOgsFx.cpp
@@ -42,8 +42,6 @@ protected:
         const mx::FileSearchPath& imageSearchPath,
         const std::string& outputPath = ".") override;
 
-    void getImplementationWhiteList(mx::StringSet& whiteList) override;
-
     mx::LightHandlerPtr _lightHandler;
 };
 
@@ -171,16 +169,6 @@ bool OgsFxShaderRenderTester::runValidator(const std::string& shaderName,
     }
 
     return true;
-}
-
-void OgsFxShaderRenderTester::getImplementationWhiteList(mx::StringSet& whiteList)
-{
-    whiteList =
-    {
-        "ambientocclusion", "arrayappend", "backfacing", "screen", "curveadjust", "displacementshader",
-        "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_light_genglsl",
-        "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl"
-    };
 }
 
 TEST_CASE("Render: OgsFx TestSuite", "[renderglsl]")

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -85,11 +85,12 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     GenShaderUtil::TestSuiteOptions options;
     if (!options.readOptions(optionsFilePath))
     {
+        std::cout << "Can't find options file. Skip test." << std::endl;
         return false;
     }
-    bool run = runTest(options);
-    if (!run)
+    if (!runTest(options))
     {
+        std::cout << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
         return false;
     }
 
@@ -113,9 +114,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     std::ostream& profilingLog(std::cout);
 #endif
 
-    // For debugging, add files to this set to override
-    // which files in the test suite are being tested.
-    // Add only the test suite filename not the full path.
+    // Add files to override the files in the test suite to be tested.
     mx::StringSet testfileOverride;
     for (auto filterFile : options.overrideFiles)
     {

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -27,221 +27,6 @@ void createLightRig(mx::DocumentPtr doc, mx::LightHandler& lightHandler, mx::Gen
     lightHandler.setLightEnvRadiancePath(envRadiancePath);
 }
 
-void RenderTestOptions::print(std::ostream& output) const
-{
-    output << "Render Test Options:" << std::endl;
-    output << "\tOverride Files: { ";
-    for (auto overrideFile : overrideFiles) { output << overrideFile << " "; }
-    output << "} " << std::endl;
-    output << "\tLight Setup Files: { ";
-    for (auto lightFile : lightFiles) { output << lightFile << " "; }
-    output << "} " << std::endl;
-    output << "\tLanguage / Targets to run: " << std::endl;
-    for (auto  l : languageAndTargets)
-    {
-        mx::StringVec languageAndTarget = mx::splitString(l, "_");
-        size_t count = languageAndTarget.size();
-        output << "\t\tLanguage: " << ((count > 0) ? languageAndTarget[0] : "NONE") << ". ";
-        output << "Target: " << ((count > 1) ? languageAndTarget[1] : "NONE");
-        output << std::endl;
-    }
-    output << "\tCheck Implementation Usage Count: " << checkImplCount << std::endl;
-    output << "\tDump Generated Code: " << dumpGeneratedCode << std::endl;
-    output << "\tShader Interfaces: " << shaderInterfaces << std::endl;
-    output << "\tValidate Element To Render: " << validateElementToRender << std::endl;
-    output << "\tCompile code: " << compileCode << std::endl;
-    output << "\tRender Images: " << renderImages << std::endl;
-    output << "\tSave Images: " << saveImages << std::endl;
-    output << "\tDump uniforms and Attributes  " << dumpUniformsAndAttributes << std::endl;
-    output << "\tNon-Shaded Geometry: " << unShadedGeometry.asString() << std::endl;
-    output << "\tShaded Geometry: " << shadedGeometry.asString() << std::endl;
-    output << "\tGeometry Scale: " << geometryScale << std::endl;
-    output << "\tEnable Direct Lighting: " << enableDirectLighting << std::endl;
-    output << "\tEnable Indirect Lighting: " << enableIndirectLighting << std::endl;
-    output << "\tSpecular Environment Method: " << specularEnvironmentMethod << std::endl;
-    output << "\tRadiance IBL File Path " << radianceIBLPath.asString() << std::endl;
-    output << "\tIrradiance IBL File Path: " << irradianceIBLPath.asString() << std::endl;
-}
-
-bool RenderTestOptions::readOptions(const std::string& optionFile)
-{
-    // These strings should make the input names defined in the
-    // RenderTestOptions nodedef in test suite file _options.mtlx
-    //
-    const std::string RENDER_TEST_OPTIONS_STRING("RenderTestOptions");
-    const std::string OVERRIDE_FILES_STRING("overrideFiles");
-    const std::string LANGUAGE_AND_TARGETS_STRING("languageAndTargets");
-    const std::string LIGHT_FILES_STRING("lightFiles");
-    const std::string SHADER_INTERFACES_STRING("shaderInterfaces");
-    const std::string VALIDATE_ELEMENT_TO_RENDER_STRING("validateElementToRender");
-    const std::string COMPILE_CODE_STRING("compileCode");
-    const std::string RENDER_IMAGES_STRING("renderImages");
-    const std::string SAVE_IMAGES_STRING("saveImages");
-    const std::string DUMP_UNIFORMS_AND_ATTRIBUTES_STRING("dumpUniformsAndAttributes");
-    const std::string CHECK_IMPL_COUNT_STRING("checkImplCount");
-    const std::string DUMP_GENERATED_CODE_STRING("dumpGeneratedCode");
-    const std::string UNSHADED_GEOMETRY_STRING("unShadedGeometry");
-    const std::string SHADED_GEOMETRY_STRING("shadedGeometry");
-    const std::string GEOMETRY_SCALE_STRING("geometryScale");
-    const std::string ENABLE_DIRECT_LIGHTING("enableDirectLighting");
-    const std::string ENABLE_INDIRECT_LIGHTING("enableIndirectLighting");
-    const std::string SPECULAR_ENVIRONMENT_METHOD("specularEnvironmentMethod");
-    const std::string RADIANCE_IBL_PATH_STRING("radianceIBLPath");
-    const std::string IRRADIANCE_IBL_PATH_STRING("irradianceIBLPath");
-    const std::string TRANSFORM_UVS_STRING("transformUVs");
-    const std::string SPHERE_OBJ("sphere.obj");
-    const std::string SHADERBALL_OBJ("shaderball.obj");
-
-    overrideFiles.clear();
-    dumpGeneratedCode = false;
-    unShadedGeometry = SPHERE_OBJ;
-    shadedGeometry = SHADERBALL_OBJ;
-    geometryScale = 1.0f;
-    enableDirectLighting = true;
-    enableIndirectLighting = true;
-    specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
-
-    MaterialX::DocumentPtr doc = MaterialX::createDocument();
-    try {
-        MaterialX::readFromXmlFile(doc, optionFile);
-
-        MaterialX::NodeDefPtr optionDefs = doc->getNodeDef(RENDER_TEST_OPTIONS_STRING);
-        if (optionDefs)
-        {
-            for (MaterialX::ParameterPtr p : optionDefs->getParameters())
-            {
-                const std::string& name = p->getName();
-                MaterialX::ValuePtr val = p->getValue();
-                if (val)
-                {
-                    if (name == OVERRIDE_FILES_STRING)
-                    {
-                        overrideFiles = MaterialX::splitString(p->getValueString(), ",");
-                    }
-                    else if (name == LIGHT_FILES_STRING)
-                    {
-                        lightFiles = MaterialX::splitString(p->getValueString(), ",");
-                    }
-                    else if (name == SHADER_INTERFACES_STRING)
-                    {
-                        shaderInterfaces = val->asA<int>();
-                    }
-                    else if (name == VALIDATE_ELEMENT_TO_RENDER_STRING)
-                    {
-                        validateElementToRender = val->asA<bool>();
-                    }
-                    else if (name == COMPILE_CODE_STRING)
-                    {
-                        compileCode = val->asA<bool>();
-                    }
-                    else if (name == RENDER_IMAGES_STRING)
-                    {
-                        renderImages = val->asA<bool>();
-                    }
-                    else if (name == SAVE_IMAGES_STRING)
-                    {
-                        saveImages = val->asA<bool>();
-                    }
-                    else if (name == DUMP_UNIFORMS_AND_ATTRIBUTES_STRING)
-                    {
-                        dumpUniformsAndAttributes = val->asA<bool>();
-                    }
-                    else if (name == LANGUAGE_AND_TARGETS_STRING)
-                    {
-                        #if defined(MATERIALX_TEST_RENDER)
-                        mx::StringVec list =  mx::splitString(p->getValueString(), ",");
-                        for (auto l : list)
-                        {
-                            languageAndTargets.insert(l);
-                        }
-                        #endif
-                    }
-                    else if (name == CHECK_IMPL_COUNT_STRING)
-                    {
-                        checkImplCount = val->asA<bool>();
-                    }
-                    else if (name == DUMP_GENERATED_CODE_STRING)
-                    {
-                        dumpGeneratedCode = val->asA<bool>();
-                    }
-                    else if (name == UNSHADED_GEOMETRY_STRING)
-                    {
-                        unShadedGeometry = p->getValueString();
-                    }
-                    else if (name == SHADED_GEOMETRY_STRING)
-                    {
-                        shadedGeometry = p->getValueString();
-                    }
-                    else if (name == GEOMETRY_SCALE_STRING)
-                    {
-                        geometryScale = val->asA<float>();
-                    }
-                    else if (name == ENABLE_DIRECT_LIGHTING)
-                    {
-                        enableDirectLighting = val->asA<bool>();
-                    }
-                    else if (name == ENABLE_INDIRECT_LIGHTING)
-                    {
-                        enableIndirectLighting = val->asA<bool>();
-                    }
-                    else if (name == SPECULAR_ENVIRONMENT_METHOD)
-                    {
-                        specularEnvironmentMethod = val->asA<int>();
-                    }
-                    else if (name == RADIANCE_IBL_PATH_STRING)
-                    {
-                        radianceIBLPath = p->getValueString();
-                    }
-                    else if (name == IRRADIANCE_IBL_PATH_STRING)
-                    {
-                        irradianceIBLPath = p->getValueString();
-                    }
-                    else if (name == TRANSFORM_UVS_STRING)
-                    {
-                        transformUVs = val->asA<mx::Matrix44>();
-                    }
-                }
-            }
-        }
-
-        // Disable render and save of images if not compiled code will be generated
-        if (!compileCode)
-        {
-            renderImages = false;
-            saveImages = false;
-        }
-        // Disable saving images, if no images are to be produced
-        if (!renderImages)
-        {
-            saveImages = false;
-        }
-        // Disable direct lighting
-        if (!enableDirectLighting)
-        {
-            lightFiles.clear();
-        }
-        // Disable indirect lighting
-        if (!enableIndirectLighting)
-        {
-            radianceIBLPath.assign(mx::EMPTY_STRING);
-            irradianceIBLPath.assign(mx::EMPTY_STRING);
-        }
-
-        // If there is a filter on the files to run turn off profile checking
-        if (!overrideFiles.empty())
-        {
-            checkImplCount = false;
-        }
-        return true;
-    }
-    catch (mx::Exception& e)
-    {
-        std::cout << e.what();
-    }
-    return false;
-}
-
-
 ShaderRenderTester::ShaderRenderTester(mx::ShaderGeneratorPtr shaderGenerator) :
     _shaderGenerator(shaderGenerator),
     _languageTargetString(shaderGenerator->getLanguage() + "_" + shaderGenerator->getTarget())
@@ -254,7 +39,7 @@ ShaderRenderTester::~ShaderRenderTester()
 
 // Create a list of generation options based on unit test options
 // These options will override the original generation context options.
-void ShaderRenderTester::getGenerationOptions(const RenderTestOptions& testOptions,
+void ShaderRenderTester::getGenerationOptions(const GenShaderUtil::TestSuiteOptions& testOptions,
                                               const mx::GenOptions& originalOptions,
                                               std::vector<mx::GenOptions>& optionsList)
 {
@@ -275,7 +60,7 @@ void ShaderRenderTester::getGenerationOptions(const RenderTestOptions& testOptio
 }
 
 void ShaderRenderTester::printRunLog(const RenderProfileTimes &profileTimes,
-                                     const RenderTestOptions& options,
+                                     const GenShaderUtil::TestSuiteOptions& options,
                                      std::ostream& stream,
                                      mx::DocumentPtr dependLib)
 {
@@ -297,7 +82,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 {
     // Test has been turned off so just do nothing.
     // Check for an option file
-    RenderUtil::RenderTestOptions options;
+    GenShaderUtil::TestSuiteOptions options;
     if (!options.readOptions(optionsFilePath))
     {
         return false;

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -274,109 +274,23 @@ void ShaderRenderTester::getGenerationOptions(const RenderTestOptions& testOptio
     }
 }
 
-void ShaderRenderTester::checkImplementationUsage(const std::string& language,
-                                                  mx::StringSet& usedImpls,
-                                                  mx::DocumentPtr dependLib,
-                                                  mx::GenContext& context,
-                                                  std::ostream& stream)
-{
-    // Get list of implementations a given langauge.
-    std::set<mx::ImplementationPtr> libraryImpls;
-    const std::vector<mx::ElementPtr>& children = dependLib->getChildren();
-    for (auto child : children)
-    {
-        mx::ImplementationPtr impl = child->asA<mx::Implementation>();
-        if (!impl)
-        {
-            continue;
-        }
-
-        if (impl->getLanguage() == language)
-        {
-            libraryImpls.insert(impl);
-        }
-    }
-
-    mx::StringSet whiteList;
-    getImplementationWhiteList(whiteList);
-
-    unsigned int implementationUseCount = 0;
-    mx::StringVec skippedImplementations;
-    mx::StringVec missedImplementations;
-    for (auto libraryImpl : libraryImpls)
-    {
-        const std::string& implName = libraryImpl->getName();
-
-        // Skip white-list items
-        bool inWhiteList = false;
-        for (auto w : whiteList)
-        {
-            if (implName.find(w) != std::string::npos)
-            {
-                inWhiteList = true;
-                break;
-            }
-        }
-        if (inWhiteList)
-        {
-            skippedImplementations.push_back(implName);
-            implementationUseCount++;
-            continue;
-        }
-
-        if (usedImpls.count(implName))
-        {
-            implementationUseCount++;
-            continue;
-        }
-
-        if (context.findNodeImplementation(implName))
-        {
-            implementationUseCount++;
-            continue;
-        }
-        missedImplementations.push_back(implName);
-    }
-
-    size_t libraryCount = libraryImpls.size();
-    stream << "Tested: " << implementationUseCount << " out of: " << libraryCount << " library implementations." << std::endl;
-    stream << "Skipped: " << skippedImplementations.size() << " implementations." << std::endl;
-    if (skippedImplementations.size())
-    {
-        for (auto implName : skippedImplementations)
-        {
-            stream << "\t" << implName << std::endl;
-        }
-    }
-    stream << "Untested: " << missedImplementations.size() << " implementations." << std::endl;
-    if (missedImplementations.size())
-    {
-        for (auto implName : missedImplementations)
-        {
-            stream << "\t" << implName << std::endl;
-        }
-        CHECK(implementationUseCount == libraryCount);
-    }
-}
-
 void ShaderRenderTester::printRunLog(const RenderProfileTimes &profileTimes,
                                      const RenderTestOptions& options,
-                                     mx::StringSet& usedImpls,
                                      std::ostream& stream,
-                                     mx::DocumentPtr dependLib,
-                                     mx::GenContext& context,
-                                     const std::string& language)
+                                     mx::DocumentPtr dependLib)
 {
     profileTimes.print(stream);
 
     stream << "---------------------------------------" << std::endl;
     options.print(stream);
 
-    if (options.checkImplCount)
-    {
-        stream << "---------------------------------------" << std::endl;
-        checkImplementationUsage(language, usedImpls, dependLib, context, stream);
-    }
+    //if (options.checkImplCount)
+    //{
+    //    stream << "---------------------------------------" << std::endl;
+    //    mx::StringSet whiteList;
+    //    getImplementationWhiteList(whiteList);
+    //    GenShaderUtil::checkImplementationUsage(language, usedImpls, whiteList, dependLib, context, stream);
+    //}
 }
 
 bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath)
@@ -583,8 +497,8 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     // Dump out profiling information
     totalTime.endTimer();
-    printRunLog(profileTimes, options, usedImpls, profilingLog, dependLib, context,
-                _shaderGenerator->getLanguage());
+    printRunLog(profileTimes, options, profilingLog, dependLib);
+
     return true;
 }
 

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -42,88 +42,6 @@ namespace RenderUtil
 void createLightRig(mx::DocumentPtr doc, mx::LightHandler& lightHandler, mx::GenContext& context,
     const mx::FilePath& envIrradiancePath, const mx::FilePath& envRadiancePath);
 
-//
-// Render validation options. Reflects the _options.mtlx
-// file in the test suite area.
-//
-class RenderTestOptions
-{
-  public:
-    // Print out options
-    void print(std::ostream& output) const;
-
-    // Option options from an options file
-    bool readOptions(const std::string& optionFile);
-
-    // Filter list of files to only run validation on.
-    mx::StringVec overrideFiles;
-
-    // List of language,target pair identifier storage as
-    // strings in the form <language>_<target>.
-    mx::StringSet languageAndTargets;
-
-    // Comma separated list of light setup files
-    mx::StringVec lightFiles;
-
-    // Set to true to always dump generated code to disk
-    bool dumpGeneratedCode = false;
-
-    // Check the count of number of implementations used
-    bool checkImplCount = true;
-
-    // Run using a set of interfaces:
-    // - 3 = run complete + reduced.
-    // - 2 = run complete only (default)
-    // - 1 = run reduced only.
-    int shaderInterfaces = 2;
-
-    // Validate element before attempting to generate code. Default is false.
-    bool validateElementToRender = false;
-
-    // Perform source code compilation validation test
-    bool compileCode = true;
-
-    // Perform rendering validation test
-    bool renderImages = true;
-
-    // Perform saving of image.
-    bool saveImages = true;
-
-    // Set this to be true if it is desired to dump out uniform and attribut information to the logging file.
-    bool dumpUniformsAndAttributes = true;
-
-    // Non-shaded geometry file
-    MaterialX::FilePath unShadedGeometry;
-
-    // Shaded geometry file
-    MaterialX::FilePath shadedGeometry;
-
-    // Amount to scale geometry. 
-    float geometryScale;
-
-    // Enable direct lighting. Default is true. 
-    bool enableDirectLighting;
-
-    // Enable indirect lighting. Default is true. 
-    bool enableIndirectLighting;
-
-    // Method for specular environment sampling (only used for HW rendering):
-    //   0 : Prefiltered - Use a radiance IBL texture that has been prefiltered with the BRDF.
-    //   1 : Filtered Importance Sampling - Use FIS to sample the IBL texture according to the BRDF in runtime.
-    // Default value is 1.
-    int specularEnvironmentMethod;
-
-    // Radiance IBL file.
-    mx::FilePath radianceIBLPath;
-
-    // Irradiance IBL file.
-    mx::FilePath irradianceIBLPath;
-
-    // Transforms UVs of loaded geometry
-    MaterialX::Matrix44 transformUVs;
-
-};
-
 // Scoped timer which adds a duration to a given externally reference timing duration
 //
 class AdditiveScopedTimer
@@ -239,9 +157,13 @@ class ShaderRenderTester
 
   protected:
     // Check if testing should be performed based in input options
-    virtual bool runTest(const RenderUtil::RenderTestOptions& testOptions)
+    virtual bool runTest(const GenShaderUtil::TestSuiteOptions& testOptions)
     {
+#if defined(MATERIALX_TEST_RENDER)
         return (testOptions.languageAndTargets.count(_languageTargetString) > 0);
+#else
+        return false;
+#endif
     }
 
     // Add files to skip
@@ -255,7 +177,7 @@ class ShaderRenderTester
 
     // Load any additional libraries requird by the generator
     virtual void loadLibraries(mx::DocumentPtr /*dependLib*/,
-                               RenderUtil::RenderTestOptions& /*options*/) {};
+                               GenShaderUtil::TestSuiteOptions& /*options*/) {};
 
     //
     // Code generation methods
@@ -266,7 +188,7 @@ class ShaderRenderTester
 
     // Register any lights used by the generation context
     virtual void registerLights(mx::DocumentPtr /*dependLib*/,
-                                const RenderUtil::RenderTestOptions &/*options*/,
+                                const GenShaderUtil::TestSuiteOptions &/*options*/,
                                 mx::GenContext& /*context*/) {};
 
     //
@@ -282,20 +204,20 @@ class ShaderRenderTester
         mx::GenContext& context,
         mx::DocumentPtr doc,
         std::ostream& log,
-        const RenderUtil::RenderTestOptions& testOptions,
+        const GenShaderUtil::TestSuiteOptions& testOptions,
         RenderUtil::RenderProfileTimes& profileTimes,
         const mx::FileSearchPath& imageSearchPath,
         const std::string& outputPath = ".") = 0;
 
     // Create a list of generation options based on unit test options
     // These options will override the original generation context options.
-    void getGenerationOptions(const RenderTestOptions& testOptions,
+    void getGenerationOptions(const GenShaderUtil::TestSuiteOptions& testOptions,
                               const mx::GenOptions& originalOptions,
                               std::vector<mx::GenOptions>& optionsList);
 
     // Print execution summary
     void printRunLog(const RenderProfileTimes &profileTimes,
-                     const RenderTestOptions& options,
+                     const GenShaderUtil::TestSuiteOptions& options,
                      std::ostream& stream,
                      mx::DocumentPtr dependLib);
 

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -157,14 +157,17 @@ class ShaderRenderTester
 
   protected:
     // Check if testing should be performed based in input options
+#if defined(MATERIALX_TEST_RENDER)
     virtual bool runTest(const GenShaderUtil::TestSuiteOptions& testOptions)
     {
-#if defined(MATERIALX_TEST_RENDER)
         return (testOptions.languageAndTargets.count(_languageTargetString) > 0);
-#else
-        return false;
-#endif
     }
+#else
+    virtual bool runTest(const GenShaderUtil::TestSuiteOptions& /*testOptions*/)
+    {
+        return false;
+    }
+#endif
 
     // Add files to skip
     void addSkipFiles()

--- a/source/MaterialXTest/RenderUtil.h
+++ b/source/MaterialXTest/RenderUtil.h
@@ -293,26 +293,11 @@ class ShaderRenderTester
                               const mx::GenOptions& originalOptions,
                               std::vector<mx::GenOptions>& optionsList);
 
-    // Get implemenation "whitelist" for those implementations that have
-    // been skipped for checking
-    virtual void getImplementationWhiteList(mx::StringSet& whiteList) = 0;
-
-    // Check to see that all implemenations have been tested for a given
-    // lanuage.
-    void checkImplementationUsage(const std::string& language,
-                                  mx::StringSet& usedImpls,
-                                  mx::DocumentPtr dependLib,
-                                  mx::GenContext& context,
-                                  std::ostream& stream);
-
     // Print execution summary
     void printRunLog(const RenderProfileTimes &profileTimes,
                      const RenderTestOptions& options,
-                     mx::StringSet& usedImpls,
                      std::ostream& stream,
-                     mx::DocumentPtr dependLib,
-                     mx::GenContext& context,
-                     const std::string& language);
+                     mx::DocumentPtr dependLib);
 
     // Generator to use
     mx::ShaderGeneratorPtr _shaderGenerator;

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -872,26 +872,29 @@ void Viewer::saveDotFiles()
         if (elem)
         {
             mx::ShaderRefPtr shaderRef = elem->asA<mx::ShaderRef>();
-            for (mx::BindInputPtr bindInput : shaderRef->getBindInputs())
+            if (shaderRef)
             {
-                mx::OutputPtr output = bindInput->getConnectedOutput();
-                mx::ConstNodeGraphPtr nodeGraph = output ? output->getAncestorOfType<mx::NodeGraph>() : nullptr;
+                for (mx::BindInputPtr bindInput : shaderRef->getBindInputs())
+                {
+                    mx::OutputPtr output = bindInput->getConnectedOutput();
+                    mx::ConstNodeGraphPtr nodeGraph = output ? output->getAncestorOfType<mx::NodeGraph>() : nullptr;
+                    if (nodeGraph)
+                    {
+                        std::string dot = nodeGraph->asStringDot();
+                        std::string baseName = _searchPath[0] / nodeGraph->getName();
+                        writeTextFile(dot, baseName + ".dot");
+                    }
+                }
+
+                mx::NodeDefPtr nodeDef = shaderRef ? shaderRef->getNodeDef() : nullptr;
+                mx::InterfaceElementPtr implement = nodeDef ? nodeDef->getImplementation() : nullptr;
+                mx::NodeGraphPtr nodeGraph = implement ? implement->asA<mx::NodeGraph>() : nullptr;
                 if (nodeGraph)
                 {
                     std::string dot = nodeGraph->asStringDot();
-                    std::string baseName = _searchPath[0] / nodeGraph->getName();
+                    std::string baseName = _searchPath[0] / nodeDef->getName();
                     writeTextFile(dot, baseName + ".dot");
                 }
-            }
-
-            mx::NodeDefPtr nodeDef = shaderRef ? shaderRef->getNodeDef() : nullptr;
-            mx::InterfaceElementPtr implement = nodeDef ? nodeDef->getImplementation() : nullptr;
-            mx::NodeGraphPtr nodeGraph = implement ? implement->asA<mx::NodeGraph>() : nullptr;
-            if (nodeGraph)
-            {
-                std::string dot = nodeGraph->asStringDot();
-                std::string baseName = _searchPath[0] / nodeDef->getName();
-                writeTextFile(dot, baseName + ".dot");
             }
         }
     }


### PR DESCRIPTION
Fixes #419.
- Moved impl count check to GenShader.
- Move options structure and _options.mtlx input code to GenShader. 
- Gen* tests can now use _options.mtlx file for 
- Where to find options files
- Check for language/target inclusion
- Check for override file list (will still disable impl check if any specified)
- Check on whether to perform implementation count check. Main impetus of migration as this was only being performed in Render* tests which were not part of CI. Will now catch adding in new impls which are *not* tested to ensure full coverage at all times.