### PR TITLE
Clean up MaterialXData interfaces.

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -77,7 +77,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
             std::string nodeName = MaterialX::createValidName(elementPath.asChar());
             _dgModifier.renameNode(node, nodeName.c_str());
 
-            materialXData->createXMLWrapper();
+            materialXData->generateXML();
             materialXData->registerFragments();
 
             MFnDependencyNode depNode(node);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -12,7 +12,7 @@
 MaterialXData::MaterialXData(const std::string& materialXDocumentPath, const std::string& elementPath)
     : _genContext(MaterialX::GlslShaderGenerator::create())
 {
-	_librarySearchPath = Plugin::instance().getLibrarySearchPath();
+    _librarySearchPath = Plugin::instance().getLibrarySearchPath();
     setData(materialXDocumentPath, elementPath);
 }
 
@@ -23,7 +23,7 @@ bool MaterialXData::setData(const std::string& materialXDocument, const std::str
     {
         _element = _document->getDescendant(elementPath);
     }
-    
+
     // Check that the element is renderable
     return isRenderable();
 }
@@ -59,12 +59,12 @@ const MaterialX::StringMap& MaterialXData::getPathOutputMap() const
 
 void MaterialXData::createDocument(const std::string& materialXDocumentPath)
 {
-	// Create document
-	_document = MaterialX::createDocument();
+    // Create document
+    _document = MaterialX::createDocument();
 
-	// Load libraries
-	static const MaterialX::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
-	MaterialX::loadLibraries(libraries, _librarySearchPath, _document);
+    // Load libraries
+    static const MaterialX::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
+    MaterialX::loadLibraries(libraries, _librarySearchPath, _document);
 
     // Read document contents from disk
     MaterialX::readFromXmlFile(_document, materialXDocumentPath);
@@ -82,13 +82,13 @@ void MaterialXData::generateXML()
         return;
     }
 
-	MaterialX::OutputPtr output = _element->asA<MaterialX::Output>();
-	MaterialX::ShaderRefPtr shaderRef = _element->asA<MaterialX::ShaderRef>();
-	if (!output && !shaderRef)
-	{
-		// Should never occur as we pre-filter renderables before creating the node + override
-		throw MaterialX::Exception("Invalid element to create wrapper for " + _element->getName());
-	}
+    MaterialX::OutputPtr output = _element->asA<MaterialX::Output>();
+    MaterialX::ShaderRefPtr shaderRef = _element->asA<MaterialX::ShaderRef>();
+    if (!output && !shaderRef)
+    {
+        // Should never occur as we pre-filter renderables before creating the node + override
+        throw MaterialX::Exception("Invalid element to create wrapper for " + _element->getName());
+    }
 
     // Set up generator context. For shaders use FIS environment lookup,
     // but disable this for textures to avoid additional unneeded XML parameter
@@ -118,17 +118,17 @@ void MaterialXData::generateXML()
 // TODO: This does not belong here. To migrate out to another class.
 void MaterialXData::registerFragments(const std::string& ogsXmlPath)
 {
-	// Register fragments with the manager if needed
-	//	
-	if (MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer())
-	{
+    // Register fragments with the manager if needed
+    //	
+    if (MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer())
+    {
         if (MHWRender::MFragmentManager* fragmentMgr = theRenderer->getFragmentManager())
-		{
-			const bool fragmentExists = (getFragmentName().size() > 0)
+        {
+            const bool fragmentExists = (getFragmentName().size() > 0)
                 && fragmentMgr->hasFragment(getFragmentName().c_str());
 
-			if (!fragmentExists)
-			{
+            if (!fragmentExists)
+            {
                 // XML should come from here. For now allow to get from a input path
                 // std::stringstream glslStream;
                 // getXML(glslStream);
@@ -149,9 +149,9 @@ void MaterialXData::registerFragments(const std::string& ogsXmlPath)
                 {
                     throw MaterialX::Exception("Failed to add OGS shader fragment from file.");
                 }
-			}
-		}
-	}
+            }
+        }
+    }
 }
 
 bool MaterialXData::isRenderable()

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -9,62 +9,65 @@
 #include <maya/MViewport2Renderer.h>
 #include <maya/MFragmentManager.h>
 
-MaterialXData::MaterialXData(const std::string& materialXDocument, const std::string& elementPath)
+MaterialXData::MaterialXData(const std::string& materialXDocument, const std::string& elementPath)    
+    : _genContext(MaterialX::GlslShaderGenerator::create())
 {
 	_librarySearchPath = Plugin::instance().getLibrarySearchPath();
-	createDocument(materialXDocument);
+    setData(materialXDocument, elementPath);
+}
 
-	if (_document)
-	{
-		_element = _document->getDescendant(elementPath);
-	}
-
-    if (!_element)
+bool MaterialXData::setData(const std::string& materialXDocument, const std::string& elementPath)
+{
+    createDocument(materialXDocument);
+    if (_document)
     {
-        throw MaterialX::Exception("Element not found");
+        _element = _document->getDescendant(elementPath);
     }
+    
+    // Check that the element is renderable
+    return isRenderable();
 }
 
 MaterialXData::~MaterialXData()
 {
 }
 
+const std::string& MaterialXData::getFragmentName() const
+{
+    return _xmlFragmentWrapper.getFragmentName();
+}
+
+void MaterialXData::getXML(std::ostream& stream) const
+{
+    _xmlFragmentWrapper.getXML(stream);
+}
+
+const MaterialX::StringVec&  MaterialXData::getGlobalsList() const
+{
+    return _xmlFragmentWrapper.getGlobalsList();
+}
+
+const MaterialX::StringMap& MaterialXData::getPathInputMap() const
+{
+    return _xmlFragmentWrapper.getPathInputMap();
+}
+
+const MaterialX::StringMap& MaterialXData::getPathOutputMap() const
+{
+    return _xmlFragmentWrapper.getPathOutputMap();
+}
+
 void MaterialXData::createDocument(const std::string& materialXDocument)
 {
 	// Create document
 	_document = MaterialX::createDocument();
-	MaterialX::readFromXmlFile(_document, materialXDocument);
 
 	// Load libraries
 	const MaterialX::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
 	MaterialX::loadLibraries(libraries, _librarySearchPath, _document);
-}
 
-bool MaterialXData::isValidOutput()
-{
-    if (!_element)
-    {
-        return false;
-    }
-
-	const std::string& elementPath = _element->getNamePath();
-	std::vector<MaterialX::TypedElementPtr> elements;
-	try {
-		MaterialX::findRenderableElements(_document, elements);
-		for (MaterialX::TypedElementPtr currentElement : elements)
-		{
-			std::string pathCompare(currentElement->getNamePath());
-			if (pathCompare == elementPath)
-			{
-				return true;
-			}
-		}
-	}
-	catch (MaterialX::Exception& e)
-	{
-		std::cerr << "Failed to find renderable element in document: " << e.what() << std::endl;
-	}
-	return false;
+    // Read document contents from disk
+    MaterialX::readFromXmlFile(_document, materialXDocument);
 }
 
 bool MaterialXData::elementIsAShader() const
@@ -72,55 +75,47 @@ bool MaterialXData::elementIsAShader() const
     return (_element ? _element->isA<MaterialX::ShaderRef>() : false);
 }
 
-void MaterialXData::createXMLWrapper()
+void MaterialXData::generateXML()
 {
+    if (!_element)
+    {
+        return;
+    }
+
 	MaterialX::OutputPtr output = _element->asA<MaterialX::Output>();
 	MaterialX::ShaderRefPtr shaderRef = _element->asA<MaterialX::ShaderRef>();
 	if (!output && !shaderRef)
 	{
 		// Should never occur as we pre-filter renderables before creating the node + override
-		throw MaterialX::Exception("MaterialXTextureOverride: Invalid type to create wrapper for");
+		throw MaterialX::Exception("Invalid element to create wrapper for " + _element->getName());
 	}
-	else
-	{
-        std::unique_ptr<MaterialX::GenContext> glslContext{
-            new MaterialX::GenContext(MaterialX::GlslShaderGenerator::create())
-        };
 
-        // Stop emission of environment map lookups.
-        glslContext->registerSourceCodeSearchPath(_librarySearchPath);
-        if (shaderRef)
-        {
-            glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_FIS;
-            glslContext->getOptions().hwMaxActiveLightSources = 0;
-        }
-        else
-        {
-            glslContext->getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_NONE;
-        }
-        glslContext->getOptions().fileTextureVerticalFlip = true;
+    // Set up generator context. For shaders use FIS environment lookup,
+    // but disable this for textures to avoid additional unneeded XML parameter
+    // generation.
+    _genContext.registerSourceCodeSearchPath(_librarySearchPath);
+    if (shaderRef)
+    {
+        _genContext.getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_FIS;
+    }
+    else
+    {
+        _genContext.getOptions().hwSpecularEnvironmentMethod = MaterialX::SPECULAR_ENVIRONMENT_NONE;
+    }
+    _genContext.getOptions().hwMaxActiveLightSources = 0;
+    // For Maya we need to insert a V-flip fragment
+    _genContext.getOptions().fileTextureVerticalFlip = true;
+    // We do not reuqire vertex shader output to XML    
+    _xmlFragmentWrapper.setOutputVertexShader(false);
 
-        _xmlFragmentWrapper.reset(new MaterialX::OGSXMLFragmentWrapper(glslContext.get()));
-        _xmlFragmentWrapper->setOutputVertexShader(false);
-
-        // TODO: This just indicates that lighting is required. As direct lighting
-        // is not supported, the requirement means that indirect lighting is required.
-        // bool requiresLighting = (shaderRef != nullptr);
-        std::cout << "MaterialXTextureOverride: Create XML wrapper" << std::endl;
-        _xmlFragmentWrapper->createWrapper(_element);
-        // Get the fragment name
-        _fragmentName.set(_xmlFragmentWrapper->getFragmentName().c_str());
-
-        _contexts.push_back(std::move(glslContext));
-        
-        // TODO: This just indicates that lighting is required. As direct lighting
-		// is not supported, the requirement means that indirect lighting is required.
-		// bool requiresLighting = (shaderRef != nullptr);
-		std::cout << "MaterialXTextureOverride: Create XML wrapper" << std::endl;
-		_xmlFragmentWrapper->createWrapper(_element);
-	}
+    // Generator XML wrapper
+    // TODO: Determine what is a suitable unique name for VP2 fragments using
+    // this as a starting identifier.
+    const std::string shaderName(_element->getName());
+    _xmlFragmentWrapper.generate(shaderName, _element, _genContext);
 }
 
+// TODO: This does not belong here. To migrate out to another class.
 void MaterialXData::registerFragments()
 {
 	// Register fragments with the manager if needed
@@ -129,13 +124,13 @@ void MaterialXData::registerFragments()
 	{
         if (MHWRender::MFragmentManager* fragmentMgr = theRenderer->getFragmentManager())
 		{
-			const bool fragmentExists = (_xmlFragmentWrapper->getFragmentName().size() > 0)
-                && fragmentMgr->hasFragment(_xmlFragmentWrapper->getFragmentName().c_str());
+			const bool fragmentExists = (getFragmentName().size() > 0)
+                && fragmentMgr->hasFragment(getFragmentName().c_str());
 
 			if (!fragmentExists)
 			{
                 std::stringstream glslStream;
-                _xmlFragmentWrapper->getDocument(glslStream);
+                getXML(glslStream);
                 std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
                 //std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/tiledImage.xml");
 
@@ -148,13 +143,40 @@ void MaterialXData::registerFragments()
                 }
                 fragmentMgr->setEffectOutputDirectory(dumpPath.c_str());
                 fragmentMgr->setIntermediateGraphOutputDirectory(dumpPath.c_str());
-                _fragmentName = fragmentMgr->addShadeFragmentFromFile(xmlFileName.c_str(), false);
+                MString fragmentName = fragmentMgr->addShadeFragmentFromFile(xmlFileName.c_str(), false);
 
-                if (_fragmentName.length() == 0)
+                if (fragmentName.length() == 0)
                 {
                     throw MaterialX::Exception("Failed to add OGS shader fragment from file.");
                 }
 			}
 		}
 	}
+}
+
+bool MaterialXData::isRenderable()
+{
+    if (!_element)
+    {
+        return false;
+    }
+
+    const std::string& elementPath = _element->getNamePath();
+    std::vector<MaterialX::TypedElementPtr> elements;
+    try {
+        MaterialX::findRenderableElements(_document, elements);
+        for (MaterialX::TypedElementPtr currentElement : elements)
+        {
+            std::string pathCompare(currentElement->getNamePath());
+            if (pathCompare == elementPath)
+            {
+                return true;
+            }
+        }
+    }
+    catch (MaterialX::Exception& e)
+    {
+        std::cerr << "Failed to find renderable element in document: " << e.what() << std::endl;
+    }
+    return false;
 }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -8,33 +8,35 @@
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXContrib/OGSXMLFragmentWrapper.h>
 
-#include <maya/MString.h>
-
 /// @class MaterialXData
 /// Wrapper for MaterialX associated data. 
 ///
 /// Keeps track of an element to render and it's associated document.
 ///
-/// Can optionally create and cache an OGS XML wrapper instance 
-/// which wraps up the interface and shader code shader code generated based 
+/// Can optionally create and cache an XML wrapper instance 
+/// which wraps up the interface and shader code for code generated based 
 /// on the specified element to render.
-/// Currently only code for GLSL is generated.
+/// Currently the only language target available is GLSL.
 ///
 struct MaterialXData
 {
   public:
     /// Create MaterialX data constainer.
-    /// The element path and document that the element resides in are passed in
-    /// as input arguments
     MaterialXData(const std::string& materialXDocument, const std::string& elementPath);
     ~MaterialXData();
 
-    /// Returns whether the element set to render is a valid output
-    bool isValidOutput();
+    /// Set the MaterialX Document and selement path.
+    bool setData(const std::string& materialXDocument, const std::string& elementPath);
+
+    /// Returns whether we have valid output element
+    bool isValidOutput()
+    {
+        return (nullptr != _element);
+    }
 
     /// Create the OGS XML wrapper for shader fragments associated
     /// with the element set to render
-    void createXMLWrapper();
+    void generateXML();
 
     /// Register the fragment(s)
     void registerFragments();
@@ -48,33 +50,41 @@ struct MaterialXData
         return _document;
     }
 
-    /// Return name of shader fragment
-    const MString& getFragmentName() const
-    {
-        return _fragmentName;
-    }
+    /// Return XML string
+    void getXML(std::ostream& stream) const;
 
-    /// Retuern pointer to the OGS XML wrapper
-    MaterialX::OGSXMLFragmentWrapper* getFragmentWrapper() const
-    {
-        return _xmlFragmentWrapper.get();
-    }
+    /// Return name of shader fragment
+    const std::string& getFragmentName() const;
+
+    /// Get list of global inputs which are not associated with any Element
+    const MaterialX::StringVec&  getGlobalsList() const;
+
+    /// Get list of Element paths and corresponding fragment input names
+    const MaterialX::StringMap& getPathInputMap() const;
+
+    /// Get list of Element paths and corresponding fragment output names
+    /// If the output is a ShaderRef then the path is to that element
+    /// as there are no associated child output Elements.
+    const MaterialX::StringMap& getPathOutputMap() const;
 
     /// Return if the element to render represents a shader graph
     /// as opposed to a texture grraph.
     bool elementIsAShader() const;
 
   protected:
+    /// Returns whether the element is renderable
+    bool isRenderable();    
+    void createDocument(const std::string& materialXDocument);
+
+  private:
+    // Reference document and element
     MaterialX::FilePath _librarySearchPath;
     MaterialX::DocumentPtr _document;
     MaterialX::ElementPtr _element;
 
-    MString _fragmentName;
-    std::unique_ptr<MaterialX::OGSXMLFragmentWrapper> _xmlFragmentWrapper;
-    std::vector<std::unique_ptr<MaterialX::GenContext>> _contexts;
-
-  private:
-    void createDocument(const std::string& materialXDocument);
+    // TODO: This is currently a prototype interface
+    MaterialX::GenContext _genContext;
+    MaterialX::OGSXMLFragmentWrapper _xmlFragmentWrapper;
 };
 
 #endif // MATERIALX_DATA_H

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -74,7 +74,7 @@ struct MaterialXData
 
   protected:
     /// Returns whether the element is renderable
-    bool isRenderable();    
+    bool isRenderable();
     void createDocument(const std::string& materialXDocument);
 
   private:

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -86,9 +86,9 @@ MStatus MaterialXNode::initialize()
 
 void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 {
-	if (materialXData && materialXData->getFragmentWrapper())
+	if (materialXData && materialXData->isValidOutput())
 	{
-        const MaterialX::StringMap& outputMap = materialXData->getFragmentWrapper()->getPathOutputMap();
+        const MaterialX::StringMap& outputMap = materialXData->getPathOutputMap();
         if (outputMap.size())
         {
             MString outputName(outputMap.begin()->second.c_str());
@@ -228,12 +228,12 @@ void MaterialXNode::setAttributeValue(MObject &materialXObject, MObject &attr, f
 void MaterialXNode::createAttributesFromDocument(MDGModifier& mdgModifier)
 {
     MaterialX::DocumentPtr document;
-    if (!materialXData || !(document= materialXData->getDocument()))
+    if (!materialXData || !(document = materialXData->getDocument()))
     {
         return;
     }
 
-	const MaterialX::StringMap& inputMap = materialXData->getFragmentWrapper()->getPathInputMap();
+	const MaterialX::StringMap& inputMap = materialXData->getPathInputMap();
 	for (auto it = inputMap.begin(); it != inputMap.end(); ++it)
 	{
 		MaterialX::ElementPtr element = document->getDescendant(it->first);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.cpp
@@ -61,7 +61,7 @@ MaterialXSurfaceOverride::MaterialXSurfaceOverride(const MObject& obj)
         glslContext->registerSourceCodeSearchPath(libSearchPath);
         contexts.push_back(glslContext);
 
-        _glslWrapper = new MaterialX::OGSXMLFragmentWrapper(glslContext);
+        _glslWrapper = new MaterialX::OGSXMLFragmentWrapper();
         _glslWrapper->setOutputVertexShader(true);
 
         MaterialX::ElementPtr element = _document->getDescendant(_element.asChar());
@@ -77,7 +77,7 @@ MaterialXSurfaceOverride::MaterialXSurfaceOverride(const MObject& obj)
         // is not supported, the requirement means that indirect lighting is required.
         // bool requiresLighting = (shaderRef != nullptr);
         std::cout << "MaterialXSurfaceOverride: Create XML wrapper" << std::endl;
-        _glslWrapper->createWrapper(element);
+        _glslWrapper->generate(element->getName(), element, *glslContext);
         // Get the fragment name
         _fragmentName.set(_glslWrapper->getFragmentName().c_str());
 
@@ -94,7 +94,7 @@ MaterialXSurfaceOverride::MaterialXSurfaceOverride(const MObject& obj)
                 if (!fragmentExists)
                 {
                     std::stringstream glslStream;
-                    _glslWrapper->getDocument(glslStream);
+                    _glslWrapper->getXML(glslStream);
                     std::string xmlFileName(Plugin::instance().getResourcePath().asString() + "/standard_surface_default.xml");
 
                     // TODO: This should not be hard-coded

--- a/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXTextureOverride.cpp
@@ -112,7 +112,7 @@ void bindEnvironmentLighting(MHWRender::MShaderInstance& shader,
                              const MStringArray parameterList,
                              const MaterialX::FileSearchPath imageSearchPath, 
                              const std::string& envRadiancePath,
-                             const std::string envIrradiancePath)
+                             const std::string& envIrradiancePath)
 {
     static std::string IRRADIANCE_PARAMETER("u_envIrradiance");
     static std::string RADIANCE_PARAMETER("u_envRadiance");
@@ -147,7 +147,7 @@ void bindEnvironmentLighting(MHWRender::MShaderInstance& shader,
                                          samplerDescription, textureDescription);
                 if (status == MStatus::kSuccess)
                 {
-                    if (parameterList.indexOf(global.c_str()) >= 0)
+                    if (parameterList.indexOf(RADIANCE_MIPS_PARAMETER.c_str()) >= 0)
                     {
                         int mipCount = (int)std::log2(std::max(textureDescription.fWidth, textureDescription.fHeight)) + 1;
                         status = shader.setParameter(global.c_str(), mipCount);
@@ -185,16 +185,9 @@ void MaterialXTextureOverride::updateShader(MHWRender::MShaderInstance& shader,
         return;
     }
 
+    // Get the parameter list fo checking against.
     MStringArray parameterList;    
     shader.parameterList(parameterList);
-    bool debug = false;
-    if (debug)
-    {
-        for (unsigned int i = 0; i < parameterList.length(); i++)
-        {
-            std::cout << "MaterialXTextureOverride: shader param: " << parameterList[i].asChar() << "\n";
-        }
-    }
 
     // Set up image file name search path. Assume we are using built in images located in resource path
     // TODO: Be able to add more image search paths.

--- a/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/tiledImage.xml
@@ -21,7 +21,7 @@
     <int name="tiled_image3_frameendaction" value="1" />
   </values>
   <outputs>
-    <float3 name="out" />
+    <float3 name="tiled_image3_output" />
   </outputs>
   <implementation>
     <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
@@ -19,8 +19,7 @@
 
 namespace MaterialX
 {
-OGSXMLFragmentWrapper::OGSXMLFragmentWrapper(GenContext* context) :
-    _context(context)
+OGSXMLFragmentWrapper::OGSXMLFragmentWrapper()
 {
     _xmlDocument = new pugi::xml_document();
 
@@ -406,17 +405,16 @@ bool OGSXMLPropertyExtractor::isGlobalUniform(const ShaderPort* port, const stri
     return false;
 }
 
-void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
+void OGSXMLFragmentWrapper::generate(const string& shaderName, ElementPtr element, GenContext& context)
 {
     _pathInputMap.clear();
     _pathOutputMap.clear();
 
-    string shaderName(element->getName());
-    ShaderGenerator& generator = _context->getShaderGenerator();
+    ShaderGenerator& generator = context.getShaderGenerator();
     ShaderPtr shader = nullptr;
     try
     {
-        shader = generator.generate(shaderName, element, *_context);
+        shader = generator.generate(shaderName, element, context);
     }
     catch (Exception& e)
     {
@@ -439,8 +437,6 @@ void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
     const string& elementName = element->getName();
     xmlRoot.append_attribute(OGS_FRAGMENT_UI_NAME.c_str()) = elementName.c_str();
     xmlRoot.append_attribute(OGS_FRAGMENT_NAME.c_str()) = elementName.c_str();
-    // TODO: determine what is a good unique fragment name to use.
-    _fragmentName = elementName.c_str();
     xmlRoot.append_attribute(OGS_FRAGMENT_TYPE.c_str()) = OGS_FRAGMENT_TYPE_PLUMBING.c_str();
     xmlRoot.append_attribute(OGS_FRAGMENT_CLASS.c_str()) = OGS_FRAGMENT_CLASS_SHADERFRAGMENT.c_str();
     xmlRoot.append_attribute(OGS_FRAGMENT_VERSION.c_str()) = OGS_VERSION_STRING.c_str();
@@ -635,9 +631,12 @@ void OGSXMLFragmentWrapper::createWrapper(ElementPtr element)
         addOGSImplementation(impls, "HLSL", "11.0", functionName, "// HLSL code", EMPTY_STRING.c_str());
         addOGSImplementation(impls, "Cg", "2.1", functionName, "// Cg code", EMPTY_STRING.c_str());
     }
+
+    // Cache fragment name. 
+    _fragmentName = elementName.c_str();
 }
 
-void OGSXMLFragmentWrapper::getDocument(std::ostream& stream)
+void OGSXMLFragmentWrapper::getXML(std::ostream& stream) const
 {
     static_cast<pugi::xml_document*>(_xmlDocument)->save(stream, XML_TAB_STRING.c_str());
 }

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.h
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.h
@@ -31,7 +31,7 @@ class OGSXMLFragmentWrapper
 {
   public:
     /// Default constructor
-    OGSXMLFragmentWrapper(GenContext* context);
+    OGSXMLFragmentWrapper();
 
     /// Default desctructor
     ~OGSXMLFragmentWrapper();
@@ -40,10 +40,10 @@ class OGSXMLFragmentWrapper
     /// @{
 
     /// Add a fragment wrapper for a shader generated from a given element
-    void createWrapper(ElementPtr node);
+    void generate(const string& shaderName, ElementPtr node, GenContext& context);
 
     /// Get the contents of the cached XML document as a stream.
-    void getDocument(std::ostream& stream);
+    void getXML(std::ostream& stream) const;
 
     /// Set to output vertex shader code (if any)
     void setOutputVertexShader(bool val)

--- a/source/MaterialXTest/GenShader.cpp
+++ b/source/MaterialXTest/GenShader.cpp
@@ -231,9 +231,9 @@ TEST_CASE("GenShader: Generate OGS fragment wrappers", "[genogsfrag]")
         contexts.push_back(oslContext);
 
         // TODO: We want 1 wrapper with both languages -- not 2 wrappers
-        mx::OGSXMLFragmentWrapper glslWrapper(glslContext);
+        mx::OGSXMLFragmentWrapper glslWrapper;
         glslWrapper.setOutputVertexShader(false);
-        mx::OGSXMLFragmentWrapper oslWrapper(oslContext);
+        mx::OGSXMLFragmentWrapper oslWrapper;
 
         std::vector<mx::TypedElementPtr> renderables;
         mx::findRenderableElements(doc, renderables, false);
@@ -260,14 +260,14 @@ TEST_CASE("GenShader: Generate OGS fragment wrappers", "[genogsfrag]")
 
             if (nodeDef)
             {
-                glslWrapper.createWrapper(elem);
-                //oslWrapper.createWrapper(elem);
+                glslWrapper.generate(elem->getName(), elem, *glslContext);
+                //oslWrapper.generate(elem->getName(), elem, *oslContext);
             }
         }
 
         std::ofstream glslStreamFile("glslOGSXMLFragmentDump.xml");
         std::stringstream glslStream;
-        glslWrapper.getDocument(glslStream);
+        glslWrapper.getXML(glslStream);
         glslStreamFile << glslStream.str();
         glslStreamFile.close();
 
@@ -295,7 +295,7 @@ TEST_CASE("GenShader: Generate OGS fragment wrappers", "[genogsfrag]")
         //}
 
         std::ofstream oslStream("oslOGSXMLFragmentDump.xml");
-        oslWrapper.getDocument(oslStream);
+        oslWrapper.getXML(oslStream);
         oslStream.close();
 
     }


### PR DESCRIPTION
Update #445.

Cleanup in prep for switching from prototype Wrapper to new XML generator.

- Hide previous direct access to wrapper class to go through the MaterlalXData class.
- Hide more MaterialX specifics within the MaterialXData class
-- Make context part of class. Does not need to be dynamic for any reason.
-  Context still references a generator. Note we only ever need one generator (fragment XML generator to come).
-- Allow ability to set a new document / element.
- Minor function renames.

Cleanup binding for IBL and textures to make them more generic.
Minor cleanup on wrapper class to pre to make it align with XML fragment generator.