### PR TITLE
Fix to catch exceptions thrown on xml read during tests.

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -44,8 +44,9 @@ bool readFile(const string& filename, string& contents)
 }
 
 void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const StringSet& includeFiles,
-                   vector<DocumentPtr>& documents, StringVec& documentsPaths)
+                   vector<DocumentPtr>& documents, StringVec& documentsPaths, StringVec& errors)
 {
+    errors.clear();
     for (const FilePath& dir : rootPath.getSubDirectories())
     {
         for (const FilePath& file : dir.getFilesInDirectory(MTLX_EXTENSION))
@@ -55,10 +56,16 @@ void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const S
             {
                 DocumentPtr doc = createDocument();
                 const FilePath filePath = dir / file;
-                readFromXmlFile(doc, filePath, dir);
-
-                documents.push_back(doc);
-                documentsPaths.push_back(filePath.asString());
+                try
+                {
+                    readFromXmlFile(doc, filePath, dir);
+                    documents.push_back(doc);
+                    documentsPaths.push_back(filePath.asString());
+                }
+                catch (Exception& e)
+                {
+                    errors.push_back("Failed to load: " + filePath.asString() + ". Error: " + e.what());
+                }
             }
         }
     }

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -31,7 +31,8 @@ bool readFile(const string& filename, string& content);
 /// Scans for all documents under a root path and returns documents which can be loaded
 void loadDocuments(const FilePath& rootPath, 
                    const StringSet& skipFiles, const StringSet& includeFiles,
-                   vector<DocumentPtr>& documents, StringVec& documentsPaths);
+                   vector<DocumentPtr>& documents, StringVec& documentsPaths, 
+                   StringVec& errorLog);
 
 /// Returns true if the given element is a surface shader with the potential
 /// of beeing transparent. This can be used by HW shader generators to determine

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -567,9 +567,15 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     setTestStages();
 
     // Load in all documents to test
+    mx::StringVec errorLog;
     for (auto testRoot : _testRootPaths)
     {
-        mx::loadDocuments(testRoot, _skipFiles, overrideFiles, _documents, _documentPaths);
+        mx::loadDocuments(testRoot, _skipFiles, overrideFiles, _documents, _documentPaths, errorLog);
+    }
+    CHECK(errorLog.empty());
+    for (auto error : errorLog)
+    {
+        _logFile << error << std::endl;
     }
 
     // Scan each document for renderable elements and check code generation

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -207,7 +207,15 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             const std::string filename = filePath;
 
             mx::DocumentPtr doc = mx::createDocument();
-            mx::readFromXmlFile(doc, filename, dir);
+            try
+            {
+                mx::readFromXmlFile(doc, filename, dir);
+            }
+            catch (mx::Exception& e)
+            {
+                docValidLog << "Failed to load in file: " << filename << ". Error: " << e.what() << std::endl;
+                WARN("Failed to load in file: " + filename + "See: " + docValidLogFilename + " for details.");                    
+            }
 
             doc->importLibrary(dependLib, &importOptions);
             ioTimer.endTimer();


### PR DESCRIPTION
XML load was throwing exceptions and not being caught, thus halting all tests when:
1. scanning docs for gen* tests
2. validating a doc for render* tests.
Will now put out errors to the log files per file.
