### PR TITLE
MATX-198 - Fixed the missing Nw in manually edited standard_surface* fragment graphs.

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/SR_brass1.xml
@@ -65,9 +65,9 @@
     <int name="image_color_framerange" />
     <int name="image_color_frameoffset" />
     <int name="image_color_frameendaction" />
-    <float3 name="Pw" semantic="POSITION" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="Tw" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="Nw" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="Pw" semantic="Pw" flags="isRequirementOnly" />
+    <float3 name="Nw" semantic="Nw" flags="varyingInputParam" />
+    <float3 name="Tw" semantic="Tw" flags="isRequirementOnly" />
     <float2 name="texcoord_0" semantic="mayaUvCoordSemantic" flags="isRequirementOnly, varyingInputParam" />
   </properties>
   <values>
@@ -1120,7 +1120,8 @@ vec3 SR_brass1
     int image_color_filtertype,
     int image_color_framerange,
     int image_color_frameoffset,
-    int image_color_frameendaction
+    int image_color_frameendaction,
+    vec3 Nw
 )
 {
     vec3 geomprop_Tworld_out596 = normalize(PIX_IN.Tw);

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
@@ -984,7 +984,7 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(PIX_IN.Nw);
+        vec3 N = normalize(Nw);
         vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
         int numLights = numActiveLightSources();
         lightshader lightShader;

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
@@ -946,7 +946,7 @@ void mx_multiply_bsdf_color_indirect(vec3 V, vec3 in1, vec3 in2, out vec3 result
     result = in1 * clamp(in2, 0.0, 1.0);
 }
 
-void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, vec3 Nw, out surfaceshader out1)
+void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, out surfaceshader out1)
 {
     roughnessinfo coat_roughness_out = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
     mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_out);
@@ -984,7 +984,7 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(Nw);
+        vec3 N = normalize(PIX_IN.Nw);
         vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
         int numLights = numActiveLightSources();
         lightshader lightShader;
@@ -1126,7 +1126,7 @@ vec3 SR_brass1
 )
 {
     vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
-    vec3 geomprop_Nworld_out = normalize(Nw);
+    vec3 geomprop_Nworld_out = normalize(PIX_IN.Nw);
     vec2 geomprop_UV0_out = PIX_IN.texcoord_0;
     float image_roughness_out = 0.0;
     NG_tiledimage_float(image_roughness_fileSampler, image_roughness_default, geomprop_UV0_out, image_roughness_uvtiling, image_roughness_uvoffset, image_roughness_filtertype, image_roughness_framerange, image_roughness_frameoffset, image_roughness_frameendaction, image_roughness_out);
@@ -1134,7 +1134,7 @@ vec3 SR_brass1
     NG_tiledimage_color3(image_color_fileSampler, image_color_default, geomprop_UV0_out, image_color_uvtiling, image_color_uvoffset, image_color_filtertype, image_color_framerange, image_color_frameoffset, image_color_frameendaction, image_color_out);
 
     surfaceshader SR_brass1_out = surfaceshader(vec3(0.0),vec3(0.0));
-    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, image_color_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, Nw, SR_brass1_out);
+    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, image_color_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_brass1_out);
     return SR_brass1_out.color;
 }
 ]]></source>

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_brass_tiled.xml
@@ -65,9 +65,9 @@
     <int name="image_color_framerange" />
     <int name="image_color_frameoffset" />
     <int name="image_color_frameendaction" />
-    <float3 name="Pw" semantic="POSITION" flags="isRequirementOnly, varyingInputParam" />
-     <float3 name="Tw" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="Nw" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="Pw" semantic="Pw" flags="isRequirementOnly" />
+    <float3 name="Nw" semantic="Nw" flags="varyingInputParam" />
+    <float3 name="Tw" semantic="Tw" flags="isRequirementOnly" />
     <float2 name="texcoord_0" semantic="mayaUvCoordSemantic" flags="isRequirementOnly, varyingInputParam" />
   </properties>
   <values>
@@ -946,7 +946,7 @@ void mx_multiply_bsdf_color_indirect(vec3 V, vec3 in1, vec3 in2, out vec3 result
     result = in1 * clamp(in2, 0.0, 1.0);
 }
 
-void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, out surfaceshader out1)
+void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, vec3 Nw, out surfaceshader out1)
 {
     roughnessinfo coat_roughness_out = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
     mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_out);
@@ -1121,11 +1121,12 @@ vec3 SR_brass1
     int image_color_filtertype,
     int image_color_framerange,
     int image_color_frameoffset,
-    int image_color_frameendaction
+    int image_color_frameendaction,
+    vec3 Nw
 )
 {
     vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
-    vec3 geomprop_Nworld_out = normalize(PIX_IN.Nw);
+    vec3 geomprop_Nworld_out = normalize(Nw);
     vec2 geomprop_UV0_out = PIX_IN.texcoord_0;
     float image_roughness_out = 0.0;
     NG_tiledimage_float(image_roughness_fileSampler, image_roughness_default, geomprop_UV0_out, image_roughness_uvtiling, image_roughness_uvoffset, image_roughness_filtertype, image_roughness_framerange, image_roughness_frameoffset, image_roughness_frameendaction, image_roughness_out);
@@ -1133,7 +1134,7 @@ vec3 SR_brass1
     NG_tiledimage_color3(image_color_fileSampler, image_color_default, geomprop_UV0_out, image_color_uvtiling, image_color_uvoffset, image_color_filtertype, image_color_framerange, image_color_frameoffset, image_color_frameendaction, image_color_out);
 
     surfaceshader SR_brass1_out = surfaceshader(vec3(0.0),vec3(0.0));
-    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, image_color_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_brass1_out);
+    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, image_color_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, Nw, SR_brass1_out);
     return SR_brass1_out.color;
 }
 ]]></source>

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -912,7 +912,7 @@ void mx_multiply_bsdf_color_indirect(vec3 V, vec3 in1, vec3 in2, out vec3 result
     result = in1 * clamp(in2, 0.0, 1.0);
 }
 
-void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, vec3 Nw, out surfaceshader out1)
+void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, out surfaceshader out1)
 {
     roughnessinfo coat_roughness_out = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
     mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_out);
@@ -950,7 +950,7 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(Nw);
+        vec3 N = normalize(PIX_IN.Nw);
         vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
         int numLights = numActiveLightSources();
         lightshader lightShader;
@@ -1079,11 +1079,11 @@ vec3 main_function(
    vec3 Nw
 )
 {
-    vec3 geomprop_Nworld_out = normalize(Nw);
+    vec3 geomprop_Nworld_out = normalize(PIX_IN.Nw);
     vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
 
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
-    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, Nw, SR_default_out);
+    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);
 
     //vec3 N = normalize(PIX_IN.Nw);
     //vec3 V = normalize(u_viewPosition - PIX_IN.Pw);

--- a/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
+++ b/source/MaterialXContrib/MaterialXNode/resources/standard_surface_default.xml
@@ -54,9 +54,9 @@
     <float3 name="opacity" />
      <!-- Varying globals come in through input structure
           Name matters for space e.g. Nw means normal world  -->
-    <float3 name="Pw" semantic="POSITION" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="Nw" semantic="NORMAL" flags="isRequirementOnly, varyingInputParam" />
-    <float3 name="Tw" semantic="TANGENT" flags="isRequirementOnly, varyingInputParam" />
+    <float3 name="Pw" semantic="Pw" flags="isRequirementOnly" />
+    <float3 name="Nw" semantic="Nw" flags="varyingInputParam" />
+    <float3 name="Tw" semantic="Tw" flags="isRequirementOnly" />
      <!-- end varying globals -->
   </properties>
   <values>
@@ -912,7 +912,7 @@ void mx_multiply_bsdf_color_indirect(vec3 V, vec3 in1, vec3 in2, out vec3 result
     result = in1 * clamp(in2, 0.0, 1.0);
 }
 
-void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, out surfaceshader out1)
+void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diffuse_roughness, float specular, vec3 specular_color, float specular_roughness, float specular_IOR, float specular_anisotropy, float specular_rotation, float metalness, float transmission, vec3 transmission_color, float transmission_depth, vec3 transmission_scatter, float transmission_scatter_anisotropy, float transmission_dispersion, float transmission_extra_roughness, float subsurface, vec3 subsurface_color, vec3 subsurface_radius, float subsurface_scale, float subsurface_anisotropy, float sheen, vec3 sheen_color, float sheen_roughness, bool thin_walled, vec3 normal, vec3 tangent, float coat, vec3 coat_color, float coat_roughness, float coat_anisotropy, float coat_rotation, float coat_IOR, vec3 coat_normal, float coat_affect_color, float coat_affect_roughness, float thin_film_thickness, float thin_film_IOR, float emission, vec3 emission_color, vec3 opacity, vec3 Nw, out surfaceshader out1)
 {
     roughnessinfo coat_roughness_out = roughnessinfo(M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS, M_FLOAT_EPS);
     mx_roughness_anisotropy(coat_roughness, coat_anisotropy, coat_roughness_out);
@@ -950,7 +950,7 @@ void IMPL_standard_surface_surfaceshader(float base, vec3 base_color, float diff
     surfaceshader standard_surface_constructor_out = surfaceshader(vec3(0.0),vec3(0.0));
     {
         // Light loop
-        vec3 N = normalize(PIX_IN.Nw);
+        vec3 N = normalize(Nw);
         vec3 V = normalize(u_viewPosition - PIX_IN.Pw);
         int numLights = numActiveLightSources();
         lightshader lightShader;
@@ -1075,14 +1075,15 @@ vec3 main_function(
    float thin_film_IOR,
    float emission,
    vec3 emission_color,
-   vec3 opacity
+   vec3 opacity,
+   vec3 Nw
 )
 {
-    vec3 geomprop_Nworld_out = normalize(PIX_IN.Nw);
+    vec3 geomprop_Nworld_out = normalize(Nw);
     vec3 geomprop_Tworld_out = normalize(PIX_IN.Tw);
 
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
-    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, SR_default_out);
+    IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, specular, specular_color, specular_roughness, specular_IOR, specular_anisotropy, specular_rotation, metalness, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out, coat, coat_color, coat_roughness, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, Nw, SR_default_out);
 
     //vec3 N = normalize(PIX_IN.Nw);
     //vec3 V = normalize(u_viewPosition - PIX_IN.Pw);


### PR DESCRIPTION
Two takeaways:

1. The semantics of Pw, Nw and Tw have to match the names.
1. Nw has to be a varyingInputParam instead of a global (isRequirementOnly). This is because the pixel shader main function generated by VP2 preprocesses Nw before passing it to the main function of the fragment graph, e.g.
```vec3 v_Nw4738 = Nw( PIX_IN.Nw ); 
    float v_facingFactor4739 = FacingFactor( mix( -1.0f, 1.0f, gl_FrontFacing ) ); 
    bool v_mayaIsBackFacing4733 = mayaIsBackFacing( v_facingFactor4739 ); 
    vec3 v_mayaNormalFlip4734 = mayaNormalFlip( v_Nw4738, v_mayaIsBackFacing4733, mayaNormalMultiplier, isSingleSided ); 
    vec3 v_mayafloat3PassThrough4732 = mayafloat3PassThrough( v_mayaNormalFlip4734 ); 
```
