### PR TITLE
Misc rendering configuration fixes.

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -74,11 +74,11 @@ def main(args=None):
                     diffPath = None
                 fh.write("    <tr>\n")
                 if glslFile:
-                    fh.write("        <td class='td_image'><img src='" + fullGlslPath + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
+                    fh.write("        <td class='td_image'><img src='" + fullGlslPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
                 if oslFile:
-                    fh.write("        <td class='td_image'><img src='" + fullOslPath + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
+                    fh.write("        <td class='td_image'><img src='" + fullOslPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
                 if diffPath:
-                    fh.write("        <td class='td_image'><img src='" + diffPath + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
+                    fh.write("        <td class='td_image'><img src='" + diffPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' style='background-color:black;'/></td>\n")
                 fh.write("    </tr>\n")
                 fh.write("    <tr>\n")
                 if glslFile:

--- a/resources/Materials/Examples/StandardSurface/standard_surface_velvet.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_velvet.mtlx
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <material name="Velvet">
+    <shaderref name="SR_velvet" node="standard_surface">
+      <bindinput name="base_color" type="color3" value="0.029130585, 0, 0.047337279" />
+      <bindinput name="specular" type="float" value="0" />
+      <bindinput name="specular_color" type="color3" value="0, 0, 0" />
+      <bindinput name="specular_roughness" type="float" value="0.69277107715606689" />
+      <bindinput name="specular_IOR" type="float" value="0" />
+      <bindinput name="sheen" type="float" value="1" />
+      <bindinput name="sheen_color" type="color3" value="0.40380001, 0.057999998, 1" />
+      <bindinput name="coat_color" type="color3" value="0, 0, 0" />
+      <bindinput name="coat_roughness" type="float" value="0.79166668653488159" />
+      <bindinput name="coat_IOR" type="float" value="0" />
+    </shaderref>
+  </material>
+</materialx>

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -49,7 +49,7 @@ size_t Material::loadDocument(mx::DocumentPtr destinationDoc, const mx::FilePath
         }
         else
         {
-            new ng::MessageDialog(nullptr, ng::MessageDialog::Type::Warning, "Include file not found:", filename);
+            std::cerr << "Include file not found:" << filename << std::endl;
         }
     };
     mx::readFromXmlFile(doc, filePath, mx::EMPTY_STRING, &readOptions);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -188,12 +188,13 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
     }
 
     // Construct the appropriate image handler for this build.
+    // Most recently added load will be checked first.
+    mx::ImageLoaderPtr stdImageLoader = mx::StbImageLoader::create();
+    _imageHandler = mx::GLTextureHandler::create(stdImageLoader);
 #if MATERIALX_BUILD_OIIO
-    mx::ImageLoaderPtr imageLoader = mx::OiioImageLoader::create();
-#else
-    mx::ImageLoaderPtr imageLoader = mx::StbImageLoader::create();
+    mx::ImageLoaderPtr oiioImageLoader = mx::OiioImageLoader::create();
+    _imageHandler->addLoader(oiioImageLoader);
 #endif
-    _imageHandler = mx::GLTextureHandler::create(imageLoader);
 
     mx::TinyObjLoaderPtr loader = mx::TinyObjLoader::create();
     _geometryHandler = mx::GeometryHandler::create();
@@ -208,20 +209,20 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
     const mx::MeshList& meshes = _envGeometryHandler->getMeshes();
     if (!meshes.empty())
     {
-        // Invert u and rotate 90 degrees.
+        // Invert u
         mx::MeshPtr mesh = meshes[0];
         mx::MeshStreamPtr stream = mesh->getStream(mx::MeshStream::TEXCOORD_ATTRIBUTE, 0);
         mx::MeshFloatBuffer &buffer = stream->getData();
         size_t stride = stream->getStride();
         for (size_t i = 0; i < buffer.size() / stride; i++)
         {
-            float val = (buffer[i*stride] * -1.0f) + 1.25f;
+            float val = (1.0f - buffer[i*stride]);
             buffer[i*stride] = (val < 0.0f) ? (val + 1.0f) : ((val > 1.0f) ? val -= 1.0f : val);
         }
-
         // Set up world matrix for drawing
         const float scaleFactor = 300.0f;
-        _envMatrix = mx::Matrix44::createScale(mx::Vector3(scaleFactor));
+        const float rotationRadians = PI / 2.0f; // 90 degree rotation
+        _envMatrix = mx::Matrix44::createScale(mx::Vector3(scaleFactor)) * mx::Matrix44::createRotationY(rotationRadians);
 
         const std::string envShaderName("__ENV_SHADER_NAME__");
         _envMaterial = Material::create();
@@ -1017,7 +1018,7 @@ void Viewer::drawContents()
         {
             glEnable(GL_CULL_FACE);
             glCullFace(GL_FRONT);
-            envShader->bind();
+            envShader->bind();            
             _envMaterial->bindViewInformation(_envMatrix, view, proj);
             _envMaterial->bindImages(_imageHandler, _searchPath, _envMaterial->getUdim());
             _envMaterial->drawPartition(envPart);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -188,7 +188,7 @@ Viewer::Viewer(const mx::StringVec& libraryFolders,
     }
 
     // Construct the appropriate image handler for this build.
-    // Most recently added load will be checked first.
+    // Most recently added loader will be checked first.
     mx::ImageLoaderPtr stdImageLoader = mx::StbImageLoader::create();
     _imageHandler = mx::GLTextureHandler::create(stdImageLoader);
 #if MATERIALX_BUILD_OIIO
@@ -1018,7 +1018,7 @@ void Viewer::drawContents()
         {
             glEnable(GL_CULL_FACE);
             glCullFace(GL_FRONT);
-            envShader->bind();            
+            envShader->bind();
             _envMaterial->bindViewInformation(_envMatrix, view, proj);
             _envMaterial->bindImages(_imageHandler, _searchPath, _envMaterial->getUdim());
             _envMaterial->drawPartition(envPart);


### PR DESCRIPTION
Affects #406, #416, #394 
- Fix env placement for viewer
- Add fallback in case png load fails for OIIO. Use stb instead
- Fix possible crash when doc load fails. Can't put up a document w/o a parent widget will just crash reading through null memory in nano-gui.
- Add in missing velvet shader from ILM.
- Fix html script as both width + height need to be specified when reading in as word document otherwise height stays same as original Chrome handles this properly.
