### PR TITLE
MATX-194 - Document and element attributes are editable

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -120,7 +120,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
     if (!status)
         return status;
 
-    MString xmlElementPath;
+    MString elementPath;
     try
     {
         MString documentFilePath;
@@ -136,7 +136,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
 
 	    if (parser.isFlagSet(kElementFlag))
 	    {
-		    argData.getFlagArgument(kElementFlag, 0, xmlElementPath);
+		    argData.getFlagArgument(kElementFlag, 0, elementPath);
 	    }
 
         MString ogsXmlFileName;
@@ -151,12 +151,12 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
 
         std::unique_ptr<MaterialXData> materialXData{
             new MaterialXData(document,
-                              xmlElementPath.asChar(),
+                              elementPath.asChar(),
                               Plugin::instance().getLibrarySearchPath())
         };
 
-        xmlElementPath.set(materialXData->getElementPath().c_str());
-        if (xmlElementPath.length() == 0)
+        elementPath.set(materialXData->getElementPath().c_str());
+        if (elementPath.length() == 0)
         {
             throw mx::Exception("The element specified is not renderable.");
         }
@@ -169,7 +169,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
 
         // Generate a valid Maya node name from the path string
         {
-            const std::string nodeName = mx::createValidName(xmlElementPath.asChar());
+            const std::string nodeName = mx::createValidName(elementPath.asChar());
             _dgModifier.renameNode(node, nodeName.c_str());
         }
 
@@ -182,7 +182,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
             throw mx::Exception("Unexpected DG node type.");
         }
 
-        materialXNode->setData(documentFilePath, xmlElementPath, std::move(materialXData));
+        materialXNode->setData(documentFilePath, elementPath, std::move(materialXData));
         materialXNode->createOutputAttr(_dgModifier);
 
         _dgModifier.doIt();
@@ -196,7 +196,7 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
     }
 
     MString message("Created MaterialX node: ");
-    message += xmlElementPath;
+    message += elementPath;
     MGlobal::displayInfo(message);
     return MS::kSuccess;
  }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -5,31 +5,6 @@
 #include <MaterialXGenOgsXml/GlslFragmentGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
-namespace
-{
-mx::DocumentPtr createDocument( const std::string& materialXDocumentPath,
-                                const MaterialX::FileSearchPath& librarySearchPath )
-{
-    // Create document
-    mx::DocumentPtr document = mx::createDocument();
-    if (!document)
-    {
-        throw mx::Exception("Failed to create a MaterialX document");
-    }
-
-    // Load libraries
-    static const mx::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
-    MaterialXMaya::loadLibraries(libraries, librarySearchPath, document);
-
-    // Read document contents from disk
-    mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
-    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
-
-    return document;
-}
-}
-
 MaterialXData::MaterialXData(   mx::DocumentPtr document,
                                 const std::string& elementPath, 
                                 const MaterialX::FileSearchPath& librarySearchPath )
@@ -82,20 +57,11 @@ MaterialXData::MaterialXData(   mx::DocumentPtr document,
     {
         generateFragment();
     }
-    catch (mx::Exception& e)
+    catch (std::exception& e)
     {
         throw mx::Exception(std::string("Failed to generate OGS shader fragment: ") + e.what());
     }
 }
-
-MaterialXData::MaterialXData(   const std::string& materialXDocumentPath,
-                                const std::string& elementPath,
-                                const MaterialX::FileSearchPath& librarySearchPath )
-    : MaterialXData(::createDocument(materialXDocumentPath, librarySearchPath),
-                    elementPath,
-                    librarySearchPath )
-{}
-
 
 MaterialXData::~MaterialXData()
 {

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -32,13 +32,8 @@ struct MaterialXData
                     const std::string& elementPath,
                     const mx::FileSearchPath& librarySearchPath);
 
-    /// The element path and the file path to the document that the element resides
-    /// in are passed in as input arguments.
-    /// If the element specified is an empty string then an attempt will be
-    /// made to find the first renderable element.
-    MaterialXData(  const std::string& materialXDocumentPath,
-                    const std::string& elementPath,
-                    const mx::FileSearchPath& librarySearchPath);
+    MaterialXData(const MaterialXData&) = delete;
+    MaterialXData(MaterialXData&&) = delete;
 
     ~MaterialXData();
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -91,7 +91,7 @@ MStatus MaterialXNode::initialize()
 
 void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 {
-    if (materialXData && !materialXData->getElementPath().empty())
+    if (_materialXData && !_materialXData->getElementPath().empty())
     {
         const MString outputName(MaterialX::OgsXmlGenerator::OUTPUT_NAME.c_str());
         MFnNumericAttribute nAttr;
@@ -130,7 +130,7 @@ MPxNode::SchedulingType MaterialXNode::schedulingType() const
 
 bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataHandle)
 {
-	if (!materialXData) return false;
+	if (!_materialXData) return false;
 
 	if (plug == DOCUMENT_ATTRIBUTE)
 	{
@@ -139,7 +139,7 @@ bool MaterialXNode::setInternalValue(const MPlug &plug, const MDataHandle &dataH
 	}
 	else if (plug == ELEMENT_ATTRIBUTE)
 	{
-		if (materialXData->getDocument())
+		if (_materialXData->getDocument())
 		{
 			//MString elementPath = dataHandle.asString();
 			//materialXData->element = materialXData->doc->getDescendant(elementPath.asChar());
@@ -225,12 +225,12 @@ void MaterialXNode::setAttributeValue(MObject &materialXObject, MObject &attr, f
 void MaterialXNode::createAttributesFromDocument(MDGModifier& mdgModifier)
 {
     MaterialX::DocumentPtr document;
-    if (!materialXData || !(document = materialXData->getDocument()))
+    if (!_materialXData || !(document = _materialXData->getDocument()))
     {
         return;
     }
 
-	const MaterialX::StringMap& inputMap = materialXData->getPathInputMap();
+	const MaterialX::StringMap& inputMap = _materialXData->getPathInputMap();
 	for (auto it = inputMap.begin(); it != inputMap.end(); ++it)
 	{
 		MaterialX::ElementPtr element = document->getDescendant(it->first);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -135,7 +135,7 @@ bool MaterialXNode::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
     }
     else if (plug == ELEMENT_ATTRIBUTE)
     {
-        dataHandle.set(_xmlElementPath);
+        dataHandle.set(_elementPath);
     }
     else
     {
@@ -180,7 +180,7 @@ bool MaterialXNode::setInternalValue(const MPlug& plug, const MDataHandle& dataH
         {
             _materialXData.reset( new MaterialXData(
                 loadDocument(),
-                _xmlElementPath.asChar(),
+                _elementPath.asChar(),
                 Plugin::instance().getLibrarySearchPath()
             ));
         }
@@ -192,12 +192,12 @@ bool MaterialXNode::setInternalValue(const MPlug& plug, const MDataHandle& dataH
     else if (plug == ELEMENT_ATTRIBUTE)
     {
         const MString& value = dataHandle.asString();
-        if (_xmlElementPath == value)
+        if (_elementPath == value)
         {
             return true;
         }
 
-        _xmlElementPath = value;
+        _elementPath = value;
         mx::DocumentPtr document;
 
         if (_materialXData)
@@ -215,7 +215,7 @@ bool MaterialXNode::setInternalValue(const MPlug& plug, const MDataHandle& dataH
 
             _materialXData.reset(new MaterialXData(
                 document,
-                _xmlElementPath.asChar(),
+                _elementPath.asChar(),
                 Plugin::instance().getLibrarySearchPath()
             ));
         }
@@ -234,11 +234,11 @@ bool MaterialXNode::setInternalValue(const MPlug& plug, const MDataHandle& dataH
 }
 
 void MaterialXNode::setData(const MString& documentFilePath,
-                            const MString& xmlElementPath,
+                            const MString& elementPath,
                             std::unique_ptr<MaterialXData>&& materialXData)
 {
     _documentFilePath = documentFilePath;
-    _xmlElementPath = xmlElementPath;
+    _elementPath = elementPath;
     _materialXData = std::move(materialXData);
 }
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
@@ -25,9 +25,14 @@ class MaterialXNode : public MPxNode
     bool setInternalValue(const MPlug &plug, const MDataHandle &dataHandle) override;
     void createAttributesFromDocument(MDGModifier& mdgModifier);
 
+    const MaterialXData* getMaterialXData() const
+    {
+        return _materialXData.get();
+    }
+
     void setMaterialXData(std::unique_ptr<MaterialXData>&& data)
     {
-        materialXData = std::move(data);
+        _materialXData = std::move(data);
     }
 
     static const MTypeId MATERIALX_NODE_TYPEID;
@@ -42,10 +47,10 @@ class MaterialXNode : public MPxNode
     static MString ELEMENT_ATTRIBUTE_SHORT_NAME;
     static MObject ELEMENT_ATTRIBUTE;
 
-    std::unique_ptr<MaterialXData> materialXData;
-
   private:
     void setAttributeValue(MObject &materialXObject, MObject &attr, float* values, unsigned int size, MDGModifier& mdgModifier);
+
+    std::unique_ptr<MaterialXData> _materialXData;
 
     MObject _outAttr;
     std::unordered_map<std::string, MaterialX::ElementPtr> _attributeElementPairMap;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
@@ -23,7 +23,6 @@ class MaterialXNode : public MPxNode
     MTypeId	typeId() const override;
     SchedulingType schedulingType() const override;
     bool setInternalValue(const MPlug &plug, const MDataHandle &dataHandle) override;
-    void createAttributesFromDocument(MDGModifier& mdgModifier);
 
     const MaterialXData* getMaterialXData() const
     {
@@ -38,10 +37,11 @@ class MaterialXNode : public MPxNode
     static const MTypeId MATERIALX_NODE_TYPEID;
     static const MString MATERIALX_NODE_TYPENAME;
 
-    /// Attribute holding a MaterialX document
+    /// Attribute holding a path to MaterialX document file
     static MString DOCUMENT_ATTRIBUTE_LONG_NAME;
     static MString DOCUMENT_ATTRIBUTE_SHORT_NAME;
     static MObject DOCUMENT_ATTRIBUTE;
+
     /// Attribute holding a MaterialX element name
     static MString ELEMENT_ATTRIBUTE_LONG_NAME;
     static MString ELEMENT_ATTRIBUTE_SHORT_NAME;
@@ -53,7 +53,6 @@ class MaterialXNode : public MPxNode
     std::unique_ptr<MaterialXData> _materialXData;
 
     MObject _outAttr;
-    std::unordered_map<std::string, MaterialX::ElementPtr> _attributeElementPairMap;
 };
 
 class MaterialXTextureNode : public MaterialXNode

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
@@ -19,19 +19,18 @@ class MaterialXNode : public MPxNode
     static MStatus initialize();
 
     void createOutputAttr(MDGModifier& mdgModifier);
-    MStatus setDependentsDirty(const MPlug &plugBeingDirtied, MPlugArray & affectedPlugs) override;
+    MStatus setDependentsDirty(const MPlug& plugBeingDirtied, MPlugArray& affectedPlugs) override;
     MTypeId	typeId() const override;
     SchedulingType schedulingType() const override;
-    bool setInternalValue(const MPlug &plug, const MDataHandle &dataHandle) override;
+
+    bool getInternalValue(const MPlug&, MDataHandle&) override;
+    bool setInternalValue(const MPlug&, const MDataHandle&) override;
+
+    void setData(const MString& documentFilePath, const MString& xmlElementPath, std::unique_ptr<MaterialXData>&&);
 
     const MaterialXData* getMaterialXData() const
     {
         return _materialXData.get();
-    }
-
-    void setMaterialXData(std::unique_ptr<MaterialXData>&& data)
-    {
-        _materialXData = std::move(data);
     }
 
     static const MTypeId MATERIALX_NODE_TYPEID;
@@ -48,7 +47,7 @@ class MaterialXNode : public MPxNode
     static MObject ELEMENT_ATTRIBUTE;
 
   private:
-    void setAttributeValue(MObject &materialXObject, MObject &attr, float* values, unsigned int size, MDGModifier& mdgModifier);
+    MString _documentFilePath, _xmlElementPath;
 
     std::unique_ptr<MaterialXData> _materialXData;
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
@@ -26,7 +26,7 @@ class MaterialXNode : public MPxNode
     bool getInternalValue(const MPlug&, MDataHandle&) override;
     bool setInternalValue(const MPlug&, const MDataHandle&) override;
 
-    void setData(const MString& documentFilePath, const MString& xmlElementPath, std::unique_ptr<MaterialXData>&&);
+    void setData(const MString& documentFilePath, const MString& elementPath, std::unique_ptr<MaterialXData>&&);
 
     const MaterialXData* getMaterialXData() const
     {
@@ -47,7 +47,7 @@ class MaterialXNode : public MPxNode
     static MObject ELEMENT_ATTRIBUTE;
 
   private:
-    MString _documentFilePath, _xmlElementPath;
+    MString _documentFilePath, _elementPath;
 
     std::unique_ptr<MaterialXData> _materialXData;
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
@@ -192,7 +192,7 @@ MaterialXShadingNodeImpl<BASE>::fragmentName() const
     MStatus status;
     MFnDependencyNode depNode(_object, &status);
     const auto* const node = dynamic_cast<MaterialXNode*>(depNode.userNode());
-    const MaterialXData* const data = node ? node->materialXData.get() : nullptr;
+    const MaterialXData* const data = node ? node->getMaterialXData() : nullptr;
     return data ? data->getFragmentName().c_str() : "";
 }
 
@@ -232,8 +232,8 @@ void MaterialXShadingNodeImpl<BASE>::updateShader(MHWRender::MShaderInstance& sh
     ::bindEnvironmentLighting(shader, parameterList, imageSearchPath,
         envRadiancePath, envIrradiancePath);
 
-    MaterialX::DocumentPtr document = node->materialXData->getDocument();
-    const MaterialX::StringMap& inputs = node->materialXData->getPathInputMap();
+    MaterialX::DocumentPtr document = node->getMaterialXData()->getDocument();
+    const MaterialX::StringMap& inputs = node->getMaterialXData()->getPathInputMap();
     for (const auto& input : inputs)
     {
         MaterialX::ElementPtr element = document->getDescendant(input.first);

--- a/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
@@ -213,6 +213,12 @@ void MaterialXShadingNodeImpl<BASE>::updateShader(MHWRender::MShaderInstance& sh
         return;
     }
 
+    const MaterialXData* const materialXData = node->getMaterialXData();
+    if (!materialXData)
+    {
+        return;
+    }
+
     // Get the parameter list to check existence against.
     MStringArray parameterList;
     shader.parameterList(parameterList);
@@ -232,8 +238,8 @@ void MaterialXShadingNodeImpl<BASE>::updateShader(MHWRender::MShaderInstance& sh
     ::bindEnvironmentLighting(shader, parameterList, imageSearchPath,
         envRadiancePath, envIrradiancePath);
 
-    MaterialX::DocumentPtr document = node->getMaterialXData()->getDocument();
-    const MaterialX::StringMap& inputs = node->getMaterialXData()->getPathInputMap();
+    MaterialX::DocumentPtr document = materialXData->getDocument();
+    const MaterialX::StringMap& inputs = materialXData->getPathInputMap();
     for (const auto& input : inputs)
     {
         MaterialX::ElementPtr element = document->getDescendant(input.first);
@@ -249,7 +255,9 @@ void MaterialXShadingNodeImpl<BASE>::updateShader(MHWRender::MShaderInstance& sh
         }
 
         const std::string& inputName = input.second;
-        const MHWRender::MAttributeParameterMapping* const mapping = mappings.findByParameterName(inputName.c_str());
+        const MHWRender::MAttributeParameterMapping* const mapping =
+            mappings.findByParameterName(inputName.c_str());
+
         const MString resolvedName = mapping ? mapping->resolvedParameterName() : inputName.c_str();
 
         if (valueElement->getType() == MaterialX::FILENAME_TYPE_STRING)

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -61,5 +61,27 @@ mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
     return foundPath;
 }
 
+mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
+                             const MaterialX::FileSearchPath& librarySearchPath)
+{
+    // Create document
+    mx::DocumentPtr document = mx::createDocument();
+    if (!document)
+    {
+        throw mx::Exception("Failed to create a MaterialX document");
+    }
+
+    // Load libraries
+    static const mx::StringVec libraries = { "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl" };
+    MaterialXMaya::loadLibraries(libraries, librarySearchPath, document);
+
+    // Read document contents from disk
+    mx::XmlReadOptions readOptions;
+    readOptions.skipDuplicateElements = true;
+    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
+
+    return document;
+}
+
 } // namespace MaterialXMaya
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
@@ -25,6 +25,9 @@ void loadLibraries(const mx::StringVec& libraryNames,
 mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
                                   const mx::FilePath& filePath);
 
+mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
+                             const MaterialX::FileSearchPath& librarySearchPath);
+
 } // namespace MaterialXMaya
 
 #endif


### PR DESCRIPTION
- The document attribute now holds a file path
- The document and element attributes are shown and are editable in the Attribute Editor
- MaterialXData updates on attribute changes.

There's definitely a lot of work to debug all the possible updates and loading and saving but at least it's not possible to create a MaterialX node via Hypershade, browse to a valid document from the document file path attribute in the Attribute Editor and get a working shader in the viewport.

I think it's time to decide on the final names of the document and element attributes and publish the spec.