### PR TITLE
Fix GLSL texture setup and OSL address implementation for image node

### DIFF
--- a/libraries/stdlib/genosl/mx_image_color2.osl
+++ b/libraries/stdlib/genosl/mx_image_color2.osl
@@ -8,7 +8,7 @@ void mx_image_color2(string file, string layer, color2 default_value, vector2 te
 
     color missingColor = color(default_value.r, default_value.a, 0.0);
     vector2 st = mx_get_target_uv(texcoord);
-    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 
     out.r = rgb[0];
     out.a = rgb[1];

--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -8,5 +8,5 @@ void mx_image_color3(string file, string layer, color default_value, vector2 tex
 
     color missingColor = default_value;
     vector2 st = mx_get_target_uv(texcoord);
-    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -11,7 +11,7 @@ void mx_image_color4(string file, string layer, color4 default_value, vector2 te
     vector2 st = mx_get_target_uv(texcoord);
     float alpha;
     color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "wrap", uaddressmode);
+                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);
 
     out = color4(rgb, alpha);
 }

--- a/libraries/stdlib/genosl/mx_image_float.osl
+++ b/libraries/stdlib/genosl/mx_image_float.osl
@@ -8,6 +8,6 @@ void mx_image_float(string file, string layer, float default_value, vector2 texc
 
     color missingColor = color(default_value);
     vector2 st = mx_get_target_uv(texcoord);
-    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out = rgb[0];
 }

--- a/libraries/stdlib/genosl/mx_image_vector2.osl
+++ b/libraries/stdlib/genosl/mx_image_vector2.osl
@@ -8,7 +8,7 @@ void mx_image_vector2(string file, string layer, vector2 default_value, vector2 
 
     color missingColor = color(default_value.x, default_value.y, 0.0);
     vector2 st = mx_get_target_uv(texcoord);
-    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+    color rgb = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
     out.x = rgb[0];
     out.y = rgb[1];
 }

--- a/libraries/stdlib/genosl/mx_image_vector3.osl
+++ b/libraries/stdlib/genosl/mx_image_vector3.osl
@@ -8,5 +8,5 @@ void mx_image_vector3(string file, string layer, vector default_value, vector2 t
 
     color missingColor = default_value;
     vector2 st = mx_get_target_uv(texcoord);
-    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "wrap", uaddressmode);
+    out = texture(file, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -11,7 +11,7 @@ void mx_image_vector4(string file, string layer, vector4 default_value, vector2 
     vector2 st = mx_get_target_uv(texcoord);
     float alpha;
     color rgb = texture(file, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "wrap", uaddressmode);
+                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);
 
     out = vector4(rgb[0], rgb[1], rgb[2], alpha);
 }

--- a/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <nodegraph name="uclamp" type="" xpos="8.43448" ypos="4.84">
+    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+      <parameter name="file" type="filename" value="resources/Images/grid.png" />
+      <parameter name="layer" type="string" value="" />
+      <parameter name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <parameter name="uaddressmode" type="string" value="clamp" />
+      <parameter name="vaddressmode" type="string" value="periodic" />
+      <parameter name="filtertype" type="string" value="linear" />
+      <parameter name="framerange" type="string" value="" />
+      <parameter name="frameoffset" type="integer" value="0" />
+      <parameter name="frameendaction" type="string" value="black" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+      <parameter name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+      <input name="in2" type="vector2" value="2.0000, 2.0000" />
+    </multiply>
+  </nodegraph>
+  <nodegraph name="vclamp" type="" xpos="8.43448" ypos="4.84">
+    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+      <parameter name="file" type="filename" value="resources/Images/grid.png" />
+      <parameter name="layer" type="string" value="" />
+      <parameter name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <parameter name="uaddressmode" type="string" value="periodic" />
+      <parameter name="vaddressmode" type="string" value="clamp" />
+      <parameter name="filtertype" type="string" value="linear" />
+      <parameter name="framerange" type="string" value="" />
+      <parameter name="frameoffset" type="integer" value="0" />
+      <parameter name="frameendaction" type="string" value="black" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+      <parameter name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+      <input name="in2" type="vector2" value="2.0000, 2.0000" />
+    </multiply>
+  </nodegraph>
+  <nodegraph name="uborder_color" type="" xpos="8.43448" ypos="4.84">
+    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+      <parameter name="file" type="filename" value="resources/Images/grid.png" />
+      <parameter name="layer" type="string" value="" />
+      <parameter name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <parameter name="uaddressmode" type="string" value="black" />
+      <parameter name="vaddressmode" type="string" value="periodic" />
+      <parameter name="filtertype" type="string" value="linear" />
+      <parameter name="framerange" type="string" value="" />
+      <parameter name="frameoffset" type="integer" value="0" />
+      <parameter name="frameendaction" type="string" value="black" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+      <parameter name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+      <input name="in2" type="vector2" value="2.0000, 2.0000" />
+    </multiply>
+  </nodegraph>
+  <nodegraph name="vborder_color" type="" xpos="8.43448" ypos="4.84">
+    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+      <parameter name="file" type="filename" value="resources/Images/grid.png" />
+      <parameter name="layer" type="string" value="" />
+      <parameter name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <parameter name="uaddressmode" type="string" value="periodic" />
+      <parameter name="vaddressmode" type="string" value="black" />
+      <parameter name="filtertype" type="string" value="linear" />
+      <parameter name="framerange" type="string" value="" />
+      <parameter name="frameoffset" type="integer" value="0" />
+      <parameter name="frameendaction" type="string" value="black" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+      <parameter name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+      <input name="in2" type="vector2" value="2.0000, 2.0000" />
+    </multiply>
+  </nodegraph>
+  <nodegraph name="uv_decal_black" type="" xpos="8.43448" ypos="4.84">
+    <image name="image_number_1" type="color3" xpos="5.36637" ypos="4.71876">
+      <parameter name="file" type="filename" value="resources/Images/grid.png" />
+      <parameter name="layer" type="string" value="" />
+      <parameter name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" value="0.0, 0.0" nodename="add1" />
+      <parameter name="uaddressmode" type="string" value="black" />
+      <parameter name="vaddressmode" type="string" value="black" />
+      <parameter name="filtertype" type="string" value="linear" />
+      <parameter name="framerange" type="string" value="" />
+      <parameter name="frameoffset" type="integer" value="0" />
+      <parameter name="frameendaction" type="string" value="black" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" xpos="2.98368" ypos="6.80918">
+      <parameter name="index" type="integer" value="0" />
+    </texcoord>
+    <multiply name="multiply1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="texcoord1" />
+      <input name="in2" type="vector2" value="2.0000, 2.0000" />
+    </multiply>
+    <add name="add1" type="vector2" xpos="4.35964" ypos="5.9449">
+      <input name="in1" type="vector2" value="0.0, 0.0" nodename="multiply1" />
+      <input name="in2" type="vector2" value="-0.5000, -0.5000" />
+  </add>
+  </nodegraph>
+</materialx>

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -605,24 +605,30 @@ void GlslProgram::bindTextures(ImageHandlerPtr imageHandler)
                 fileName != IRRADIANCE_ENV_UNIFORM_NAME)
             {
                 // Get the additional texture parameters based on image uniform name
-                MaterialX::StringVec root = MaterialX::splitString(uniform.first, IMAGE_SEPARATOR);
+                // excluding the trailing "_file" postfix string
+                std::string root = uniform.first;
+                size_t pos = root.find_last_of(IMAGE_SEPARATOR);
+                if (pos != std::string::npos)
+                {
+                    root = root.substr(0, pos);
+                }
 
                 ImageSamplingProperties samplingProperties;
 
                 const int INVALID_MAPPED_INT_VALUE = -1; // Any value < 0 is not considered to be invalid
-                const std::string uaddressModeStr = root[0] + UADDRESS_MODE_POST_FIX;
+                const std::string uaddressModeStr = root + UADDRESS_MODE_POST_FIX;
                 ValuePtr intValue = findUniformValue(uaddressModeStr, uniformList);
                 samplingProperties.uaddressMode = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-                const std::string vaddressmodeStr = root[0] + VADDRESS_MODE_POST_FIX;
+                const std::string vaddressmodeStr = root + VADDRESS_MODE_POST_FIX;
                 intValue = findUniformValue(vaddressmodeStr, uniformList);
                 samplingProperties.vaddressMode = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-                const std::string filtertypeStr = root[0] + FILTER_TYPE_POST_FIX;
+                const std::string filtertypeStr = root + FILTER_TYPE_POST_FIX;
                 intValue = findUniformValue(filtertypeStr, uniformList);
                 samplingProperties.filterType = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-                const std::string defaultColorStr = root[0] + DEFAULT_COLOR_POST_FIX;
+                const std::string defaultColorStr = root + DEFAULT_COLOR_POST_FIX;
                 ValuePtr colorValue = findUniformValue(defaultColorStr, uniformList);
                 Color4 defaultColor;
                 mapValueToColor(colorValue, defaultColor);

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -439,24 +439,31 @@ void Material::bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSe
         // Extract out sampling properties
         mx::ImageSamplingProperties samplingProperties;
 
-        MaterialX::StringVec root = MaterialX::splitString(uniformName, IMAGE_SEPARATOR);
+        // Get the additional texture parameters based on image uniform name
+        // excluding the trailing "_file" postfix string
+        std::string root = uniformName;
+        size_t pos = root.find_last_of(IMAGE_SEPARATOR);
+        if (pos != std::string::npos)
+        {
+            root = root.substr(0, pos);
+        }
 
-        const std::string uaddressmodeStr = root[0] + UADDRESS_MODE_POST_FIX;
+        const std::string uaddressmodeStr = root + UADDRESS_MODE_POST_FIX;
         const mx::ShaderPort* port = publicUniforms->find(uaddressmodeStr);
         mx::ValuePtr intValue = port ? port->getValue() : nullptr;
         samplingProperties.uaddressMode = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-        const std::string vaddressmodeStr = root[0] + VADDRESS_MODE_POST_FIX;
+        const std::string vaddressmodeStr = root + VADDRESS_MODE_POST_FIX;
         port = publicUniforms->find(vaddressmodeStr);
         intValue = port ? port->getValue() : nullptr;
         samplingProperties.vaddressMode = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-        const std::string filtertypeStr = root[0] + FILTER_TYPE_POST_FIX;
+        const std::string filtertypeStr = root + FILTER_TYPE_POST_FIX;
         port = publicUniforms->find(filtertypeStr);
         intValue = port ? port->getValue() : nullptr;
         samplingProperties.filterType = intValue && intValue->isA<int>() ? intValue->asA<int>() : INVALID_MAPPED_INT_VALUE;
 
-        const std::string defaultColorStr = root[0] + DEFAULT_COLOR_POST_FIX;
+        const std::string defaultColorStr = root + DEFAULT_COLOR_POST_FIX;
         port = publicUniforms->find(defaultColorStr);
         mx::ValuePtr colorValue = port ? port->getValue() : nullptr;
         mx::Color4 defaultColor;


### PR DESCRIPTION
Fixes #447

- Fix up parsing of image uniforms to strip away the contents after last "_" vs stripping away everything after the first occurence of "_".
- Also fix implementations for OSL which did not use v address mode (only u) in the texture lookups.
Note: "black" means black color for outside the range in OSL but means "default color" in GLSL. Looking into extending spec, but unsure if OSL can handle this as "default" means something else.
- See issue for test results.