### PR TITLE
Rename and move normal map definition to stdlib

### DIFF
--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -74,9 +74,6 @@
   <!-- <complex_ior> -->
   <implementation name="IM_complex_ior_genglsl" nodedef="ND_complex_ior" file="pbrlib/genglsl/mx_complex_ior.glsl" function="mx_complex_ior" language="genglsl"/>
 
-  <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="pbrlib/genglsl/mx_normalmap.glsl" function="mx_normalmap" language="genglsl"/>
-
   <!-- <fresnel> -->
   <implementation name="IM_fresnel_ior_genglsl" nodedef="ND_fresnel_ior" file="pbrlib/genglsl/mx_fresnel_ior.glsl" function="mx_fresnel_ior" language="genglsl"/>
 

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -62,9 +62,6 @@
   <!-- <complex_ior> -->
   <implementation name="IM_complex_ior_genosl" nodedef="ND_complex_ior" file="pbrlib/genosl/mx_complex_ior.osl" function="mx_complex_ior" language="genosl"/>
 
-  <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="pbrlib/genosl/mx_normalmap.osl" function="mx_normalmap" language="genosl"/>
-
   <!-- <fresnel> -->
   <implementation name="IM_fresnel_ior_genosl" nodedef="ND_fresnel_ior" file="pbrlib/genosl/mx_fresnel_ior.osl" function="mx_fresnel_ior" language="genosl"/>
 

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -312,16 +312,6 @@
   </nodedef>
 
   <!--
-    Node: <normalmap>
-  -->
-  <nodedef name="ND_normalmap" node="normalmap" type="vector3" nodegroup="pbr">
-    <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
-    <parameter name="tangent_space" type="integer" value="1"/>
-    <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
-  </nodedef>
-
-  <!--
     Node: <fresnel>
   -->
   <nodedef name="ND_fresnel_ior" node="fresnel" type="float" nodegroup="pbr"

--- a/libraries/stdlib/genglsl/mx_normal_map.glsl
+++ b/libraries/stdlib/genglsl/mx_normal_map.glsl
@@ -1,4 +1,4 @@
-void mx_normalmap(vec3 value, int tangent_space, vec3 N, vec3 T, out vec3 result)
+void mx_normal_map(vec3 value, int tangent_space, vec3 N, vec3 T, out vec3 result)
 {
     // Tangent space
     if (tangent_space == 1)

--- a/libraries/stdlib/genglsl/mx_normal_map.glsl
+++ b/libraries/stdlib/genglsl/mx_normal_map.glsl
@@ -1,16 +1,16 @@
-void mx_normal_map(vec3 value, int tangent_space, vec3 N, vec3 T, out vec3 result)
+void mx_normal_map(vec3 value, int map_space, float normal_scale, vec3 N, vec3 T,  out vec3 result)
 {
     // Tangent space
-    if (tangent_space == 1)
+    if (map_space == 1)
     {
         vec3 v = value * 2.0 - 1.0;
         vec3 B = normalize(cross(N, T));
-        result = normalize(T * v.x + B * v.y + N * v.z);
+        result = normalize(T * v.x * normal_scale + B * v.y * normal_scale + N * v.z);
     }
     // Object space
     else
     {
         vec3 n = value * 2.0 - 1.0;
-        result = normalize(n);
+        result = normalize(n * normal_scale);
     }
 }

--- a/libraries/stdlib/genglsl/mx_normal_map.glsl
+++ b/libraries/stdlib/genglsl/mx_normal_map.glsl
@@ -11,6 +11,6 @@ void mx_normal_map(vec3 value, int map_space, float normal_scale, vec3 N, vec3 T
     else
     {
         vec3 n = value * 2.0 - 1.0;
-        result = normalize(n * normal_scale);
+        result = normalize(n);
     }
 }

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -35,6 +35,8 @@
     <parameter name="default" type="vector4" implname="default_value"/>
   </implementation>
 
+  <!-- <normal_map> -->
+  <implementation name="IM_normal_map_genglsl" nodedef="ND_normal_map" file="stdlib/genglsl/mx_normal_map.glsl" function="mx_normal_map" language="genglsl"/>
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->

--- a/libraries/stdlib/genosl/mx_normal_map.osl
+++ b/libraries/stdlib/genosl/mx_normal_map.osl
@@ -1,4 +1,4 @@
-void mx_normalmap(vector value, int tangent_space,  vector N, vector U, output vector result)
+void mx_normal_map(vector value, int tangent_space,  vector N, vector U, output vector result)
 {
     // Tangent space
     if (tangent_space == 1)

--- a/libraries/stdlib/genosl/mx_normal_map.osl
+++ b/libraries/stdlib/genosl/mx_normal_map.osl
@@ -12,6 +12,6 @@ void mx_normal_map(vector value, string map_space, float normal_scale, vector N,
     else
     {
         vector n = value * 2.0 - 1.0;
-        result = normalize(n * normal_scale);
+        result = normalize(n);
     }
 }

--- a/libraries/stdlib/genosl/mx_normal_map.osl
+++ b/libraries/stdlib/genosl/mx_normal_map.osl
@@ -1,17 +1,17 @@
-void mx_normal_map(vector value, int tangent_space,  vector N, vector U, output vector result)
+void mx_normal_map(vector value, string map_space, float normal_scale, vector N, vector U, output vector result)
 {
     // Tangent space
-    if (tangent_space == 1)
+    if (map_space == "tangent")
     {
         vector v = value * 2.0 - 1.0;
         vector T = normalize(U - dot(U, N) * N);
         vector B = normalize(cross(N, T));
-        result = normalize(T * v[0] + B * v[1] + N * v[2]);
+        result = normalize(T * v[0] * normal_scale + B * v[1] * normal_scale + N * v[2]);
     }
     // Object space
     else
     {
         vector n = value * 2.0 - 1.0;
-        result = normalize(n);
+        result = normalize(n * normal_scale);
     }
 }

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -37,6 +37,9 @@
 
   <!-- <triplanarprojection> -->
 
+  <!-- <normal_map> -->
+  <implementation name="IM_normal_map_genosl" nodedef="ND_normal_map" file="stdlib/genosl/mx_normal_map.osl" function="mx_normal_map" language="genosl"/>
+
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -352,7 +352,8 @@
   -->
   <nodedef name="ND_normal_map" node="normal_map" type="vector3" nodegroup="texture">
     <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
-    <parameter name="tangent_space" type="integer" value="1"/>
+    <parameter name="space" type="string" value="tangent" enum="object,tangent"/>
+    <input name="normalScale" type="float" value="1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
     <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
   </nodedef>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -353,7 +353,7 @@
   <nodedef name="ND_normal_map" node="normal_map" type="vector3" nodegroup="texture">
     <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
     <parameter name="space" type="string" value="tangent" enum="object,tangent"/>
-    <input name="normalScale" type="float" value="1.0"/>
+    <input name="scale" type="float" value="1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
     <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
   </nodedef>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -347,6 +347,15 @@
     <parameter name="frameendaction" type="string" value="black" enum="black,clamp,periodic,mirror"/>
   </nodedef>
 
+  <!--
+    Node: <normal_map>
+  -->
+  <nodedef name="ND_normal_map" node="normal_map" type="vector3" nodegroup="texture">
+    <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
+    <parameter name="tangent_space" type="integer" value="1"/>
+    <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
+  </nodedef>
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->

--- a/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
+++ b/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
@@ -34,7 +34,7 @@
       </image>
       <normal_map name="SurfaceNormal_normal" type="vector3">
          <input name="in" type="vector3" nodename="normal_image" />
-         <input name="normalScale" type="float" value="1.5" />
+         <input name="scale" type="float" value="1.5" />
       </normal_map>
       <output name="SurfaceNormal_output" type="vector3" nodename="SurfaceNormal_normal" />
 

--- a/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
+++ b/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
@@ -32,9 +32,9 @@
          <parameter name="file" type="filename" value="textures/mesh_wire_norm.png" />
          <input name="texcoord" type="vector2" nodename="normal_transform" />
       </image>
-      <normalmap name="SurfaceNormal_normal" type="vector3">
+      <normal_map name="SurfaceNormal_normal" type="vector3">
          <input name="in" type="vector3" nodename="normal_image" />
-      </normalmap>
+      </normal_map>
       <output name="SurfaceNormal_output" type="vector3" nodename="SurfaceNormal_normal" />
 
       <!-- SurfaceCutout -->

--- a/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
+++ b/resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx
@@ -34,6 +34,7 @@
       </image>
       <normal_map name="SurfaceNormal_normal" type="vector3">
          <input name="in" type="vector3" nodename="normal_image" />
+         <input name="normalScale" type="float" value="1.5" />
       </normal_map>
       <output name="SurfaceNormal_output" type="vector3" nodename="SurfaceNormal_normal" />
 

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/surfaceshader.mtlx
@@ -17,10 +17,10 @@
     <parameter name="default" type="vector3" value="0.5, 0.5, 1" />
     <input name="texcoord" type="vector2" nodename="uvscale" />
   </image>
-  <normalmap name="normalmap1" type="vector3">
+  <normal_map name="normal_map1" type="vector3">
     <input name="in" type="vector3" nodename="normalTex" />
-  </normalmap>
-  <output name="outNormal" type="vector3" nodename="normalmap1" />
+  </normal_map>
+  <output name="outNormal" type="vector3" nodename="normal_map1" />
   <nodedef name="ND_testshader2" type="surfaceshader" node="testshader2">
     <input name="diffuse_reflectance" type="color3" />
     <input name="diffuse_roughness" type="float" />
@@ -140,8 +140,8 @@
     <input name="coat_roughness" type="float" />
     <input name="coat_roughness_map" type="filename" />
     <input name="coat_IOR" type="float" />
-    <input name="normalmap" type="filename" />
-    <input name="coat_normalmap" type="filename" />
+    <input name="normal_map" type="filename" />
+    <input name="coat_normal_map" type="filename" />
   </nodedef>
   <nodegraph name="IMP_testshader4" nodedef="ND_testshader4">
     <image name="base_color" type="color3">
@@ -189,19 +189,19 @@
       <parameter name="default" type="float" interfacename="coat_roughness" />
     </image>
     <image name="normalTex" type="vector3">
-      <parameter name="file" type="filename" interfacename="normalmap" />
+      <parameter name="file" type="filename" interfacename="normal_map" />
       <parameter name="default" type="vector3" value="0.5, 0.5, 1" />
     </image>
-    <normalmap name="normalmap1" type="vector3">
+    <normal_map name="normal_map1" type="vector3">
       <input name="in" type="vector3" nodename="normalTex" />
-    </normalmap>
+    </normal_map>
     <image name="coatTex" type="vector3">
-      <parameter name="file" type="filename" interfacename="coat_normalmap" />
+      <parameter name="file" type="filename" interfacename="coat_normal_map" />
       <parameter name="default" type="vector3" value="0.5, 0.5, 1" />
     </image>
-    <normalmap name="normalmap2" type="vector3">
+    <normal_map name="normal_map2" type="vector3">
       <input name="in" type="vector3" nodename="coatTex" />
-    </normalmap>
+    </normal_map>
     <standard_surface name="standardsurface1" type="surfaceshader">
       <input name="base" type="float" interfacename="base" />
       <input name="base_color" type="color3" nodename="base_color" />
@@ -221,8 +221,8 @@
       <input name="coat_color" type="color3" nodename="coat_color" />
       <input name="coat_roughness" type="float" nodename="coat_roughness" />
       <input name="coat_IOR" type="float" interfacename="coat_IOR" />
-      <input name="normal" type="vector3" nodename="normalmap1" />
-      <input name="coat_normal" type="vector3" nodename="normalmap2" />
+      <input name="normal" type="vector3" nodename="normal_map1" />
+      <input name="coat_normal" type="vector3" nodename="normal_map2" />
     </standard_surface>
     <output name="out" type="surfaceshader" nodename="standardsurface1" />
   </nodegraph>


### PR DESCRIPTION
Updates: #484 

- Move <normalmap> nodedef from pbrlib to stdlib and renamed to <normal_map>
- Change "tangent_space" to "space" string enum with "tangent" being the default.
- Add in normal "scale" input. Default value 1.0.