### PR TITLE
Viewer fixes for AO+transparency and UI updates for R/L material cycling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,21 +22,3 @@ deploy
 # Ignore local editor settings
 .vscode/*
 
-build_public_rel/
-resources/Materials/TestSuite/libraries/prism_presets_May16/
-resources/Materials/TestSuite/libraries/prism_presets_May16.zip
-rel_publicbuild_viewer.bat
-rel_publicbuild_vcpkg.bat
-rel_publicbuild_oiio_viewer.bat
-shaderx_merge_build.bat
-rel_publicbuild_oiio_no_testsuite.bat
-rel_publicbuild_nopython.bat
-rel_publicbuild_all.bat
-rel_publicbuild.bat
-publicbuild_arnold_osl.bat
-publicbuild.bat
-ilm_build.bat
-docs.txt
-cpTest.bat
-cpRelTest.bat
-cpAllTest.bat

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,21 @@ deploy
 # Ignore local editor settings
 .vscode/*
 
+build_public_rel/
+resources/Materials/TestSuite/libraries/prism_presets_May16/
+resources/Materials/TestSuite/libraries/prism_presets_May16.zip
+rel_publicbuild_viewer.bat
+rel_publicbuild_vcpkg.bat
+rel_publicbuild_oiio_viewer.bat
+shaderx_merge_build.bat
+rel_publicbuild_oiio_no_testsuite.bat
+rel_publicbuild_nopython.bat
+rel_publicbuild_all.bat
+rel_publicbuild.bat
+publicbuild_arnold_osl.bat
+publicbuild.bat
+ilm_build.bat
+docs.txt
+cpTest.bat
+cpRelTest.bat
+cpAllTest.bat

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1175,8 +1175,8 @@ void Viewer::drawScene3D()
             _ambOccMaterial->bindShader();
             _ambOccMaterial->bindViewInformation(world, view, proj);
             _ambOccMaterial->bindLights(_lightHandler, _imageHandler, _searchPath,
-                _directLighting, _indirectLighting,
-                _specularEnvironmentMethod, _envSamples);
+                                        _directLighting, _indirectLighting,
+                                        _specularEnvironmentMethod, _envSamples);
             _ambOccMaterial->bindImages(_imageHandler, _searchPath, material->getUdim());
             _ambOccMaterial->drawPartition(geom);
         }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1072,6 +1072,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
             if (!_materials.empty() && !_geometryList.empty())
             {
                 assignMaterial(getSelectedGeometry(), getSelectedMaterial());
+                updateMaterialSelectionUI();
             }
         }
         return true;
@@ -1135,35 +1136,9 @@ void Viewer::drawScene3D()
         material->drawPartition(geom);
     }
 
-    // Ambient occlusion pass
-    if (_ambientOcclusion && _ambOccMaterial)
-    {
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_DST_COLOR, GL_ZERO);
-        for (auto assignment : _materialAssignments)
-        {
-            mx::MeshPartitionPtr geom = assignment.first;
-            MaterialPtr material = assignment.second;
-            if (!material || material->hasTransparency())
-            {
-                continue;
-            }
-
-            mx::TypedElementPtr shader = _ambOccMaterial->getElement();
-            _ambOccMaterial->bindShader();
-            _ambOccMaterial->bindViewInformation(world, view, proj);
-            _ambOccMaterial->bindLights(_lightHandler, _imageHandler, _searchPath,
-                                        _directLighting, _indirectLighting,
-                                        _specularEnvironmentMethod, _envSamples);
-            _ambOccMaterial->bindImages(_imageHandler, _searchPath, material->getUdim());
-            _ambOccMaterial->drawPartition(geom);
-        }
-    }
-
     // Transparent pass
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glEnable(GL_CULL_FACE); // Cull back-faces otherwise they render black (unlit)
     for (auto assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
@@ -1181,7 +1156,32 @@ void Viewer::drawScene3D()
         material->bindImages(_imageHandler, _searchPath, material->getUdim());
         material->drawPartition(geom);
     }
-    glDisable(GL_CULL_FACE);
+    
+    // Ambient occlusion pass
+    if (_ambientOcclusion && _ambOccMaterial)
+    {
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_DST_COLOR, GL_ZERO);
+        for (auto assignment : _materialAssignments)
+        {
+            mx::MeshPartitionPtr geom = assignment.first;
+            MaterialPtr material = assignment.second;
+            if (!material)
+            {
+                continue;
+            }
+
+            mx::TypedElementPtr shader = _ambOccMaterial->getElement();
+            _ambOccMaterial->bindShader();
+            _ambOccMaterial->bindViewInformation(world, view, proj);
+            _ambOccMaterial->bindLights(_lightHandler, _imageHandler, _searchPath,
+                _directLighting, _indirectLighting,
+                _specularEnvironmentMethod, _envSamples);
+            _ambOccMaterial->bindImages(_imageHandler, _searchPath, material->getUdim());
+            _ambOccMaterial->drawPartition(geom);
+        }
+    }
+    
     glDisable(GL_BLEND);
     glDisable(GL_FRAMEBUFFER_SRGB);
 


### PR DESCRIPTION
- AO was being drawn before transparent objects which would overwrite it. Move AO to be after. Neither is really correct as it should be done as part of lighting but okay for now.
- Fix so that left/right arrow cycling will update the UI properly. Got broken in some recent cleanup from master.

