### PR TITLE
Merge changes to support standard surface shader

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -87,7 +87,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
                 throw MaterialX::Exception("Unexpected DG node type.");
             }
 
-            std::string documentString = MaterialX::writeToXmlString(materialXData->doc);
+            std::string documentString = MaterialX::writeToXmlString(materialXData->getDocument());
 
             materialXNode->setMaterialXData(std::move(materialXData));
             materialXNode->createOutputAttr(_dgModifier);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -131,8 +131,8 @@ void MaterialXData::registerFragments()
 			{
                 std::stringstream glslStream;
                 _xmlFragmentWrapper->getDocument(glslStream);
-                //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
-                std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
+                std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
+                //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
 
                 // TODO: This should not be hard-coded
                 std::string dumpPath("d:/work/shader_dump/");

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -11,31 +11,18 @@
 
 MaterialXData::MaterialXData(const std::string& materialXDocument, const std::string& elementPath)
 {
-	libSearchPath = Plugin::instance().getLibrarySearchPath();
+	_libSearchPath = Plugin::instance().getLibrarySearchPath();
 	createDocument(materialXDocument);
 
-	if (doc)
+	if (_doc)
 	{
-		element = doc->getDescendant(elementPath);
+		_element = _doc->getDescendant(elementPath);
 	}
 
-    if (!element)
+    if (!_element)
     {
         throw MaterialX::Exception("Element not found");
     }
-
-    std::unique_ptr<MaterialX::GenContext> glslContext{
-        new MaterialX::GenContext(MaterialX::GlslShaderGenerator::create())
-    };
-
-	// Stop emission of environment map lookups.
-	glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_NONE;
-	glslContext->registerSourceCodeSearchPath(libSearchPath);
-
-    glslFragmentWrapper.reset(new MaterialX::OGSXMLFragmentWrapper(glslContext.get()));
-	glslFragmentWrapper->setOutputVertexShader(true);
-
-    contexts.push_back(std::move(glslContext));
 }
 
 MaterialXData::~MaterialXData()
@@ -45,25 +32,25 @@ MaterialXData::~MaterialXData()
 void MaterialXData::createDocument(const std::string& materialXDocument)
 {
 	// Create document
-	doc = MaterialX::createDocument();
-	MaterialX::readFromXmlFile(doc, materialXDocument);
+	_doc = MaterialX::createDocument();
+	MaterialX::readFromXmlFile(_doc, materialXDocument);
 
 	// Load libraries
 	const MaterialX::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
-	MaterialX::loadLibraries(libraries, libSearchPath, doc);
+	MaterialX::loadLibraries(libraries, _libSearchPath, _doc);
 }
 
 bool MaterialXData::isValidOutput()
 {
-    if (!element)
+    if (!_element)
     {
         return false;
     }
 
-	const std::string& elementPath = element->getNamePath();
+	const std::string& elementPath = _element->getNamePath();
 	std::vector<MaterialX::TypedElementPtr> elements;
 	try {
-		MaterialX::findRenderableElements(doc, elements);
+		MaterialX::findRenderableElements(_doc, elements);
 		for (MaterialX::TypedElementPtr currentElement : elements)
 		{
 			std::string pathCompare(currentElement->getNamePath());
@@ -82,8 +69,8 @@ bool MaterialXData::isValidOutput()
 
 void MaterialXData::createXMLWrapper()
 {
-	MaterialX::OutputPtr output = element->asA<MaterialX::Output>();
-	MaterialX::ShaderRefPtr shaderRef = element->asA<MaterialX::ShaderRef>();
+	MaterialX::OutputPtr output = _element->asA<MaterialX::Output>();
+	MaterialX::ShaderRefPtr shaderRef = _element->asA<MaterialX::ShaderRef>();
 	if (!output && !shaderRef)
 	{
 		// Should never occur as we pre-filter renderables before creating the node + override
@@ -91,11 +78,41 @@ void MaterialXData::createXMLWrapper()
 	}
 	else
 	{
-		// TODO: This just indicates that lighting is required. As direct lighting
+        std::unique_ptr<MaterialX::GenContext> glslContext{
+            new MaterialX::GenContext(MaterialX::GlslShaderGenerator::create())
+        };
+
+        // Stop emission of environment map lookups.
+        glslContext->registerSourceCodeSearchPath(_libSearchPath);
+        if (shaderRef)
+        {
+            glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_FIS;
+            glslContext->getOptions().hwMaxActiveLightSources = 0;
+        }
+        else
+        {
+            glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_NONE;
+        }
+        glslContext->getOptions().fileTextureVerticalFlip = true;
+
+        _xmlFragmentWrapper.reset(new MaterialX::OGSXMLFragmentWrapper(glslContext.get()));
+        _xmlFragmentWrapper->setOutputVertexShader(false);
+
+        // TODO: This just indicates that lighting is required. As direct lighting
+        // is not supported, the requirement means that indirect lighting is required.
+        // bool requiresLighting = (shaderRef != nullptr);
+        std::cout << "MaterialXTextureOverride: Create XML wrapper" << std::endl;
+        _xmlFragmentWrapper->createWrapper(_element);
+        // Get the fragment name
+        _fragmentName.set(_xmlFragmentWrapper->getFragmentName().c_str());
+
+        _contexts.push_back(std::move(glslContext));
+        
+        // TODO: This just indicates that lighting is required. As direct lighting
 		// is not supported, the requirement means that indirect lighting is required.
 		// bool requiresLighting = (shaderRef != nullptr);
 		std::cout << "MaterialXTextureOverride: Create XML wrapper" << std::endl;
-		glslFragmentWrapper->createWrapper(element);
+		_xmlFragmentWrapper->createWrapper(_element);
 	}
 }
 
@@ -107,17 +124,28 @@ void MaterialXData::registerFragments()
 	{
         if (MHWRender::MFragmentManager* fragmentMgr = theRenderer->getFragmentManager())
 		{
-			const bool fragmentExists = (glslFragmentWrapper->getFragmentName().size() > 0)
-                && fragmentMgr->hasFragment(glslFragmentWrapper->getFragmentName().c_str());
+			const bool fragmentExists = (_xmlFragmentWrapper->getFragmentName().size() > 0)
+                && fragmentMgr->hasFragment(_xmlFragmentWrapper->getFragmentName().c_str());
 
 			if (!fragmentExists)
 			{
-				std::stringstream glslStream;
-				glslFragmentWrapper->getDocument(glslStream);
-				const std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
-				fragmentName = fragmentMgr->addShadeFragmentFromFile(xmlFileName.c_str(), false);
+                std::stringstream glslStream;
+                _xmlFragmentWrapper->getDocument(glslStream);
+                //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
+                std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
 
-                if (fragmentName.length() == 0)
+                // TODO: This should not be hard-coded
+                std::string dumpPath("d:/work/shader_dump/");
+                MaterialX::FileSearchPath path = MaterialX::getEnvironmentPath("TEMP");
+                if (path.size() > 0)
+                {
+                    dumpPath = path[0].asString();
+                }
+                fragmentMgr->setEffectOutputDirectory(dumpPath.c_str());
+                fragmentMgr->setIntermediateGraphOutputDirectory(dumpPath.c_str());
+                _fragmentName = fragmentMgr->addShadeFragmentFromFile(xmlFileName.c_str(), false);
+
+                if (_fragmentName.length() == 0)
                 {
                     throw MaterialX::Exception("Failed to add OGS shader fragment from file.");
                 }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -11,12 +11,12 @@
 
 MaterialXData::MaterialXData(const std::string& materialXDocument, const std::string& elementPath)
 {
-	_libSearchPath = Plugin::instance().getLibrarySearchPath();
+	_librarySearchPath = Plugin::instance().getLibrarySearchPath();
 	createDocument(materialXDocument);
 
-	if (_doc)
+	if (_document)
 	{
-		_element = _doc->getDescendant(elementPath);
+		_element = _document->getDescendant(elementPath);
 	}
 
     if (!_element)
@@ -32,12 +32,12 @@ MaterialXData::~MaterialXData()
 void MaterialXData::createDocument(const std::string& materialXDocument)
 {
 	// Create document
-	_doc = MaterialX::createDocument();
-	MaterialX::readFromXmlFile(_doc, materialXDocument);
+	_document = MaterialX::createDocument();
+	MaterialX::readFromXmlFile(_document, materialXDocument);
 
 	// Load libraries
 	const MaterialX::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
-	MaterialX::loadLibraries(libraries, _libSearchPath, _doc);
+	MaterialX::loadLibraries(libraries, _librarySearchPath, _document);
 }
 
 bool MaterialXData::isValidOutput()
@@ -50,7 +50,7 @@ bool MaterialXData::isValidOutput()
 	const std::string& elementPath = _element->getNamePath();
 	std::vector<MaterialX::TypedElementPtr> elements;
 	try {
-		MaterialX::findRenderableElements(_doc, elements);
+		MaterialX::findRenderableElements(_document, elements);
 		for (MaterialX::TypedElementPtr currentElement : elements)
 		{
 			std::string pathCompare(currentElement->getNamePath());
@@ -83,7 +83,7 @@ void MaterialXData::createXMLWrapper()
         };
 
         // Stop emission of environment map lookups.
-        glslContext->registerSourceCodeSearchPath(_libSearchPath);
+        glslContext->registerSourceCodeSearchPath(_librarySearchPath);
         if (shaderRef)
         {
             glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_FIS;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -67,6 +67,11 @@ bool MaterialXData::isValidOutput()
 	return false;
 }
 
+bool MaterialXData::elementIsAShader() const
+{
+    return (_element ? _element->isA<MaterialX::ShaderRef>() : false);
+}
+
 void MaterialXData::createXMLWrapper()
 {
 	MaterialX::OutputPtr output = _element->asA<MaterialX::Output>();

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -27,17 +27,17 @@ struct MaterialXData
     /// The element path and document that the element resides in are passed in
     /// as input arguments
     MaterialXData(const std::string& materialXDocument, const std::string& elementPath);
-	~MaterialXData();
+    ~MaterialXData();
 
     /// Returns whether the element set to render is a valid output
-	bool isValidOutput();
+    bool isValidOutput();
 
     /// Create the OGS XML wrapper for shader fragments associated
     /// with the element set to render
-	void createXMLWrapper();
+    void createXMLWrapper();
 
     /// Register the fragment(s)
-	void registerFragments();
+    void registerFragments();
 
     MaterialXData& operator=(const MaterialXData&) = delete;
     MaterialXData& operator=(MaterialXData&&) = delete;
@@ -60,6 +60,10 @@ struct MaterialXData
         return _xmlFragmentWrapper.get();
     }
 
+    /// Return if the element to render represents a shader graph
+    /// as opposed to a texture grraph.
+    bool elementIsAShader() const;
+
   protected:
     MaterialX::FilePath _librarySearchPath;
     MaterialX::DocumentPtr _document;
@@ -70,7 +74,7 @@ struct MaterialXData
     std::vector<std::unique_ptr<MaterialX::GenContext>> _contexts;
 
   private:
-	void createDocument(const std::string& materialXDocument);
+    void createDocument(const std::string& materialXDocument);
 };
 
 #endif // MATERIALX_DATA_H

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -3,16 +3,18 @@
 
 #include <MaterialXCore/Document.h>
 #include <MaterialXGenShader/GenContext.h>
-
-#include "../OGSXMLFragmentWrapper.h"
+#include <MaterialXContrib/OGSXMLFragmentWrapper.h>
 
 #include <maya/MString.h>
 
 #include <vector>
 
+using OGSXMLFragmentWrapperPtr = std::unique_ptr<MaterialX::OGSXMLFragmentWrapper>;
+
 struct MaterialXData
 {
-	MaterialXData(const std::string& materialXDocument, const std::string& elementPath);
+  public:
+    MaterialXData(const std::string& materialXDocument, const std::string& elementPath);
 	~MaterialXData();
 
 	bool isValidOutput();
@@ -22,13 +24,29 @@ struct MaterialXData
     MaterialXData& operator=(const MaterialXData&) = delete;
     MaterialXData& operator=(MaterialXData&&) = delete;
 
-	MaterialX::FilePath libSearchPath;
-	MaterialX::DocumentPtr doc;
-	MaterialX::ElementPtr element;
+    MaterialX::DocumentPtr getDocument() const
+    {
+        return _doc;
+    }
 
-	MString fragmentName;
-	std::unique_ptr<MaterialX::OGSXMLFragmentWrapper> glslFragmentWrapper;
-	std::vector<std::unique_ptr<MaterialX::GenContext>> contexts;
+    const MString& getFragmentName()
+    {
+        return _fragmentName;
+    }
+
+    MaterialX::OGSXMLFragmentWrapper* getFragmentWrapper() const
+    {
+        return _xmlFragmentWrapper.get();
+    }
+
+  protected:
+	MaterialX::FilePath _libSearchPath;
+	MaterialX::DocumentPtr _doc;
+	MaterialX::ElementPtr _element;
+
+	MString _fragmentName;
+    OGSXMLFragmentWrapperPtr _xmlFragmentWrapper;
+	std::vector<std::unique_ptr<MaterialX::GenContext>> _contexts;
 
   private:
 	void createDocument(const std::string& materialXDocument);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -1,52 +1,73 @@
 #ifndef MATERIALX_DATA_H
 #define MATERIALX_DATA_H
 
+/// @file
+/// MaterialX Data wrapper
+
 #include <MaterialXCore/Document.h>
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXContrib/OGSXMLFragmentWrapper.h>
 
 #include <maya/MString.h>
 
-#include <vector>
-
-using OGSXMLFragmentWrapperPtr = std::unique_ptr<MaterialX::OGSXMLFragmentWrapper>;
-
+/// @class MaterialXData
+/// Wrapper for MaterialX associated data. 
+///
+/// Keeps track of an element to render and it's associated document.
+///
+/// Can optionally create and cache an OGS XML wrapper instance 
+/// which wraps up the interface and shader code shader code generated based 
+/// on the specified element to render.
+/// Currently only code for GLSL is generated.
+///
 struct MaterialXData
 {
   public:
+    /// Create MaterialX data constainer.
+    /// The element path and document that the element resides in are passed in
+    /// as input arguments
     MaterialXData(const std::string& materialXDocument, const std::string& elementPath);
 	~MaterialXData();
 
+    /// Returns whether the element set to render is a valid output
 	bool isValidOutput();
+
+    /// Create the OGS XML wrapper for shader fragments associated
+    /// with the element set to render
 	void createXMLWrapper();
+
+    /// Register the fragment(s)
 	void registerFragments();
 
     MaterialXData& operator=(const MaterialXData&) = delete;
     MaterialXData& operator=(MaterialXData&&) = delete;
 
+    /// Return MaterialX document 
     MaterialX::DocumentPtr getDocument() const
     {
-        return _doc;
+        return _document;
     }
 
-    const MString& getFragmentName()
+    /// Return name of shader fragment
+    const MString& getFragmentName() const
     {
         return _fragmentName;
     }
 
+    /// Retuern pointer to the OGS XML wrapper
     MaterialX::OGSXMLFragmentWrapper* getFragmentWrapper() const
     {
         return _xmlFragmentWrapper.get();
     }
 
   protected:
-	MaterialX::FilePath _libSearchPath;
-	MaterialX::DocumentPtr _doc;
-	MaterialX::ElementPtr _element;
+    MaterialX::FilePath _librarySearchPath;
+    MaterialX::DocumentPtr _document;
+    MaterialX::ElementPtr _element;
 
-	MString _fragmentName;
-    OGSXMLFragmentWrapperPtr _xmlFragmentWrapper;
-	std::vector<std::unique_ptr<MaterialX::GenContext>> _contexts;
+    MString _fragmentName;
+    std::unique_ptr<MaterialX::OGSXMLFragmentWrapper> _xmlFragmentWrapper;
+    std::vector<std::unique_ptr<MaterialX::GenContext>> _contexts;
 
   private:
 	void createDocument(const std::string& materialXDocument);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -169,38 +169,38 @@ bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataH
 				std::string type = valueElement->getType();
 				if (type == MaterialX::TypedValue<MaterialX::Vector2>::TYPE)
 				{
-					double2& value = dataHandle.asDouble2();
-					valueElement->setValue(MaterialX::Vector2(static_cast<float>(value[0]), static_cast<float>(value[1])));
+                    float2& value = dataHandle.asFloat2();
+                    valueElement->setValue(MaterialX::Vector2(value[0], value[1]));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Vector3>::TYPE)
 				{
-					double3& value = dataHandle.asDouble3();
-					valueElement->setValue(MaterialX::Vector3(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2])));
+                    float3& value = dataHandle.asFloat3();
+                    valueElement->setValue(MaterialX::Vector3(value[0], value[1], value[2]));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Vector4>::TYPE)
 				{
-					//double4& value = dataHandle.asDouble4();
-					//valueElement->setValue(MaterialX::Vector4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
+                    MFloatVector& value = dataHandle.asFloatVector();
+                    valueElement->setValue(MaterialX::Vector4(value[0], value[1], value[2], value[3]));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Color2>::TYPE)
 				{
-					double2& value = dataHandle.asDouble2();
-					valueElement->setValue(MaterialX::Color2(static_cast<float>(value[0]), static_cast<float>(value[1])));
+                    float2& value = dataHandle.asFloat2();
+                    valueElement->setValue(MaterialX::Color2(value[0], value[1]));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Color3>::TYPE)
 				{
-					double3& value = dataHandle.asDouble3();
-					valueElement->setValue(MaterialX::Color3(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2])));
+					float3& value = dataHandle.asFloat3();
+					valueElement->setValue(MaterialX::Color3(value[0], value[1], value[2]));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Color4>::TYPE)
 				{
-					//double4& value = dataHandle.asDouble4();
-					//valueElement->setValue(MaterialX::Color4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
+					MFloatVector& value = dataHandle.asFloatVector();
+                    valueElement->setValue(MaterialX::Color4(value[0], value[1], value[2], value[3]));
 				}
 				else if (type == MaterialX::TypedValue<float>::TYPE)
 				{
-					double& value = dataHandle.asDouble();
-					valueElement->setValue(static_cast<float>(value));
+					float& value = dataHandle.asFloat();
+					valueElement->setValue(value);
 				}
 			}
 		}

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -4,6 +4,7 @@
 
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MStringArray.h>
+#include <maya/MPlugArray.h>
 #include <maya/MDGModifier.h>
 #include <maya/MFnStringData.h>
 #include <maya/MFnTypedAttribute.h>
@@ -89,7 +90,7 @@ void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 	{
 		MFnNumericAttribute nAttr;
 
-		MString outputName = materialXData->glslFragmentWrapper->getFragmentName().c_str();
+		MString outputName = materialXData->getFragmentWrapper()->getFragmentName().c_str();
 		_outAttr = nAttr.createColor(outputName, outputName);
 		CHECK_MSTATUS(nAttr.setStorable(false));
 		CHECK_MSTATUS(nAttr.setInternal(false));
@@ -135,7 +136,7 @@ bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataH
 	}
 	else if (plug == ELEMENT_ATTRIBUTE)
 	{
-		if (materialXData->doc)
+		if (materialXData->getDocument())
 		{
 			//MString elementPath = dataHandle.asString();
 			//materialXData->element = materialXData->doc->getDescendant(elementPath.asChar());
@@ -172,8 +173,8 @@ bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataH
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Vector4>::TYPE)
 				{
-					double4& value = dataHandle.asDouble4();
-					valueElement->setValue(MaterialX::Vector4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
+					//double4& value = dataHandle.asDouble4();
+					//valueElement->setValue(MaterialX::Vector4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Color2>::TYPE)
 				{
@@ -187,8 +188,8 @@ bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataH
 				}
 				else if (type == MaterialX::TypedValue<MaterialX::Color4>::TYPE)
 				{
-					double4& value = dataHandle.asDouble4();
-					valueElement->setValue(MaterialX::Color4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
+					//double4& value = dataHandle.asDouble4();
+					//valueElement->setValue(MaterialX::Color4(static_cast<float>(value[0]), static_cast<float>(value[1]), static_cast<float>(value[2]), static_cast<float>(value[3])));
 				}
 				else if (type == MaterialX::TypedValue<float>::TYPE)
 				{
@@ -220,12 +221,16 @@ void MaterialXNode::setAttributeValue(MObject &materialXObject, MObject &attr, f
 
 void MaterialXNode::createAttributesFromDocument(MDGModifier& mdgModifier)
 {
-	if (!materialXData || !materialXData->doc) return;
+    MaterialX::DocumentPtr document;
+    if (!materialXData || !(document= materialXData->getDocument()))
+    {
+        return;
+    }
 
-	const MaterialX::StringMap& inputMap = materialXData->glslFragmentWrapper->getPathInputMap();
+	const MaterialX::StringMap& inputMap = materialXData->getFragmentWrapper()->getPathInputMap();
 	for (auto it = inputMap.begin(); it != inputMap.end(); ++it)
 	{
-		MaterialX::ElementPtr element = materialXData->doc->getDescendant(it->first);
+		MaterialX::ElementPtr element = document->getDescendant(it->first);
 		if (!element) continue;
 		MObject mobject = thisMObject();
 		if (element->isA<MaterialX::ValueElement>())

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -86,21 +86,27 @@ MStatus MaterialXNode::initialize()
 
 void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 {
-	if (materialXData)
+	if (materialXData && materialXData->getFragmentWrapper())
 	{
-		MFnNumericAttribute nAttr;
+        const MaterialX::StringMap& outputMap = materialXData->getFragmentWrapper()->getPathOutputMap();
+        if (outputMap.size())
+        {
+            MString outputName(outputMap.begin()->second.c_str());
+            if (outputName.length())
+            {
+                MFnNumericAttribute nAttr;
+                _outAttr = nAttr.createColor(outputName, outputName);
+                CHECK_MSTATUS(nAttr.setStorable(false));
+                CHECK_MSTATUS(nAttr.setInternal(false));
+                CHECK_MSTATUS(nAttr.setReadable(true));
+                CHECK_MSTATUS(nAttr.setWritable(false));
+                CHECK_MSTATUS(nAttr.setCached(true));
+                CHECK_MSTATUS(nAttr.setHidden(false));
 
-		MString outputName = materialXData->getFragmentWrapper()->getFragmentName().c_str();
-		_outAttr = nAttr.createColor(outputName, outputName);
-		CHECK_MSTATUS(nAttr.setStorable(false));
-		CHECK_MSTATUS(nAttr.setInternal(false));
-		CHECK_MSTATUS(nAttr.setReadable(true));
-		CHECK_MSTATUS(nAttr.setWritable(false));
-		CHECK_MSTATUS(nAttr.setCached(true));
-		CHECK_MSTATUS(nAttr.setHidden(false));
-
-		mdgModifier.addAttribute(thisMObject(), _outAttr);
-//		CHECK_MSTATUS(addAttribute(_outAttr));
+                mdgModifier.addAttribute(thisMObject(), _outAttr);
+                //		CHECK_MSTATUS(addAttribute(_outAttr));
+            }
+        }
 	}
 }
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
@@ -86,8 +86,8 @@ MaterialXTextureOverride::MaterialXTextureOverride(const MObject& obj)
                 {
                     std::stringstream glslStream;
                     _glslWrapper->getDocument(glslStream);
-                    //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
-                    std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
+                    std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
+                    //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
                     
                     // TODO: This should not be hard-coded
                     std::string dumpPath("d:/work/shader_dump/");

--- a/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
@@ -210,7 +210,8 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
     std::string envIrradiancePath = "san_giuseppe_bridge_diffuse.hdr";
     const std::string irradianceParameter("u_envIrradiance");
     const std::string radianceParameter("u_envRadiance");
-    MString radianceMipsParameter("u_envRadianceMips");
+    const std::string radianceMipsParameter("u_envRadianceMips");
+    const std::string environmentMatrixParameter("u_envMatrix");
 
     // Bind globals which are not associated with any document elements
     const MaterialX::StringVec& globals = node->materialXData->getFragmentWrapper()->getGlobalsList();
@@ -236,14 +237,32 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
                 {
                     if (status == MStatus::kSuccess)
                     {
-                        if (parameterList.indexOf(radianceMipsParameter) >= 0)
+                        if (parameterList.indexOf(radianceMipsParameter.c_str()) >= 0)
                         {
                             int mipCount = (int)std::log2(std::max(textureDescription.fWidth, textureDescription.fHeight)) + 1;
-                            status = shader.setParameter(radianceMipsParameter, mipCount);
+                            status = shader.setParameter(radianceMipsParameter.c_str(), mipCount);
                             std::cout << "Bind radiance mip count: " << mipCount << " Status: " << status << std::endl;
                         }
                     }
                 }
+            }
+        }
+
+        // Environment matrix
+        else if (global == environmentMatrixParameter)
+        {
+            if (parameterList.indexOf(global.c_str()) >= 0)
+            {
+                const float yRotationPI[4][4]{
+                    -1, 0, 0, 0,
+                    0, 1, 0, 0,
+                    0, 0, -1, 0,
+                    0, 0, 0, 1
+                };
+                MFloatMatrix matrix(yRotationPI);
+                //matrix.setToIdentity();
+                status = shader.setParameter(environmentMatrixParameter.c_str(), matrix);
+                std::cout << "Bind environment matrix: " << environmentMatrixParameter << ". Status: " << status << std::endl;
             }
         }
     }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
@@ -155,13 +155,26 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shader, const std::string& p
                     MHWRender::MTextureAssignment textureAssignment;
                     textureAssignment.texture = texture;
                     status = shader.setParameter(parameterName.c_str(), textureAssignment);
-                    std::cout << "Bound file: " << imagePath.asString() << " to shader parameter:" << parameterName << ". Status: " << status << std::endl;
+                    std::cout << "Bound file: " << imagePath.asString() << " to shader parameter:" << parameterName << ". Status: " << 
+                        status << "\r\n";
 
                     // release our reference now that it is set on the shader
                     textureManager->releaseTexture(texture);
                 }
             }
         }
+    }
+
+    // Bind sampler
+    std::string samplerParameterName(parameterName + "Sampler");
+    MHWRender::MSamplerStateDesc desc;
+    desc.filter = MHWRender::MSamplerState::kAnisotropic;
+    desc.maxAnisotropy = 16;
+    const MSamplerState* samplerState = MHWRender::MStateManager::acquireSamplerState(desc);
+    if (samplerState)
+    {
+        status = shader.setParameter(samplerParameterName.c_str(), *samplerState);
+        std::cout << "Bind sampler: " << samplerParameterName << ". Status: " << status << "\r\n";
     }
 
     return status;
@@ -182,7 +195,7 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
     shader.parameterList(params);
     for (unsigned int j = 0; j < params.length(); j++)
     {
-        std::cout << "MaterialXTextureOverride: shader param: " << params[j].asChar() << std::endl;
+        std::cout << "MaterialXTextureOverride: shader param: " << params[i].asChar() << "\n";
     }
 
     MaterialX::FileSearchPath imageSearchPath(Plugin::instance().getResourcePath() / MaterialX::FilePath("Images"));
@@ -226,7 +239,6 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
 			{
                 // This is the hard-cided OGS convention to associate a texture with a sampler (via post-fix "Sampler" string)
                 std::string textureParameterName(resolvedName.asChar());
-                std::string samplerParameterName(textureParameterName + "Sampler");
 
                 // Bind texture
                 std::string fileName; 
@@ -234,17 +246,6 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
                 if (!valueString.empty())
                 {
                     status = bindFileTexture(shader, textureParameterName, imageSearchPath, valueString);
-                }
-
-                // Bind sampler
-                MHWRender::MSamplerStateDesc desc;
-                desc.filter = MHWRender::MSamplerState::kAnisotropic;
-                desc.maxAnisotropy = 16;
-                const MSamplerState* samplerState = MHWRender::MStateManager::acquireSamplerState(desc);
-                if (samplerState)
-                {
-                    status = shader.setParameter(samplerParameterName.c_str(), *samplerState);
-                    std::cout << "Bind sampler: " << samplerParameterName << ". Status: " << status << std::endl;
                 }
 			}
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.h
@@ -35,6 +35,9 @@ private:
 	MaterialXTextureOverride(const MObject& obj);
 
 	MObject _object;
+
+    // Is editing allowed
+    bool _enableEditing;
 };
 
 /////////////////////////////////////////////

--- a/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
@@ -1,24 +1,21 @@
 <?xml version="1.0"?>
-<fragment uiName="SR_default" name="SR_default" type="plumbing" class="ShadeFragment" version="1.36">
-  <description><![CDATA[MaterialX generated code for element: SR_default]]></description>
+<fragment uiName="SR_brass1" name="SR_brass1" type="plumbing" class="ShadeFragment" version="1">
+  <description><![CDATA[Code generated from MaterialX description]]></description>
   <properties>
-     <!-- Non varying parameter name can be used as is. Varying come through via a structure. -->
     <float4x4 name="u_envMatrix" flags="isRequirementOnly" />
     <texture2 name="u_envIrradiance" flags="isRequirementOnly" />
-    <sampler name="u_envIrradianceSampler" flags="isRequirementOnly" /> <!-- TODO: Follow OGS convention of adding "Sampler" to the texture name -->
+    <sampler name="u_envIrradianceSampler" flags="isRequirementOnly" />
     <texture2 name="u_envRadiance" flags="isRequirementOnly" />
-    <sampler name="u_envRadianceSampler" flags="isRequirementOnly" /> <!-- TODO: Follow OGS convention of adding "Sampler" to the texture name -->
+    <sampler name="u_envRadianceSampler" flags="isRequirementOnly" />
     <int name="u_envRadianceMips" flags="isRequirementOnly" />
     <int name="u_envSamples" flags="isRequirementOnly" />
     <float3 name="u_viewPosition" semantic="WorldCameraPosition" flags="isRequirementOnly" />
     <int name="u_numActiveLightSources" flags="isRequirementOnly" />
-     <!-- end non-varying globals -->
     <float name="base" />
     <float3 name="base_color" />
     <float name="diffuse_roughness" />
     <float name="specular" />
     <float3 name="specular_color" />
-    <float name="specular_roughness" />
     <float name="specular_IOR" />
     <float name="specular_anisotropy" />
     <float name="specular_rotation" />
@@ -40,8 +37,6 @@
     <float name="sheen_roughness" />
     <bool name="thin_walled" />
     <float name="coat" />
-    <float3 name="coat_color" />
-    <float name="coat_roughness" />
     <float name="coat_anisotropy" />
     <float name="coat_rotation" />
     <float name="coat_IOR" />
@@ -52,27 +47,43 @@
     <float name="emission" />
     <float3 name="emission_color" />
     <float3 name="opacity" />
-     <!-- Varying globals come in through input structure -->
-    <float3 name="positionWorld" semantic="Pw" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="normalWorld" semantic="Nw" flags="isRequirementOnly, varyingInputParam" />
+    <texture2 name="image_roughness_file" />
+    <sampler name="image_roughness_fileSampler" />
+    <float name="image_roughness_default" />
+    <float2 name="image_roughness_uvtiling" />
+    <float2 name="image_roughness_uvoffset" />
+    <int name="image_roughness_filtertype" />
+    <int name="image_roughness_framerange" />
+    <int name="image_roughness_frameoffset" />
+    <int name="image_roughness_frameendaction" />
+    <texture2 name="image_color_file" />
+    <sampler name="image_color_fileSampler" />
+    <float3 name="image_color_default" />
+    <float2 name="image_color_uvtiling" />
+    <float2 name="image_color_uvoffset" />
+    <int name="image_color_filtertype" />
+    <int name="image_color_framerange" />
+    <int name="image_color_frameoffset" />
+    <int name="image_color_frameendaction" />
     <float3 name="tangentWorld" semantic="mayaTangentIn" flags="isRequirementOnly, varyingInputParam" />
-     <!-- end varying globals -->
+    <float3 name="normalWorld" semantic="Nw" flags="isRequirementOnly, varyingInputParam" />
+    <float2 name="texcoord_0" semantic="mayaUvCoordSemantic" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="positionWorld" semantic="Pw" flags="isRequirementOnly, varyingInputParam" />
   </properties>
   <values>
     <float4x4 name="u_envMatrix" value="-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1" />
     <int name="u_envRadianceMips" value="1" />
     <int name="u_envSamples" value="16" />
     <int name="u_numActiveLightSources" value="0" />
-    <float name="base" value="0.8" />
+    <float name="base" value="1" />
     <float3 name="base_color" value="1, 1, 1" />
     <float name="diffuse_roughness" value="0" />
-    <float name="specular" value="1" />
+    <float name="specular" value="0" />
     <float3 name="specular_color" value="1, 1, 1" />
-    <float name="specular_roughness" value="0.1" />
     <float name="specular_IOR" value="1.52" />
     <float name="specular_anisotropy" value="0" />
     <float name="specular_rotation" value="0" />
-    <float name="metalness" value="0" />
+    <float name="metalness" value="1" />
     <float name="transmission" value="0" />
     <float3 name="transmission_color" value="1, 1, 1" />
     <float name="transmission_depth" value="0" />
@@ -89,9 +100,7 @@
     <float3 name="sheen_color" value="1, 1, 1" />
     <float name="sheen_roughness" value="0.3" />
     <bool name="thin_walled" value="false" />
-    <float name="coat" value="0" />
-    <float3 name="coat_color" value="1, 1, 1" />
-    <float name="coat_roughness" value="0.1" />
+    <float name="coat" value="1" />
     <float name="coat_anisotropy" value="0" />
     <float name="coat_rotation" value="0" />
     <float name="coat_IOR" value="1.5" />
@@ -102,20 +111,30 @@
     <float name="emission" value="0" />
     <float3 name="emission_color" value="1, 1, 1" />
     <float3 name="opacity" value="1, 1, 1" />
+    <float name="image_roughness_default" value="0" />
+    <float2 name="image_roughness_uvtiling" value="1, 1" />
+    <float2 name="image_roughness_uvoffset" value="0, 0" />
+    <int name="image_roughness_filtertype" value="1" />
+    <int name="image_roughness_frameoffset" value="0" />
+    <int name="image_roughness_frameendaction" value="0" />
+    <float3 name="image_color_default" value="0, 0, 0" />
+    <float2 name="image_color_uvtiling" value="1, 1" />
+    <float2 name="image_color_uvoffset" value="0, 0" />
+    <int name="image_color_filtertype" value="1" />
+    <int name="image_color_frameoffset" value="0" />
+    <int name="image_color_frameendaction" value="0" />
   </values>
   <outputs>
     <float3 name="out" />
   </outputs>
   <implementation>
     <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
-       <!-- Note: we cannot use the function main, since OGS effect building will use the funciton main() -->
-       <function_name val="main_function" />
-       <source>
-   <![CDATA[#define M_PI 3.1415926535897932384626433832795
+      <function_name val="SR_brass1" />
+      <source><![CDATA[#define M_PI 3.1415926535897932384626433832795
 #define M_PI_INV 1.0/3.1415926535897932384626433832795
 #define M_GOLDEN_RATIO 1.6180339887498948482045868343656
 #define M_FLOAT_EPS 0.000001
-#define MAX_LIGHT_SOURCES 1
+#define MAX_LIGHT_SOURCES 3
 
 #define BSDF vec3
 #define EDF vec3
@@ -125,43 +144,6 @@ struct surfaceshader { vec3 color; vec3 transparency; };
 struct volumeshader { VDF vdf; EDF edf; };
 struct displacementshader { vec3 offset; float scale; };
 struct lightshader { vec3 intensity; vec3 direction; };
-
-// TODO: Is generated so cannot be added here otherwise it will show up twice.
-// Uniform block: PrivateUniforms
-//uniform mat4 u_envMatrix = mat4(-1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 0.000000, -1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000);
-//uniform sampler2D u_envIrradianceSampler;
-//uniform sampler2D u_envRadianceSampler;
-//uniform int u_envRadianceMips = 1;
-//uniform int u_envSamples = 16;
-//uniform vec3 u_viewPosition = vec3(0.0);
-//uniform int u_numActiveLightSources = 0;
-
-// Manually comment out. These should never be output by any generator in the
-// first place since it is never used.
-//uniform int geomprop_Nworld_space = 2;
-//uniform int geomprop_Tworld_space = 2;
-//uniform int geomprop_Tworld_index = 0;
-
-struct LightData
-{
-    int type;
-};
-
-uniform LightData u_lightData[MAX_LIGHT_SOURCES];
-
-// Manually commented out. This is only the pixel shader so comment
-// out the vertex in and pixel out
-// Q: Can make this a input requirement, but how to tell what the name of the
-// input structure for the pixel shader. Seems to be PIX_IN for some reason.
-//in VertexData
-//{
-//    vec3 normalWorld;
-//    vec3 tangentWorld;
-//    vec3 positionWorld;
-//} vd;
-
-// Pixel shader outputs
-//out vec4 out1;
 
 float mx_square(float x)
 {
@@ -523,7 +505,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, roughnessinfo roughness, in
 
 vec3 mx_environment_irradiance(vec3 N)
 {
-    return mx_latlong_map_lookup(N, u_envMatrix, 0.0, u_envIrradianceSampler);
+    return mx_latlong_map_lookup(N, u_envMatrix, 0.0, u_envIrradiancSampler);
 }
 
 //
@@ -542,6 +524,52 @@ int numActiveLightSources()
 void sampleLightSource(LightData light, vec3 position, out lightshader result)
 {
     result.intensity = vec3(0.0);
+}
+
+void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out float result)
+{
+    // TODO: Fix handling of addressmode
+    if(textureSize(tex_sampler, 0).x > 1)
+    {
+        vec2 uv = mx_get_target_uv(texcoord);
+        result = texture(tex_sampler, uv).r;
+    }
+    else
+    {
+        result = defaultval;
+    }
+}
+
+void NG_tiledimage_float(sampler2D file, float default1, vec2 texcoord, vec2 uvtiling, vec2 uvoffset, int filtertype, int framerange, int frameoffset, int frameendaction, out float N_out_float)
+{
+    vec2 N_mult_float_out = texcoord * uvtiling;
+    vec2 N_sub_float_out = N_mult_float_out - uvoffset;
+    float N_img_float_out = 0.0;
+    mx_image_float(file, 0, default1, N_sub_float_out, 2, 2, filtertype, framerange, frameoffset, frameendaction, N_img_float_out);
+    N_out_float = N_img_float_out;
+}
+
+void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec3 result)
+{
+    // TODO: Fix handling of addressmode
+    if(textureSize(tex_sampler, 0).x > 1)
+    {
+        vec2 uv = mx_get_target_uv(texcoord);
+        result = texture(tex_sampler, uv).rgb;
+    }
+    else
+    {
+        result = defaultval;
+    }
+}
+
+void NG_tiledimage_color3(sampler2D file, vec3 default1, vec2 texcoord, vec2 uvtiling, vec2 uvoffset, int filtertype, int framerange, int frameoffset, int frameendaction, out vec3 N_out_color3)
+{
+    vec2 N_mult_color3_out = texcoord * uvtiling;
+    vec2 N_sub_color3_out = N_mult_color3_out - uvoffset;
+    vec3 N_img_color3_out = vec3(0.0);
+    mx_image_color3(file, 0, default1, N_sub_color3_out, 2, 2, filtertype, framerange, frameoffset, frameendaction, N_img_color3_out);
+    N_out_color3 = N_img_color3_out;
 }
 
 void mx_roughness_anisotropy(float roughness, float anisotropy, out roughnessinfo result)
@@ -692,34 +720,6 @@ void mx_diffuse_brdf_indirect(vec3 V, float weight, vec3 color, float roughness,
     result = Li * color * weight;
 }
 
-// Fake with simple diffuse transmission
-void mx_subsurface_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out BSDF result)
-{
-    // Invert normal since we're transmitting light from the other side
-    float NdotL = dot(L, -normal);
-    if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
-    {
-        result = BSDF(0.0);
-        return;
-    }
-
-    result = color * weight * NdotL * M_PI_INV;
-}
-
-// Fake with simple diffuse transmission
-void mx_subsurface_brdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out vec3 result)
-{
-    if (weight < M_FLOAT_EPS)
-    {
-        result = vec3(0.0);
-        return;
-    }
-
-    // Invert normal since we're transmitting light from the other side
-    vec3 Li = mx_environment_irradiance(-normal);
-    result = Li * color * weight;
-}
-
 // We fake diffuse transmission by using diffuse reflection from the opposite side.
 // So this BTDF is really a BRDF.
 void mx_diffuse_btdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 normal, out BSDF result)
@@ -736,6 +736,34 @@ void mx_diffuse_btdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 n
 }
 
 void mx_diffuse_btdf_indirect(vec3 V, float weight, vec3 color, vec3 normal, out vec3 result)
+{
+    if (weight < M_FLOAT_EPS)
+    {
+        result = vec3(0.0);
+        return;
+    }
+
+    // Invert normal since we're transmitting light from the other side
+    vec3 Li = mx_environment_irradiance(-normal);
+    result = Li * color * weight;
+}
+
+// Fake with simple diffuse transmission
+void mx_subsurface_brdf_reflection(vec3 L, vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out BSDF result)
+{
+    // Invert normal since we're transmitting light from the other side
+    float NdotL = dot(L, -normal);
+    if (NdotL <= 0.0 || weight < M_FLOAT_EPS)
+    {
+        result = BSDF(0.0);
+        return;
+    }
+
+    result = color * weight * NdotL * M_PI_INV;
+}
+
+// Fake with simple diffuse transmission
+void mx_subsurface_brdf_indirect(vec3 V, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, out vec3 result)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -948,13 +976,13 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(PIX_IN.normalWorld);
-        vec3 V = normalize(u_viewPosition - PIX_IN.positionWorld);
+        vec3 N = normalize(vd.normalWorld);
+        vec3 V = normalize(u_viewPosition - vd.positionWorld);
         int numLights = numActiveLightSources();
         lightshader lightShader;
         for (int activeLightIndex = 0; activeLightIndex < numLights; ++activeLightIndex)
         {
-            sampleLightSource(u_lightData[activeLightIndex], PIX_IN.positionWorld, lightShader);
+            sampleLightSource(u_lightData[activeLightIndex], vd.positionWorld, lightShader);
             vec3 L = lightShader.direction;
 
             // Calculate the BSDF response for this light source
@@ -963,10 +991,10 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
             BSDF transmission_bsdf_out = BSDF(0.0);
             BSDF diffuse_bsdf_out = BSDF(0.0);
             mx_diffuse_brdf_reflection(L, V, base, coat_affected_diffuse_color_out, diffuse_roughness, normal, diffuse_bsdf_out);
-            BSDF subsurface_bsdf_out = BSDF(0.0);
-            mx_subsurface_brdf_reflection(L, V, 1.000000, coat_affected_subsurface_color_out, subsurface_radius, subsurface_anisotropy, normal, subsurface_bsdf_out);
             BSDF translucent_bsdf_out = BSDF(0.0);
             mx_diffuse_btdf_reflection(L, V, 1.000000, coat_affected_subsurface_color_out, normal, translucent_bsdf_out);
+            BSDF subsurface_bsdf_out = BSDF(0.0);
+            mx_subsurface_brdf_reflection(L, V, 1.000000, coat_affected_subsurface_color_out, subsurface_radius, subsurface_anisotropy, normal, subsurface_bsdf_out);
             BSDF sheen_bsdf_out = BSDF(0.0);
             mx_sheen_brdf_reflection(L, V, sheen, sheen_color, sheen_roughness, normal, diffuse_bsdf_out, sheen_bsdf_out);
             BSDF selected_subsurface_bsdf_out = BSDF(0.0);
@@ -1002,10 +1030,10 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
             BSDF transmission_bsdf_out = BSDF(0.0);
             BSDF diffuse_bsdf_out = BSDF(0.0);
             mx_diffuse_brdf_indirect(V, base, coat_affected_diffuse_color_out, diffuse_roughness, normal, diffuse_bsdf_out);
-            BSDF subsurface_bsdf_out = BSDF(0.0);
-            mx_subsurface_brdf_indirect(V, 1.000000, coat_affected_subsurface_color_out, subsurface_radius, subsurface_anisotropy, normal, subsurface_bsdf_out);
             BSDF translucent_bsdf_out = BSDF(0.0);
             mx_diffuse_btdf_indirect(V, 1.000000, coat_affected_subsurface_color_out, normal, translucent_bsdf_out);
+            BSDF subsurface_bsdf_out = BSDF(0.0);
+            mx_subsurface_brdf_indirect(V, 1.000000, coat_affected_subsurface_color_out, subsurface_radius, subsurface_anisotropy, normal, subsurface_bsdf_out);
             BSDF sheen_bsdf_out = BSDF(0.0);
             mx_sheen_brdf_indirect(V, sheen, sheen_color, sheen_roughness, normal, diffuse_bsdf_out, sheen_bsdf_out);
             BSDF selected_subsurface_bsdf_out = BSDF(0.0);
@@ -1032,68 +1060,83 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     out1 = standard_surface_constructor_out;
 }
 
-// TODO: Arguments here manually added. Need to modify generator to place uniforms here
-// versus as global.
-vec3 main_function(
-   float base,
-   vec3 base_color,
-   float diffuse_roughness,
-   float specular,
-   vec3 specular_color,
-   float specular_roughness,
-   float specular_IOR,
-   float specular_anisotropy,
-   float specular_rotation,
-   float metalness,
-   float transmission,
-   vec3 transmission_color,
-   float transmission_depth,
-   vec3 transmission_scatter,
-   float transmission_scatter_anisotropy,
-   float transmission_dispersion,
-   float transmission_extra_roughness,
-   float subsurface,
-   vec3 subsurface_color,
-   vec3 subsurface_radius,
-   float subsurface_scale,
-   float subsurface_anisotropy,
-   float sheen,
-   vec3 sheen_color,
-   float sheen_roughness,
-   bool thin_walled,
-   float coat,
-   vec3 coat_color,
-   float coat_roughness,
-   float coat_anisotropy,
-   float coat_rotation,
-   float coat_IOR,
-   float coat_affect_color,
-   float coat_affect_roughness,
-   float thin_film_thickness,
-   float thin_film_IOR,
-   float emission,
-   vec3 emission_color,
-   vec3 opacity
+vec3 SR_brass1
+(
+    float base,
+    vec3 base_color,
+    float diffuse_roughness,
+    float specular,
+    vec3 specular_color,
+    float specular_IOR,
+    float specular_anisotropy,
+    float specular_rotation,
+    float metalness,
+    float transmission,
+    vec3 transmission_color,
+    float transmission_depth,
+    vec3 transmission_scatter,
+    float transmission_scatter_anisotropy,
+    float transmission_dispersion,
+    float transmission_extra_roughness,
+    float subsurface,
+    vec3 subsurface_color,
+    vec3 subsurface_radius,
+    float subsurface_scale,
+    float subsurface_anisotropy,
+    float sheen,
+    vec3 sheen_color,
+    float sheen_roughness,
+    bool thin_walled,
+    float coat,
+    float coat_anisotropy,
+    float coat_rotation,
+    float coat_IOR,
+    float coat_affect_color,
+    float coat_affect_roughness,
+    float thin_film_thickness,
+    float thin_film_IOR,
+    float emission,
+    vec3 emission_color,
+    vec3 opacity,
+    uniform sampler2D image_roughness_fileSampler,
+    float image_roughness_default,
+    vec2 image_roughness_uvtiling,
+    vec2 image_roughness_uvoffset,
+    int image_roughness_filtertype,
+    int image_roughness_framerange,
+    int image_roughness_frameoffset,
+    int image_roughness_frameendaction,
+    uniform sampler2D image_color_fileSampler,
+    vec3 image_color_default,
+    vec2 image_color_uvtiling,
+    vec2 image_color_uvoffset,
+    int image_color_filtertype,
+    int image_color_framerange,
+    int image_color_frameoffset,
+    int image_color_frameendaction
 )
 {
-    vec3 geomprop_Nworld_out = normalize(PIX_IN.normalWorld);
     vec3 geomprop_Tworld_out = normalize(PIX_IN.tangentWorld);
+    vec3 geomprop_Nworld_out = normalize(PIX_IN.normalWorld);
+    vec2 geomprop_UV0_out = PIX_IN.texcoord_0;
+    float image_roughness_out = 0.0;
+    NG_tiledimage_float(image_roughness_fileSampler, image_roughness_default, geomprop_UV0_out, image_roughness_uvtiling, image_roughness_uvoffset, image_roughness_filtertype, image_roughness_framerange, image_roughness_frameoffset, image_roughness_frameendaction, image_roughness_out);
+    vec3 image_color_out = vec3(0.0);
+    NG_tiledimage_color3(image_color_fileSampler, image_color_default, geomprop_UV0_out, image_color_uvtiling, image_color_uvoffset, image_color_filtertype, image_color_framerange, image_color_frameoffset, image_color_frameendaction, image_color_out);
 
-    surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
-    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);
-    return vec3(1.0, 0.0, 0.0); //SR_default_out.color;
+    surfaceshader SR_brass1_out = surfaceshader(vec3(0.0),vec3(0.0));
+    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, image_color_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_brass1_out);
+    returnSR_brass1_out.color;
 }
-
 ]]></source>
     </implementation>
     <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
-      <function_name val="main" />
+      <function_name val="SR_brass1" />
       <source><![CDATA[// HLSL]]></source>
     </implementation>
     <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
-      <function_name val="main" />
-      <source>
-   <![CDATA[// Cg]]></source>
+      <function_name val="SR_brass1" />
+      <source><![CDATA[// Cg]]></source>
     </implementation>
   </implementation>
 </fragment>

--- a/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
@@ -513,7 +513,7 @@ vec3 mx_environment_irradiance(vec3 N)
 //
 vec2 mx_get_target_uv(vec2 uv)
 {
-   return uv;
+    return vec2(uv.x, 1.0 - uv.y);
 }
 
 int numActiveLightSources()

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -466,36 +466,10 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
 
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
 {
-    //vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
+    vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(dir);
     return textureLod(sampler, uv, lod).rgb;
 }
-
-
-/*
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lodBias, sampler2D sampler)
-{
-    vec2 res = textureSize(sampler, 0);
-    if (res.x > 0)
-    {
-        // Heuristic for faking a blur by roughness
-        int levels = 1 + int(floor(log2(max(res.x, res.y))));
-        lodBias = lodBias < 0.25 ? sqrt(lodBias) : 0.5*lodBias + 0.375;
-        float lod = lodBias * levels;
-
-        //vec3 dir = normalize((transform * vec4(dir,0.0)).xyz);
-        vec2 uv = mx_latlong_projection(dir);
-        return textureLod(sampler, uv, lod).rgb;
-    }
-    return vec3(0.0);
-}
-
-vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, roughnessinfo roughness, int distribution)
-{
-    vec3 dir = reflect(-V, N);
-    return mx_latlong_map_lookup(dir, u_envMatrix, roughness.alpha, u_envRadianceSampler);
-}
-        */
 
 // Only GGX is supported for now and the distribution argument is ignored
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, roughnessinfo roughness, int distribution)

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -10,7 +10,7 @@
     <sampler name="u_envRadianceSampler" flags="isRequirementOnly" /> <!-- TODO: Follow OGS convention of adding "Sampler" to the texture name -->
     <int name="u_envRadianceMips" flags="isRequirementOnly" />
     <int name="u_envSamples" flags="isRequirementOnly" />
-    <float3 name="u_viewPosition" semantic="WorldCameraPosition" flags="isRequirementOnly" />
+    <float3 name="u_viewPosition" semantic="WorldCameraPosition" flags="isRequirementOnly" /> <!-- or should this be ViewPosition ?-->
     <int name="u_numActiveLightSources" flags="isRequirementOnly" />
      <!-- end non-varying globals -->
     <float name="base" />
@@ -52,10 +52,11 @@
     <float name="emission" />
     <float3 name="emission_color" />
     <float3 name="opacity" />
-     <!-- Varying globals come in through input structure -->
-    <float3 name="positionWorld" semantic="Pw" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="normalWorld" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="tangentWorld" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
+     <!-- Varying globals come in through input structure
+          Name matters for space e.g. Nw means normal world  -->
+    <float3 name="Pw" semantic="POSITION" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="Nw" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="Tw" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
      <!-- end varying globals -->
   </properties>
   <values>
@@ -155,8 +156,8 @@ uniform LightData u_lightData[MAX_LIGHT_SOURCES];
 // input structure for the pixel shader. Seems to be PIX_IN for some reason.
 //in VertexData
 //{
-//    vec3 normalWorld;
-//    vec3 tangentWorld;
+//    vec3 Nw;
+//    vec3 Tw;
 //    vec3 positionWorld;
 //} vd;
 
@@ -914,13 +915,13 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
 {
     roughnessinfo coat_roughness_out = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
     mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_out);
-    vec3 geomprop_Tworld_out = normalize(PIX_IN.tangentWorld);
+    vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
     float coat_affect_roughness_multiply1_out = coat_affect_roughness * coat;
     const float coat_clamped_low_tmp = 0.000000;
     const float coat_clamped_high_tmp = 1.000000;
     float coat_clamped_out = clamp(coat, coat_clamped_low_tmp, coat_clamped_high_tmp);
     float subsurface_selector_out = float(thin_walled);
-    vec3 geomprop_Vworld_out = normalize(PIX_IN.positionWorld - u_viewPosition);
+    vec3 geomprop_Vworld_out = normalize(PIX_IN.Pw - u_viewPosition);
     const vec3 coat_attenuation_bg_tmp = vec3(1.000000, 1.000000, 1.000000);
     vec3 coat_attenuation_out = mix(coat_attenuation_bg_tmp, coat_color, coat);
     vec3 emission_weight_out = emission_color * emission;
@@ -948,13 +949,13 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(PIX_IN.normalWorld);
-        vec3 V = normalize(u_viewPosition - PIX_IN.positionWorld);
+        vec3 N = normalize(PIX_IN.Nw);
+        vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
         int numLights = numActiveLightSources();
         lightshader lightShader;
         for (int activeLightIndex = 0; activeLightIndex < numLights; ++activeLightIndex)
         {
-            sampleLightSource(u_lightData[activeLightIndex], PIX_IN.positionWorld, lightShader);
+            sampleLightSource(u_lightData[activeLightIndex], PIX_IN.Pw, lightShader);
             vec3 L = lightShader.direction;
 
             // Calculate the BSDF response for this light source
@@ -1076,8 +1077,8 @@ vec3 main_function(
    vec3 opacity
 )
 {
-    vec3 geomprop_Nworld_out = normalize(PIX_IN.normalWorld);
-    vec3 geomprop_Tworld_out = normalize(PIX_IN.tangentWorld);
+    vec3 geomprop_Nworld_out = normalize(PIX_IN.Nw);
+    vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
 
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -5,12 +5,12 @@
      <!-- Non varying parameter name can be used as is. Varying come through via a structure. -->
     <float4x4 name="u_envMatrix" flags="isRequirementOnly" />
     <texture2 name="u_envIrradiance" flags="isRequirementOnly" />
-    <sampler name="u_envIrradianceSampler" flags="isRequirementOnly" /> <!-- TODO: Follow OGS convention of adding "Sampler" to the texture name -->
+    <sampler name="u_envIrradianceSampler" flags="isRequirementOnly" />
     <texture2 name="u_envRadiance" flags="isRequirementOnly" />
-    <sampler name="u_envRadianceSampler" flags="isRequirementOnly" /> <!-- TODO: Follow OGS convention of adding "Sampler" to the texture name -->
+    <sampler name="u_envRadianceSampler" flags="isRequirementOnly" />
     <int name="u_envRadianceMips" flags="isRequirementOnly" />
     <int name="u_envSamples" flags="isRequirementOnly" />
-    <float3 name="u_viewPosition" semantic="WorldCameraPosition" flags="isRequirementOnly" /> <!-- or should this be ViewPosition ?-->
+    <float3 name="u_viewPosition" semantic="WorldCameraPosition" flags="isRequirementOnly" /> <!-- ViewPosition never changes -->
     <int name="u_numActiveLightSources" flags="isRequirementOnly" />
      <!-- end non-varying globals -->
     <float name="base" />
@@ -61,8 +61,8 @@
   </properties>
   <values>
     <float4x4 name="u_envMatrix" value="-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1" />
-    <int name="u_envRadianceMips" value="1" />
-    <int name="u_envSamples" value="16" />
+    <int name="u_envRadianceMips" value="10" />
+    <int name="u_envSamples" value="4" />
     <int name="u_numActiveLightSources" value="0" />
     <float name="base" value="0.8" />
     <float3 name="base_color" value="1, 1, 1" />
@@ -463,12 +463,39 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
     return max(effectiveMaxMipLevel - 0.5 * log2(envSamples * pdf * distortion), 0.0);
 }
 
+
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
 {
-    vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
-    vec2 uv = mx_latlong_projection(envDir);
+    //vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
+    vec2 uv = mx_latlong_projection(dir);
     return textureLod(sampler, uv, lod).rgb;
 }
+
+
+/*
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lodBias, sampler2D sampler)
+{
+    vec2 res = textureSize(sampler, 0);
+    if (res.x > 0)
+    {
+        // Heuristic for faking a blur by roughness
+        int levels = 1 + int(floor(log2(max(res.x, res.y))));
+        lodBias = lodBias < 0.25 ? sqrt(lodBias) : 0.5*lodBias + 0.375;
+        float lod = lodBias * levels;
+
+        //vec3 dir = normalize((transform * vec4(dir,0.0)).xyz);
+        vec2 uv = mx_latlong_projection(dir);
+        return textureLod(sampler, uv, lod).rgb;
+    }
+    return vec3(0.0);
+}
+
+vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, roughnessinfo roughness, int distribution)
+{
+    vec3 dir = reflect(-V, N);
+    return mx_latlong_map_lookup(dir, u_envMatrix, roughness.alpha, u_envRadianceSampler);
+}
+        */
 
 // Only GGX is supported for now and the distribution argument is ignored
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, roughnessinfo roughness, int distribution)
@@ -1082,7 +1109,23 @@ vec3 main_function(
 
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);
+
+    //vec3 N = normalize(PIX_IN.Nw);
+    //vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
+    //vec3 T = normalize(PIX_IN.Tw);
+
+    //vec2 proj = mx_latlong_projection(N);
+    //return texture(u_envIrradianceSampler, proj).rgb;
+
+    //return mx_environment_irradiance(N);
+    //roughnessinfo roughness = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
+    //vec3 val = mx_environment_radiance(N, V, T, roughness, 0);
+    //return val;
+
+    //return vec3(proj,0.0);
+    //return mx_environment_irradiance(N);
     return SR_default_out.color;
+    //return normalize(u_viewPosition - PIX_IN.Pw);
 }
 
 ]]></source>

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -467,7 +467,7 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
-    vec2 uv = mx_latlong_projection(dir);
+    vec2 uv = mx_latlong_projection(envDir);
     return textureLod(sampler, uv, lod).rgb;
 }
 

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -531,7 +531,7 @@ vec3 mx_environment_irradiance(vec3 N)
 //
 vec2 mx_get_target_uv(vec2 uv)
 {
-   return uv;
+    return vec2(uv.x, 1.0 - uv.y);
 }
 
 int numActiveLightSources()

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -54,8 +54,8 @@
     <float3 name="opacity" />
      <!-- Varying globals come in through input structure -->
     <float3 name="positionWorld" semantic="Pw" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="normalWorld" semantic="Nw" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="tangentWorld" semantic="mayaTangentIn" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="normalWorld" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="tangentWorld" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
      <!-- end varying globals -->
   </properties>
   <values>
@@ -1081,7 +1081,7 @@ vec3 main_function(
 
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);
-    return vec3(1.0, 0.0, 0.0); //SR_default_out.color;
+    return SR_default_out.color;
 }
 
 ]]></source>

--- a/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
@@ -33,7 +33,7 @@
 //
 vec2 mx_get_target_uv(vec2 uv)
 {
-   return uv;
+   return vec2(uv.x, 1.0 - uv.y);
 }
 
 void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, out vec3 result)

--- a/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
@@ -21,7 +21,7 @@
     <int name="tiled_image3_frameendaction" value="1" />
   </values>
   <outputs>
-    <float3 name="tiled_image3_output" />
+    <float3 name="out" />
   </outputs>
   <implementation>
     <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
@@ -481,8 +481,13 @@ void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
 
             if (!path.empty())
             {
-                //std::cout << "Add path: " << path << ". Frag name: " << name << std::endl;
+                std::cout << "Add path: " << path << ". Frag name: " << name << std::endl;
                 _pathInputMap[path] = name;
+            }
+            else
+            {
+                std::cout << "Add input globals name: " << name << std::endl;
+                _globalsList.push_back(name);
             }
         }
     }
@@ -584,7 +589,7 @@ void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
             // Add to cached list of output name
             if (!path.empty())
             {
-                //std::cout << "Add output path: " << path << ". Frag name: " << name << std::endl;
+                std::cout << "Add output path: " << path << ". Frag name: " << name << std::endl;
                 _pathOutputMap[path] = name;
             }
         }

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
@@ -97,11 +97,11 @@ const string OGS_FLAGS("flags");
 const string OGS_VARYING_INPUT_PARAM("varyingInputParam");
 const string OGS_POSITION_WORLD_SEMANTIC("Pw");
 const string OGS_POSITION_OBJECT_SEMANTIC("Pm");
-const string OGS_NORMAL_WORLD_SEMANTIC("Nw");
+const string OGS_NORMAL_WORLD_SEMANTIC("NORMAL");
 const string OGS_NORMAL_OBJECT_SEMANTIC("Nm");
 const string OGS_COLORSET_SEMANTIC("colorset");
-const string OGS_MAYA_BITANGENT_SEMANTIC("mayaBitangentIn"); // Maya bitangent semantic
-const string OGS_MAYA_TANGENT_SEMANTIC("mayaTangentIn"); // Maya tangent semantic
+const string OGS_MAYA_BITANGENT_SEMANTIC("BINORMAL"); // Maya bitangent semantic
+const string OGS_MAYA_TANGENT_SEMANTIC("TANGENT"); // Tangent semantic
 const string OGS_MAYA_UV_COORD_SEMANTIC("mayaUvCoordSemantic");  // Maya uv semantic
 
 void createOGSProperty(pugi::xml_node& propertiesNode, pugi::xml_node& valuesNode,

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
@@ -95,11 +95,11 @@ const string OGS_SAMPLER("sampler");
 const string OGS_SEMANTIC("semantic");
 const string OGS_FLAGS("flags");
 const string OGS_VARYING_INPUT_PARAM("varyingInputParam");
-const string OGS_POSITION_WORLD_SEMANTIC("Pw");
-const string OGS_POSITION_OBJECT_SEMANTIC("Pm");
+const string OGS_POSITION_WORLD_SEMANTIC("POSITION");
+const string OGS_POSITION_OBJECT_SEMANTIC("POSITION");
 const string OGS_NORMAL_WORLD_SEMANTIC("NORMAL");
-const string OGS_NORMAL_OBJECT_SEMANTIC("Nm");
-const string OGS_COLORSET_SEMANTIC("colorset");
+const string OGS_NORMAL_OBJECT_SEMANTIC("NORMAL");
+const string OGS_COLORSET_SEMANTIC("COLOR0");
 const string OGS_MAYA_BITANGENT_SEMANTIC("BINORMAL"); // Maya bitangent semantic
 const string OGS_MAYA_TANGENT_SEMANTIC("TANGENT"); // Tangent semantic
 const string OGS_MAYA_UV_COORD_SEMANTIC("mayaUvCoordSemantic");  // Maya uv semantic
@@ -228,6 +228,22 @@ void OGSXMLPropertyExtractor::getStreamInformation(const ShaderPort* port, strin
         return;
     }
 
+    /* Should just use a map here.
+    { "i_position", "POSITION"},
+    { "i_normal", "NORMAL" },
+    { "i_tangent", "TANGENT" },
+    { "i_bitangent", "BINORMAL" },
+
+    { "i_texcoord_0", "TEXCOORD0" },
+    { "i_texcoord_1", "TEXCOORD1" },
+    { "i_texcoord_2", "TEXCOORD2" },
+    { "i_texcoord_3", "TEXCOORD3" },
+    { "i_texcoord_4", "TEXCOORD4" },
+    { "i_texcoord_5", "TEXCOORD5" },
+    { "i_texcoord_6", "TEXCOORD6" },
+    { "i_texcoord_7", "TEXCOORD7" },
+    */
+
     if (name.find(MTLX_GENHW_POSITION) != string::npos)
     {
         // TODO: Determine how to tell if object / model space is required
@@ -236,7 +252,7 @@ void OGSXMLPropertyExtractor::getStreamInformation(const ShaderPort* port, strin
     }
     else if (name.find(MTLX_GENHW_UVSET) != string::npos)
     {
-        // TODO: Remove leadning "i_"
+        // TODO: Remove leading "i_"
         semantic = OGS_MAYA_UV_COORD_SEMANTIC;
     }
     else if (name.find(MTLX_GENHW_NORMAL) != string::npos)
@@ -307,7 +323,7 @@ string OGSXMLPropertyExtractor::getUniformSemantic(const ShaderPort* port) const
         { "u_worldViewProjectionMatrix", "WorldViewProjection" },
 
         { "u_viewDirection", "ViewDirection" },
-        { "u_viewPosition", "WorldCameraPosition" }
+        { "u_viewPosition", "WorldCameraPosition" } // Or should this be ViewPosition as for the GLSL plug-in ?
     };
     auto val = semanticMap.find(name);
     if (val != semanticMap.end())
@@ -510,7 +526,8 @@ void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
                 // and not the pixel shader name. Need to figure out what to
                 // do with code gen so that we get the correct name.
                 string name = vertexInput->getName();
-                if (name.empty())
+                // Position is always pass through so cannot pass through again. Need to use pixel struct .Pw value.
+                if (name.empty() || name.find(MTLX_GENHW_POSITION))
                 {
                     continue;
                 }

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.h
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.h
@@ -61,6 +61,12 @@ class OGSXMLFragmentWrapper
         return _outputVertexShader;
     }
 
+    /// Get list of global inputs which are not associated with any Element
+    const StringVec&  getGlobalsList() const
+    {
+        return _globalsList;
+    }
+
     /// Get list of Element paths and corresponding fragment input names
     const StringMap& getPathInputMap() const
     {
@@ -102,10 +108,13 @@ class OGSXMLFragmentWrapper
     // Fragment name
     string _fragmentName;
 
-    // Mapping from MTLX Element paths to fragment input names
+    // List of globals which are not associated with any Element.
+    StringVec _globalsList;
+
+    // Mapping from MaterialX Element paths to fragment input names
     StringMap _pathInputMap;
 
-    // Mapping from MTLX Element paths to fragment output names
+    // Mapping from MaterialX Element paths to fragment output names
     StringMap _pathOutputMap;
 
     // Context for generating shaders

--- a/source/MaterialXTest/GenShader.cpp
+++ b/source/MaterialXTest/GenShader.cpp
@@ -214,9 +214,9 @@ TEST_CASE("GenShader: Generate OGS fragment wrappers", "[genogsfrag]")
     {
         mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
         //mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/geometric/streams.mtlx");
-        //mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/texture/tiledImage.mtlx");
+        mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/texture/tiledImage.mtlx");
         //mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/texture/image_addressing.mtlx");
-        mx::readFromXmlFile(doc, "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+        //mx::readFromXmlFile(doc, "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
         mx::StringVec libraryFolders = { "stdlib", "pbrlib", "stdlib/genglsl", "pbrlib/genglsl", "bxdf" };
         GenShaderUtil::loadLibraries(libraryFolders, searchPath, doc);
 
@@ -256,6 +256,8 @@ TEST_CASE("GenShader: Generate OGS fragment wrappers", "[genogsfrag]")
                 glslContext->getOptions().hwMaxActiveLightSources = 0;
                 nodeDef = shaderRef->getNodeDef();
             }
+            glslContext->getOptions().fileTextureVerticalFlip = true;
+
             if (nodeDef)
             {
                 glslWrapper.createWrapper(elem);


### PR DESCRIPTION
Core work:
- Add xml version for brasss shader for testing.
- Add in global list and ouptut map list. 
  - Globals are used to bind environment maps. Need to make sure to re-bind mip level and 
   env matrix as these *do not get auto-bound* for some reason when creating the effect from xml?
- Fix template files to have V-flip for image lookup. Change test to also cause V-flip when
generating shader for the wrapper.
- FIx up world space position, normals and tangents to route using magic names Pw, Nw and Tw. 
-- Note that Nw get's *removed* from the shader during effect building for some reason if using a surface shader.  Need to assign to lambert for now to get it to not fail due to lack of Nw. 

Plug-in changes:
- Fix path and include issues
- Fix output path name setting as was using the incorrect wrapper api
- Make MaterialXData a class with protected data. Very little of it should be made public. More cleanup is probably required.