### PR TITLE
MATX-198 - Set up the MPxSurfaceShadingNodeOverride, fixed surface no…

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.cpp
@@ -22,14 +22,15 @@ const MString
     MaterialXSurfaceOverride::REGISTRANT_ID = "materialXSurface",
     MaterialXSurfaceOverride::DRAW_CLASSIFICATION = "drawdb/shader/surface/materialX";
 
-MHWRender::MPxShadingNodeOverride* MaterialXSurfaceOverride::creator(const MObject& obj)
+MHWRender::MPxSurfaceShadingNodeOverride*
+MaterialXSurfaceOverride::creator(const MObject& obj)
 {
 	std::cout.rdbuf(std::cerr.rdbuf());
 	return new MaterialXSurfaceOverride(obj);
 }
 
 MaterialXSurfaceOverride::MaterialXSurfaceOverride(const MObject& obj)
-	: MPxShadingNodeOverride(obj)
+	: MPxSurfaceShadingNodeOverride(obj)
 	, _object(obj)
 {
 	MStatus status;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXSurfaceOverride.h
@@ -5,12 +5,13 @@
 
 #include <MaterialXCore/Document.h>
 
-#include <maya/MPxShadingNodeOverride.h>
+#include <maya/MPxSurfaceShadingNodeOverride.h>
 
-class MaterialXSurfaceOverride : public MHWRender::MPxShadingNodeOverride
+class MaterialXSurfaceOverride
+    : public MHWRender::MPxSurfaceShadingNodeOverride
 {
   public:
-	static MHWRender::MPxShadingNodeOverride* creator(const MObject& obj);
+	static MHWRender::MPxSurfaceShadingNodeOverride* creator(const MObject&);
 
 	~MaterialXSurfaceOverride() override;
 

--- a/source/MaterialXContrib/MaterialXNode/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXNode/Plugin.cpp
@@ -9,6 +9,7 @@
 #include <maya/MDrawRegistry.h>
 #include <maya/MGlobal.h>
 #include <maya/MIOStream.h>
+#include <maya/MHWShaderSwatchGenerator.h>
 
 Plugin& Plugin::instance()
 {
@@ -65,13 +66,15 @@ MStatus initializePlugin(MObject obj)
     }
 
     {
-        CHECK_MSTATUS(MHWRender::MDrawRegistry::registerShadingNodeOverrideCreator(
+        CHECK_MSTATUS(MHWRender::MDrawRegistry::registerSurfaceShadingNodeOverrideCreator(
             MaterialXSurfaceOverride::DRAW_CLASSIFICATION,
             MaterialXSurfaceOverride::REGISTRANT_ID,
             MaterialXSurfaceOverride::creator));
 
+        const MString& swatchName = MHWShaderSwatchGenerator::initialize();
+
         static const MString surfaceNodeClassification =
-            MString("shader/surface:") + MaterialXSurfaceOverride::DRAW_CLASSIFICATION;
+            MString("shader/surface:") + MaterialXSurfaceOverride::DRAW_CLASSIFICATION + ":swatch/" + swatchName;
 
         CHECK_MSTATUS(plugin.registerNode(
             MaterialXSurfaceNode::MATERIALX_SURFACE_NODE_TYPENAME,


### PR DESCRIPTION
…de registration to include swatch classification.

MaterialXSurfaceNode can now be created without crashing, however MaterialXSurfaceOverride needs to be cleaned up along the lines of MaterialXTextureOverride to get something rendering.