### PR TITLE
Prepend parent paths when searching for child include files for document read.

### DIFF
--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -190,7 +190,8 @@ void processXIncludes(DocumentPtr doc, xml_node& xmlNode, const string& searchPa
                             includeSearchPath = filePath.asString() + PATH_LIST_SEPARATOR + searchPath;
                         }
                     }
-                    else
+                    // Set default search path if no parent path found
+                    if (includeSearchPath.empty())
                     {
                         includeSearchPath = searchPath;
                     }

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -184,4 +184,10 @@ TEST_CASE("Load content", "[xmlio]")
     // Read a non-existent document.
     mx::DocumentPtr nonExistentDoc = mx::createDocument();
     REQUIRE_THROWS_AS(mx::readFromXmlFile(nonExistentDoc, "NonExistent.mtlx"), mx::ExceptionFileMissing&);
+
+    // Read in include file without specifying search to the parent document
+    mx::DocumentPtr parentDoc = mx::createDocument();
+    mx::readFromXmlFile(parentDoc,
+        "resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx", searchPath);
+    REQUIRE(nullptr != parentDoc->getNodeDef("ND_TestMetal"));
 }


### PR DESCRIPTION
Update #394

- Pre-pend parent path to include search path to allow for includes with relative pats relative to a to parent without explicitly knowing the parent path.
- Note that the parent could also be relative. In this manner a hierarchy of sub-folder includes is possible without any absolute paths being specified.
- This relies on source URIs being set at the proper time (parent must be set before parsing children). 
- *Additional note* : During the read of the parent, a different source can be set than that of the actual filename (which could be relative or absolute). Thus a relative parent path can be set even when an absolute parent file name is used for actual reading.