### PR TITLE
Fixed issue with unnormalized view direction in OSL sheen_brdf.

### DIFF
--- a/libraries/pbrlib/genosl/mx_sheen_brdf.osl
+++ b/libraries/pbrlib/genosl/mx_sheen_brdf.osl
@@ -42,8 +42,20 @@ float mx_microfacet_sheen_albedo(float cosTheta, float roughness)
 // so use 'diffuse' scaled by sheen directional albedo for now.
 void mx_sheen_brdf(float weight, color Ks, float roughness, vector N, BSDF base, output BSDF result)
 {
-    float NdotV = fabs(dot(N,-I));
-    float alpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float albedo = weight * mx_microfacet_sheen_albedo(NdotV, alpha);
-    result = albedo * Ks * diffuse(N) + (1.0 - albedo) * base;
+    if (weight > M_FLOAT_EPS)
+    {
+        // TODO: Normalization should not be needed. My suspision is that
+        // BSDF sampling of new outgoing direction in 'testrender' needs
+        // to be fixed.
+        vector V = normalize(-I);
+
+        float NdotV = fabs(dot(N,V));
+        float alpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+        float albedo = weight * mx_microfacet_sheen_albedo(NdotV, alpha);
+        result = albedo * Ks * diffuse(N) + (1.0 - albedo) * base;
+    }
+    else
+    {
+        result = base;
+    }
 }

--- a/libraries/pbrlib/genosl/mx_sheen_brdf.osl
+++ b/libraries/pbrlib/genosl/mx_sheen_brdf.osl
@@ -44,7 +44,7 @@ void mx_sheen_brdf(float weight, color Ks, float roughness, vector N, BSDF base,
 {
     if (weight > M_FLOAT_EPS)
     {
-        // TODO: Normalization should not be needed. My suspision is that
+        // TODO: Normalization should not be needed. My suspicion is that
         // BSDF sampling of new outgoing direction in 'testrender' needs
         // to be fixed.
         vector V = normalize(-I);


### PR DESCRIPTION
- Added early out to sheen_brdf if weight is zero
- Fixed issue with unnormalized view direction causing indexing into sheen albedo table to go out of bounds (this is a short term fix, we should fix OSL testrender to normalize correctly)
