### PR TITLE
RTS test / test setup fixes

### DIFF
--- a/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
@@ -18,7 +18,7 @@ Tests the channel attribute for inputs and outputs
          <parameter name="filtertype" type="string" value="linear"/>
          <parameter name="frameendaction" type="string" value="periodic"/>
       </image>
-      <output name="out" type="color2" nodename="image4" channels="ra" />
+      <output name="out" type="color2" nodename="image4" channels="rr" />
    </nodegraph>
 
    <nodegraph name="image4_to_color3_bgr_out" type="">
@@ -100,7 +100,7 @@ Tests the channel attribute for inputs and outputs
          <parameter name="frameendaction" type="string" value="periodic"/>
       </image>
       <add name="add1" type="color3">
-         <input name="in1" type="color3" nodename="image4" channels="bga" />
+         <input name="in1" type="color3" nodename="image4" channels="bgr" />
          <input name="in2" type="color3" value="0.5, 0.5, 0.5" />
       </add>
       <output name="out" type="color3" nodename="add1" />
@@ -115,8 +115,8 @@ Tests the channel attribute for inputs and outputs
          <parameter name="frameendaction" type="string" value="periodic"/>
       </image>
       <add name="add1" type="color2">
-         <input name="in1" type="color2" nodename="image4" channels="ga" />
-         <input name="in2" type="color2" value="0.5, 0.5" />
+         <input name="in1" type="color2" nodename="image4" channels="gg" />
+         <input name="in2" type="color2" value="0.5, 0.0" />
       </add>
       <output name="out" type="color2" nodename="add1" />
    </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
@@ -52,7 +52,7 @@ Tests the channel attribute for inputs and outputs
 
    <nodegraph name="color2_to_color4_arar_out" type="">
       <constant name="constant1" type="color2">
-         <parameter name="value" type="color2" value="0.5, 1.0" />
+         <parameter name="value" type="color2" value="1.0, 0.5" />
       </constant>
       <output name="out" type="color4" nodename="constant1" channels="arar" />
    </nodegraph>
@@ -149,7 +149,7 @@ Tests the channel attribute for inputs and outputs
 
    <nodegraph name="color2_to_color4_arar_in" type="">
       <constant name="constant1" type="color2">
-         <parameter name="value" type="color2" value="0.5, 1.0" />
+         <parameter name="value" type="color2" value="1.0, 0.5" />
       </constant>
       <add name="add1" type="color4">
          <input name="in1" type="color4" nodename="constant1" channels="arar" />

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -11,7 +11,7 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_lin_rec709" />
         </standard_surface>
         <image name="image_lin_rec709" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="lin_rec709" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_rec709" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
@@ -20,7 +20,7 @@ Basic image unit test with one image node for each variation in input type.
 
         <output name="image4_lin_rec709_output" type="color4" nodename="image4_lin_rec709" />
         <image name="image4_lin_rec709" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="lin_rec709" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_rec709" />
         </image>
 
         <output name="image_gamma18_output" type="surfaceshader" nodename="image_gamma18_standard_surface2" />
@@ -28,7 +28,7 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma18" />
         </standard_surface>
         <image name="image_gamma18" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma18" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma18" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
@@ -37,7 +37,7 @@ Basic image unit test with one image node for each variation in input type.
 
         <output name="image4_gamma18_output" type="color4" nodename="image4_gamma18" />
         <image name="image4_gamma18" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma18" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma18" />
         </image>
 
         <output name="image_gamma22_output" type="surfaceshader" nodename="image_gamma22_standard_surface3" />
@@ -45,16 +45,16 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma22" />
         </standard_surface>
         <image name="image_gamma22" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma22" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma22" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
           <parameter name="frameendaction" type="string" value="periodic"/>
         </image>
-        
+
         <output name="image4_gamma22_output" type="color4" nodename="image4_gamma22" />
         <image name="image4_gamma22" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma22" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma22" />
         </image>
 
         <output name="image_gamma24_output" type="surfaceshader" nodename="image_gamma24_standard_surface4" />
@@ -62,7 +62,7 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_gamma24" />
         </standard_surface>
         <image name="image_gamma24" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma24" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma24" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
@@ -71,7 +71,7 @@ Basic image unit test with one image node for each variation in input type.
 
         <output name="image4_gamma24_output" type="color4" nodename="image4_gamma24" />
         <image name="image4_gamma24" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="gamma24" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma24" />
         </image>
 
         <output name="image_acescg_output" type="surfaceshader" nodename="image_acescg_standard_surface5" />
@@ -79,7 +79,7 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_acescg" />
         </standard_surface>
         <image name="image_acescg" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="acescg" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="acescg" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
@@ -88,7 +88,7 @@ Basic image unit test with one image node for each variation in input type.
 
         <output name="image4_acescg_output" type="color4" nodename="image4_acescg" />
         <image name="image4_acescg" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="acescg" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="acescg" />
         </image>
 
         <output name="image_srgb_texture_output" type="surfaceshader" nodename="image_srgb_texture_standard_surface6" />
@@ -96,7 +96,7 @@ Basic image unit test with one image node for each variation in input type.
           <input name="base_color" type="color3" value="1, 1, 1" nodename="image_srgb_texture" />
         </standard_surface>
         <image name="image_srgb_texture" type="color3">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="srgb_texture" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
           <parameter name="uaddressmode" type="string" value="black"/>
           <parameter name="vaddressmode" type="string" value="clamp"/>
           <parameter name="filtertype" type="string" value="linear"/>
@@ -105,7 +105,7 @@ Basic image unit test with one image node for each variation in input type.
 
         <output name="image4_srgb_texture_output" type="color4" nodename="image4_srgb_texture" />
         <image name="image4_srgb_texture" type="color4">
-          <parameter name="file" type="filename" value="resources/Images/marble.png" colorspace="srgb_texture" />
+          <parameter name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
         </image>
 
         <output name="color_lin_rec709_output" type="surfaceshader" nodename="color_lin_rec709_standard_surface" />

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -160,13 +160,15 @@ Basic image unit test with one image node for each variation in input type.
           <parameter name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma24" />
         </constant>
 
-        <output name="color_acescg_output" type="surfaceshader" nodename="color_acescg_standard_surface5" />
+        <output name="color_acescg_output_standard_surface" type="surfaceshader" nodename="color_acescg_standard_surface5" />
         <standard_surface name="color_acescg_standard_surface5" type="surfaceshader" xpos="6.29441" ypos="2.18094">
           <input name="base_color" type="color3" value="1, 1, 1" nodename="color_acescg" />
         </standard_surface>
         <constant name="color_acescg" type="color3">
           <parameter name="value" type="color3" value="0.5, 0.0, 0.0" colorspace="acescg" />
         </constant>
+
+        <output name="color_acescg_output" type="color3" nodename="color_acescg" />
 
         <output name="color4_acescg_output" type="color4" nodename="color4_acescg" />
         <constant name="color4_acescg" type="color4">

--- a/resources/Materials/TestSuite/stdlib/geometric/geomattrvalue.mtlx
+++ b/resources/Materials/TestSuite/stdlib/geometric/geomattrvalue.mtlx
@@ -3,7 +3,7 @@
 <materialx version="1.36">
   <output name="geomattrvalue_integer_out" type="vector4" nodename="switch1" xpos="12.4207" ypos="4.42" />
   <switch name="switch1" type="vector4" xpos="5.74483" ypos="4.12">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 1.0" />
     <input name="in2" type="vector4" value="0.3000, 0.3000, 0.3000, 0.3000" />
     <input name="in3" type="vector4" value="0.5000, 0.5000, 0.5000, 0.5000" />
     <input name="in4" type="vector4" value="0.7000, 0.7000, 0.7000, 0.7000" />

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -467,18 +467,25 @@ void GlslProgram::bindStreams(MeshPtr mesh)
     for (auto Input : foundList)
     {
         // Only handle float1-4 types for now
-        if (Input.second->gltype == GL_FLOAT)
+        switch (Input.second->gltype)
         {
-            GLfloat floatVal[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
-            int size = Input.second->size;
-            if (size == 1)
-                glUniform1fv(Input.second->location, 1, floatVal);
-            else if (size == 2)
-                glUniform2fv(Input.second->location, 1, floatVal);
-            else if (size == 3)
-                glUniform3fv(Input.second->location, 1, floatVal);
-            else if (size == 4)
-                glUniform4fv(Input.second->location, 1, floatVal);
+            case GL_INT:
+                glUniform1i(Input.second->location, 1);
+                break;
+            case GL_FLOAT:
+                glUniform1f(Input.second->location, 0.0f);
+                break;
+            case GL_FLOAT_VEC2:
+                glUniform2f(Input.second->location, 0.0f, 0.0f);
+                break;
+            case GL_FLOAT_VEC3:
+                glUniform3f(Input.second->location, 0.0f, 0.0f, 0.0f);
+                break;
+            case GL_FLOAT_VEC4:
+                glUniform4f(Input.second->location, 0.0f, 0.0f, 0.0f, 1.0f);
+                break;
+            default:
+                break;
         }
     }
 

--- a/source/MaterialXRenderOsl/OslValidator.cpp
+++ b/source/MaterialXRenderOsl/OslValidator.cpp
@@ -174,6 +174,16 @@ void OslValidator::renderOSL(const FilePath& dirPath, const string& shaderName, 
     result.assign(std::istreambuf_iterator<char>(errorStream),
         std::istreambuf_iterator<char>());
 
+    // Remove any erroneous messages.
+    const string pngWarning("libpng warning: iCCP: known incorrect sRGB profile");
+    size_t pngWarningLength = pngWarning.length();
+    size_t pos = std::string::npos;
+    while ((pos = result.find(pngWarning)) != std::string::npos)
+    {
+        result.erase(pos, pngWarningLength);
+    }
+    result.erase(std::remove(result.begin(), result.end(), '\n'), result.end());
+
     if (!result.empty())
     {
         errors.push_back("Command string: " + command);

--- a/source/MaterialXRenderOsl/OslValidator.cpp
+++ b/source/MaterialXRenderOsl/OslValidator.cpp
@@ -174,7 +174,7 @@ void OslValidator::renderOSL(const FilePath& dirPath, const string& shaderName, 
     result.assign(std::istreambuf_iterator<char>(errorStream),
         std::istreambuf_iterator<char>());
 
-    // Remove any erroneous messages.
+    // Remove any erroneous messages and carriage returns.
     const string pngWarning("libpng warning: iCCP: known incorrect sRGB profile");
     size_t pngWarningLength = pngWarning.length();
     size_t pos = std::string::npos;


### PR DESCRIPTION
*OSL png "failures"*
- Filter out erroneous libpng warnings from OSL render validation which just checks for any return strings from testrender.
*geomattrvalue*
- OSL doesn't bind anything so make GLSL bind black. Fix for program binding value as well to handle vectors.
*channels attribute*
- Fix arar channel test to avoid alpha blend differences for channels attr test.
- Fix channel attribute test to avoid mapping from alpha on an image as they are read differently in GLSL and OSL loaders.
*color management*
- Change the input image for color management as alpha from images are not read into OSL so results differ. Use grid texture in tests which has no alpha.
- Add missing test for unconnected constant acescg.