### PR TITLE
Workaround fact that OGS does not have a matrix33 interface type.

### DIFF
--- a/source/MaterialXGenOgsXml/GlslFragmentGenerator.h
+++ b/source/MaterialXGenOgsXml/GlslFragmentGenerator.h
@@ -40,6 +40,7 @@ class GlslFragmentGenerator : public GlslShaderGenerator
                                  bool assignValue = true) const override;
 
     static const string TARGET;
+    static const string MATRIX3_TO_MATRIX4_POSTFIX;
 
   protected:
     static void toVec3(const TypeDesc* type, string& variable);

--- a/source/MaterialXTest/GenOgsXml.cpp
+++ b/source/MaterialXTest/GenOgsXml.cpp
@@ -36,7 +36,7 @@ TEST_CASE("GenShader: OGS XML Generation", "[ogsxml]")
     mx::OgsXmlGenerator xmlGenerator;
 
     mx::StringVec testGraphs = { };
-    mx::StringVec testMaterials = { "Tiled_Brass" };
+    mx::StringVec testMaterials = { "Tiled_Brass", "Brass_Wire_Mesh" };
 
     for (auto testGraph : testGraphs)
     {


### PR DESCRIPTION
Hack to publish matrix33 as matrix44 for OGS as it does not support a  matrix33 type.

* The XML parameters and function args are matrix44 which requires additional code to be inserted to convert them back to matrix33. 
* The paramater and args are use "dummy" generated names with an additional post-fix string appended.
* The destination of the conversion back to matrix33 use the original shader names.