### PR TITLE
Add in new logic for handling of Nw stream

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -81,6 +81,10 @@ void registerFragment(const MaterialXData& materialData, const std::string& ogsX
             fragmentNameM = fragmentManager->addShadeFragmentFromBuffer(fragmentString.c_str(), false);
         }
     }
+    else
+    {
+        fragmentNameM.set(fragmentName.c_str());
+    }
 
     if (setDumpPath)
     {

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -9,7 +9,7 @@
 #include <MaterialXGenOgsXml/OgsXmlGenerator.h>
 #include <MaterialXGenShader/Shader.h>
 
-#include <maya/MShaderManager.h>
+namespace mx = MaterialX;
 
 /// @class MaterialXData
 /// Wrapper for MaterialX associated data. 
@@ -26,30 +26,33 @@ struct MaterialXData
   public:
     /// The element path and document that the element resides in are passed in
     /// as input arguments
-    MaterialXData(const std::string& materialXDocumentPath, const std::string& elementPath);
+    MaterialXData(const std::string& materialXDocumentPath, const std::string& elementPath, const mx::FilePath& librarySearchPath);
     ~MaterialXData();
 
-    /// Set the MaterialX Document and selement path.
-    bool setData(const std::string& materialXDocumentPath, const std::string& elementPath);
+    /// Set the element to render with.
+    /// If the element specified is an empty string then an attempt will be
+    /// make to find the first renderable element.
+    bool setRenderableElement(const std::string& materialXDocumentPath, const std::string& elementPath);
 
-    /// Returns whether we have valid output element
-    bool isValidOutput()
+    /// Returns the path of the element to render
+    std::string getElementPath() const
     {
-        return (nullptr != _element);
+        if (_element)
+        {
+            return _element->getNamePath();
+        }
+        return mx::EMPTY_STRING;
     }
 
     /// Create the OGS XML wrapper for shader fragments associated
     /// with the element set to render
     void generateXml();
 
-    /// Register the fragment(s)
-    void registerFragments(const std::string& ogsXmlPath);
-
     MaterialXData& operator=(const MaterialXData&) = delete;
     MaterialXData& operator=(MaterialXData&&) = delete;
 
     /// Return MaterialX document 
-    MaterialX::DocumentPtr getDocument() const
+    mx::DocumentPtr getDocument() const
     {
         return _document;
     }
@@ -61,7 +64,7 @@ struct MaterialXData
     const std::string& getFragmentName() const;
 
     /// Get list of Element paths and corresponding XML input names
-    const MaterialX::StringMap& getPathInputMap() const;
+    const mx::StringMap& getPathInputMap() const;
 
     /// Return if the element to render represents a shader graph
     /// as opposed to a texture grraph.
@@ -79,14 +82,14 @@ struct MaterialXData
 
   private:
     // Reference document and element
-    MaterialX::FilePath _librarySearchPath;
-    MaterialX::DocumentPtr _document;
-    MaterialX::ElementPtr _element;
+    mx::FilePath _librarySearchPath;
+    mx::DocumentPtr _document;
+    mx::ElementPtr _element;
 
     // TODO: This is currently a prototype interface
-    MaterialX::ShaderGeneratorPtr _shaderGenerator;
-    MaterialX::GenContext _genContext;
-    MaterialX::OgsXmlGenerator _generator;
+    mx::ShaderGeneratorPtr _shaderGenerator;
+    mx::GenContext _genContext;
+    mx::OgsXmlGenerator _generator;
 
     // XML fragment name
     std::string _fragmentName;
@@ -95,7 +98,7 @@ struct MaterialXData
     std::string _fragmentWrapper;
 
     // Mapping from MaterialX Element paths to XML input names
-    MaterialX::StringMap _pathInputMap;
+    mx::StringMap _pathInputMap;
 };
 
 #endif // MATERIALX_DATA_H

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -91,7 +91,7 @@ MStatus MaterialXNode::initialize()
 
 void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 {
-    if (materialXData && materialXData->isValidOutput())
+    if (materialXData && !materialXData->getElementPath().empty())
     {
         const MString outputName(MaterialX::OgsXmlGenerator::OUTPUT_NAME.c_str());
         MFnNumericAttribute nAttr;

--- a/source/MaterialXContrib/MaterialXNode/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXNode/Plugin.cpp
@@ -22,6 +22,8 @@ void Plugin::initialize(const std::string& loadPath)
 	MaterialX::FilePath searchPath(loadPath);
 	_librarySearchPath = searchPath / MaterialX::FilePath("../../libraries");
 	_resourcePath = searchPath / MaterialX::FilePath("../resources");
+    // Set to resource path for now
+    _shaderDebugPath = _resourcePath;
 }
 
 ///////////////////////////////////////////////////////////////

--- a/source/MaterialXContrib/MaterialXNode/Plugin.h
+++ b/source/MaterialXContrib/MaterialXNode/Plugin.h
@@ -13,23 +13,32 @@ class Plugin
 
 	void initialize(const std::string& loadPath);
 
-	MaterialX::FilePath getLibrarySearchPath() const
+    /// Get root path to search for MaterialX libraries
+	const MaterialX::FilePath& getLibrarySearchPath() const
 	{
 		return _librarySearchPath;
 	}
 
-	MaterialX::FilePath getResourcePath() const
+    /// Get root path to search for MaterialX resources
+    const MaterialX::FilePath& getResourcePath() const
 	{
 		return _resourcePath;
 	}
+
+    /// Get path for shader debugging output
+    const MaterialX::FilePath& getShaderDebugPath() const
+    {
+        return _shaderDebugPath;
+    }
 
   private:
 	Plugin()
 	{
 	}
 
-	std::string _librarySearchPath;
-	std::string _resourcePath;
+	MaterialX::FilePath _librarySearchPath;
+    MaterialX::FilePath _resourcePath;
+    MaterialX::FilePath _shaderDebugPath;
 };
 
 #endif /* PLUGIN_H */

--- a/source/MaterialXContrib/MaterialXNode/Plugin.h
+++ b/source/MaterialXContrib/MaterialXNode/Plugin.h
@@ -9,21 +9,22 @@
 class Plugin
 {
   public:
-	static Plugin& instance();
+    static Plugin& instance();
 
-	void initialize(const std::string& loadPath);
+    /// Plugin initialization
+    void initialize(const std::string& loadPath);
 
     /// Get root path to search for MaterialX libraries
-	const MaterialX::FilePath& getLibrarySearchPath() const
-	{
-		return _librarySearchPath;
-	}
+    const MaterialX::FilePath& getLibrarySearchPath() const
+    {
+        return _librarySearchPath;
+    }
 
     /// Get root path to search for MaterialX resources
     const MaterialX::FilePath& getResourcePath() const
-	{
-		return _resourcePath;
-	}
+    {
+        return _resourcePath;
+    }
 
     /// Get path for shader debugging output
     const MaterialX::FilePath& getShaderDebugPath() const
@@ -32,11 +33,11 @@ class Plugin
     }
 
   private:
-	Plugin()
-	{
-	}
+    Plugin()
+    {
+    }
 
-	MaterialX::FilePath _librarySearchPath;
+    MaterialX::FilePath _librarySearchPath;
     MaterialX::FilePath _resourcePath;
     MaterialX::FilePath _shaderDebugPath;
 };

--- a/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -153,6 +153,23 @@ ShaderPtr GlslFragmentGenerator::generate(const string& name, ElementPtr element
         }
         emitLineEnd(stage, false);
     }
+    // Special case handling of world space normals which for now must be added 
+    // as a "dummy" argument if it exists.
+    const VariableBlock& streams = stage.getInputBlock(HW::VERTEX_DATA);
+    const size_t numStreams = streams.size();
+    for (size_t i = 0; i < numStreams; ++i)
+    {
+        const ShaderPort* p = streams[i];
+        if (p->getName() == HW::T_NORMAL_WORLD)
+        {
+            emitLineBegin(stage);
+            emitString(COMMA, stage);
+            emitVariableDeclaration(p, EMPTY_STRING, context, stage, false);
+            emitLineEnd(stage, false);
+            break;
+        }
+    }
+
     emitScopeEnd(stage);
 
     // Add function body

--- a/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -156,18 +156,13 @@ ShaderPtr GlslFragmentGenerator::generate(const string& name, ElementPtr element
     // Special case handling of world space normals which for now must be added 
     // as a "dummy" argument if it exists.
     const VariableBlock& streams = stage.getInputBlock(HW::VERTEX_DATA);
-    const size_t numStreams = streams.size();
-    for (size_t i = 0; i < numStreams; ++i)
-    {
-        const ShaderPort* p = streams[i];
-        if (p->getName() == HW::T_NORMAL_WORLD)
-        {
-            emitLineBegin(stage);
-            emitString(COMMA, stage);
-            emitVariableDeclaration(p, EMPTY_STRING, context, stage, false);
-            emitLineEnd(stage, false);
-            break;
-        }
+    const ShaderPort* port = streams.find(HW::T_NORMAL_WORLD);
+    if (port)
+    { 
+        emitLineBegin(stage);
+        emitString(COMMA, stage);
+        emitVariableDeclaration(port, EMPTY_STRING, context, stage, false);
+        emitLineEnd(stage, false);
     }
 
     emitScopeEnd(stage);

--- a/source/MaterialXGenOgsXml/OgsXmlGenerator.cpp
+++ b/source/MaterialXGenOgsXml/OgsXmlGenerator.cpp
@@ -38,14 +38,15 @@ namespace
     // Semantics used by OGS
     static const std::unordered_map<string, const pugi::char_t*> OGS_SEMANTICS_MAP =
     {
-        { "Pw", "POSITION"},
-        { "Pm", "POSITION"},
-        { "Nw", "NORMAL" },
-        { "Nm", "NORMAL" },
-        { "Tw", "TANGENT" },
-        { "Tm", "TANGENT" },
-        { "Bw", "BINORMAL" },
-        { "Bm", "BINORMAL" },
+        // Note: The semantics of Pw, Nw and Tw have to match the name of the property.
+        { "Pw", "Pw"},
+        { "Pm", "Pm"},
+        { "Nw", "Nw" },
+        { "Nm", "Nm" },
+        { "Tw", "Tw" },
+        { "Tm", "Tm" },
+        { "Bw", "Bw" },
+        { "Bm", "Bm" },
         { "texcoord_0", "mayaUvCoordSemantic" },
         { "color_0", "colorset" },
 
@@ -73,6 +74,23 @@ namespace
 
         { "u_frame", "Frame" },
         { "u_time", "Time" }
+    };
+
+    // Custom flags required by OGS XML
+    static const StringMap OGS_FLAGS_MAP = 
+    {
+        // Note: Nw has to be a varyingInputParam instead of a global (isRequirementOnly).
+        // This is because the pixel shader main function generated preprocesses Nw before passing it 
+        // to the main function of the fragment graph.
+        //
+        { "Pw", "isRequirementOnly" },
+        { "Pm", "isRequirementOnly" },
+        { "Nw", "varyingInputParam" },
+        { "Nm", "isRequirementOnly" },
+        { "Tw", "isRequirementOnly" },
+        { "Tm", "isRequirementOnly" },
+        { "Bw", "isRequirementOnly" },
+        { "Bm", "isRequirementOnly" } 
     };
 
     // String constants
@@ -126,7 +144,12 @@ namespace
         {
             prop.append_attribute(SEMANTIC) = semantic->second;
         }
-        if (!flags.empty())
+        auto flag = OGS_FLAGS_MAP.find(name);
+        if (flag != OGS_FLAGS_MAP.end())
+        {
+            prop.append_attribute(FLAGS) = flag->second.c_str();
+        }
+        else if (!flags.empty())
         {
             prop.append_attribute(FLAGS) = flags.c_str();
         }


### PR DESCRIPTION
Update #445, MATX-217

- Nw must be treated as a non-global to be passed through properly when Effect generation occurs as additional processing is required.
- Fix so the semantic names to match the names for streams.
- Make sure to add Nw to the argument list for main function as it is no longer global. It is a dummy argument for now.
- Minor cleanup to move fragment registration to the command level. Clean up some hard-coded values / paths as well.

Results:
![image](https://user-images.githubusercontent.com/14275104/60110958-025c9f80-973b-11e9-8212-5a6b65a2a7e3.png)

Here we show two shader graphs assigned to two sphere. The left-most is a texture graph assigned as a shader. Note the shaders/textures created as textures still works but is not shown here.