### PR TITLE
 Added a fresnel node to pbrlib

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -210,9 +210,25 @@
       <input name="in1" type="color3" interfacename="emission_color" />
       <input name="in2" type="float" interfacename="emission" />
     </multiply>
+    <fresnel name="coat_fresnel" type="float">
+      <input name="ior" type="float" interfacename="coat_IOR" />
+      <input name="normal" type="vector3" interfacename="coat_normal" />
+    </fresnel>
+    <invert name="coat_fresnel_inv" type="float">
+      <input name="in" type="float" nodename="coat_fresnel" />
+    </invert>
+    <multiply name="coat_color_fresnel" type="color3">
+      <input name="in1" type="color3" interfacename="coat_color" />
+      <input name="in2" type="float" nodename="coat_fresnel_inv" />
+    </multiply>
+    <mix name="coat_emission_attenuation" type="color3" >
+      <input name="fg" type="color3" nodename="coat_color_fresnel" />
+      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="mix" type="float" interfacename="coat" />
+    </mix>
     <multiply name="emission_weight_attenuated" type="color3">
       <input name="in1" type="color3" nodename="emission_weight" />
-      <input name="in2" type="color3" nodename="coat_attenuation" />
+      <input name="in2" type="color3" nodename="coat_emission_attenuation" />
     </multiply>
     <uniform_edf name="emission_edf" type="EDF">
       <input name="intensity" type="color3" nodename="emission_weight_attenuated" />

--- a/libraries/pbrlib/genglsl/mx_fresnel_ior.glsl
+++ b/libraries/pbrlib/genglsl/mx_fresnel_ior.glsl
@@ -1,0 +1,7 @@
+#include "pbrlib/genglsl/lib/mx_bsdfs.glsl"
+
+void mx_fresnel_ior(float ior, vec3 N, vec3 V, out float result)
+{
+    float cosTheta = dot(N, -V);
+    result = mx_fresnel_dielectric(cosTheta, ior);
+}

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -77,4 +77,7 @@
   <!-- <normalmap> -->
   <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="pbrlib/genglsl/mx_normalmap.glsl" function="mx_normalmap" language="genglsl"/>
 
+  <!-- <fresnel> -->
+  <implementation name="IM_fresnel_ior_genglsl" nodedef="ND_fresnel_ior" file="pbrlib/genglsl/mx_fresnel_ior.glsl" function="mx_fresnel_ior" language="genglsl"/>
+
 </materialx>

--- a/libraries/pbrlib/genosl/mx_fresnel_ior.osl
+++ b/libraries/pbrlib/genosl/mx_fresnel_ior.osl
@@ -1,0 +1,7 @@
+#include "pbrlib/genosl/lib/mx_fresnel.osl"
+
+void mx_fresnel_ior(float ior, vector _normal, vector viewdir, output float result)
+{
+    float cosTheta = dot(_normal, -viewdir);
+    result = mx_fresnel_dielectric(cosTheta, ior);
+}

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -65,4 +65,7 @@
   <!-- <normalmap> -->
   <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="pbrlib/genosl/mx_normalmap.osl" function="mx_normalmap" language="genosl"/>
 
+  <!-- <fresnel> -->
+  <implementation name="IM_fresnel_ior_genosl" nodedef="ND_fresnel_ior" file="pbrlib/genosl/mx_fresnel_ior.osl" function="mx_fresnel_ior" language="genosl"/>
+
 </materialx>

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -321,4 +321,14 @@
     <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
   </nodedef>
 
+  <!--
+    Node: <fresnel>
+  -->
+  <nodedef name="ND_fresnel_ior" node="fresnel" type="float" nodegroup="pbr"
+           doc="Node for calculating the Fresnel equation from index of refraction for a dielectric surface.">
+    <input name="ior" type="float" value="1.5"/>
+    <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
+    <input name="viewdirection" type="vector3" defaultgeomprop="Vworld"/>
+  </nodedef>
+
 </materialx>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -54,6 +54,7 @@
   <geompropdef name="Nworld" geomprop="normal" space="world"/>
   <geompropdef name="Tworld" geomprop="tangent" space="world" index="0"/>
   <geompropdef name="UV0" geomprop="texcoord" index="0"/>
+  <geompropdef name="Vworld" geomprop="viewdirection" space="world"/>
 
   <!-- ======================================================================== -->
   <!-- Texture nodes                                                            -->

--- a/resources/Materials/Examples/StandardSurface/standard_surface_emission.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_emission.mtlx
@@ -1,9 +1,65 @@
 <?xml version="1.0"?>
 <materialx version="1.36">
+
+  <nodegraph name="NG_marble1">
+    <position name="objpos" type="vector3" />
+    <dotproduct name="addxyz" type="float">
+      <input name="in1" type="vector3" nodename="objpos" />
+      <input name="in2" type="vector3" value="1, 1, 1" />
+    </dotproduct>
+    <multiply name="scalexyz" type="float">
+      <input name="in1" type="float" nodename="addxyz" />
+      <input name="in2" type="float" value="10" />
+    </multiply>
+    <multiply name="scalepos" type="vector3">
+      <input name="in1" type="vector3" nodename="objpos" />
+      <input name="in2" type="float" value="4.0" />
+    </multiply>
+    <fractal3d name="noise" type="float">
+      <parameter name="octaves" type="integer" value="1" />
+      <input name="position" type="vector3" nodename="scalepos" />
+    </fractal3d>
+    <multiply name="scalenoise" type="float">
+      <input name="in1" type="float" nodename="noise" />
+      <input name="in2" type="float" value="3.0" />
+    </multiply>
+    <add name="sum" type="float">
+      <input name="in1" type="float" nodename="scalexyz" />
+      <input name="in2" type="float" nodename="scalenoise" />
+    </add>
+    <sin name="sin" type="float">
+      <input name="in" type="float" nodename="sum" />
+    </sin>
+    <multiply name="scale" type="float">
+      <input name="in1" type="float" nodename="sin" />
+      <input name="in2" type="float" value="0.4" />
+    </multiply>
+    <add name="bias" type="float">
+      <input name="in1" type="float" nodename="scale" />
+      <input name="in2" type="float" value="0.5" />
+    </add>
+    <power name="power" type="float">
+      <input name="in1" type="float" nodename="bias" />
+      <input name="in2" type="float" value="3.0" />
+    </power>
+    <constant name="constant_1" type="color3">
+      <parameter name="value" type="color3" value="1.0, 1.0, 1.0" />
+    </constant>
+    <constant name="constant_2" type="color3">
+      <parameter name="value" type="color3" value="0.2, 0.0, 0.0" />
+    </constant>
+    <mix name="mix1" type="color3">
+      <input name="bg" type="color3" nodename="constant_1" />
+      <input name="fg" type="color3" nodename="constant_2" />
+      <input name="mix" type="float" nodename="power" />
+    </mix>
+    <output name="out" type="color3" nodename="mix1" />
+  </nodegraph>
+
   <material name="Default">
     <shaderref name="SR_emission" node="standard_surface">
       <bindinput name="base" type="float" value="0.0"/>
--     <bindinput name="base_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="base_color" type="color3" value="1, 1, 1"/>
       <bindinput name="diffuse_roughness" type="float" value="0"/>
       <bindinput name="specular" type="float" value="0"/>
       <bindinput name="specular_color" type="color3" value="1, 1, 1"/>
@@ -29,7 +85,7 @@
       <bindinput name="sheen_roughness" type="float" value="0.3"/>
       <bindinput name="thin_walled" type="boolean" value="false"/>
       <bindinput name="coat" type="float" value="1.0"/>
-      <bindinput name="coat_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="coat_color" type="color3" nodegraph="NG_marble1" output="out"/>
       <bindinput name="coat_roughness" type="float" value="0.1"/>
       <bindinput name="coat_anisotropy" type="float" value="0.0"/>
       <bindinput name="coat_rotation" type="float" value="0.0"/>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_emission.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_emission.mtlx
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <material name="Default">
+    <shaderref name="SR_emission" node="standard_surface">
+      <bindinput name="base" type="float" value="0.0"/>
+-     <bindinput name="base_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="diffuse_roughness" type="float" value="0"/>
+      <bindinput name="specular" type="float" value="0"/>
+      <bindinput name="specular_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="specular_roughness" type="float" value="0.1"/>
+      <bindinput name="specular_IOR" type="float" value="1.52"/>
+      <bindinput name="specular_anisotropy" type="float" value="0"/>
+      <bindinput name="specular_rotation" type="float" value="0"/>
+      <bindinput name="metalness" type="float" value="0"/>
+      <bindinput name="transmission" type="float" value="0"/>
+      <bindinput name="transmission_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="transmission_depth" type="float" value="0"/>
+      <bindinput name="transmission_scatter" type="color3" value="0, 0, 0"/>
+      <bindinput name="transmission_scatter_anisotropy" type="float" value="0"/>
+      <bindinput name="transmission_dispersion" type="float" value="0"/>
+      <bindinput name="transmission_extra_roughness" type="float" value="0"/>
+      <bindinput name="subsurface" type="float" value="0"/>
+      <bindinput name="subsurface_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="subsurface_radius" type="vector3" value="1, 1, 1"/>
+      <bindinput name="subsurface_scale" type="float" value="1"/>
+      <bindinput name="subsurface_anisotropy" type="float" value="0"/>
+      <bindinput name="sheen" type="float" value="0"/>
+      <bindinput name="sheen_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="sheen_roughness" type="float" value="0.3"/>
+      <bindinput name="thin_walled" type="boolean" value="false"/>
+      <bindinput name="coat" type="float" value="1.0"/>
+      <bindinput name="coat_color" type="color3" value="1, 1, 1"/>
+      <bindinput name="coat_roughness" type="float" value="0.1"/>
+      <bindinput name="coat_anisotropy" type="float" value="0.0"/>
+      <bindinput name="coat_rotation" type="float" value="0.0"/>
+      <bindinput name="coat_IOR" type="float" value="1.5"/>
+      <bindinput name="coat_affect_color" type="float" value="0"/>
+      <bindinput name="coat_affect_roughness" type="float" value="0"/>
+      <bindinput name="thin_film_thickness" type="float" value="0"/>
+      <bindinput name="thin_film_IOR" type="float" value="1.5"/>
+      <bindinput name="emission" type="float" value="1"/>
+      <bindinput name="emission_color" type="color3" value="1, 0, 0"/>
+      <bindinput name="opacity" type="color3" value="1, 1, 1"/>
+    </shaderref>
+  </material>
+</materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_sheen.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_sheen.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <material name="Default">
+    <shaderref name="SR_sheen" node="standard_surface">
+      <bindinput name="base" type="float" value="0.172"/>
+      <bindinput name="base_color" type="color3" value="0.3, 0.16, 1.0"/>
+      <bindinput name="diffuse_roughness" type="float" value="0"/>
+      <bindinput name="specular" type="float" value="0"/>
+      <bindinput name="sheen" type="float" value="1"/>
+      <bindinput name="sheen_color" type="color3" value="0.5, 0.16, 0.8"/>
+      <bindinput name="sheen_roughness" type="float" value="0.047"/>
+    </shaderref>
+  </material>
+</materialx>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/fresnel.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/fresnel.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <nodegraph name="fresnel_test">
+    <fresnel name="fresnel1" type="float">
+      <input name="ior" type="float" value="1.52" />
+    </fresnel>
+    <fresnel name="fresnel2" type="float">
+      <input name="ior" type="float" value="3.50" />
+    </fresnel>
+    <output name="out1" type="color3" nodename="fresnel1" channels="rrr" />
+    <output name="out2" type="color3" nodename="fresnel2" channels="rrr" />
+  </nodegraph>
+</materialx>


### PR DESCRIPTION
- Added a fresnel node to pbrlib.
- Use it for better approximation of emission when under coat in standard_surface implementation.
- Updated some material examples.
