### PR TITLE
Fix logic of managing used texture units for ImageHandler 

### DIFF
--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -162,6 +162,11 @@ bool ImageHandler::bindImage(const FilePath& /*filePath*/, const ImageSamplingPr
     return false;
 }
 
+bool ImageHandler::unbindImage(const FilePath& /*filePath*/)
+{
+    return false;
+}
+
 void ImageHandler::cacheImage(const string& filePath, const ImageDesc& desc)
 {
     if (!_imageCache.count(filePath))

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -277,6 +277,10 @@ class ImageHandler
     /// @return true if succeded to bind
     virtual bool bindImage(const FilePath& filePath, const ImageSamplingProperties& samplingProperties);
 
+    /// Unbind an image. The default implementation performs no action.
+    /// @param filePath File path to image description to unbind
+    virtual bool unbindImage(const FilePath& filePath);
+
     /// Clear the contents of the image cache.
     /// deleteImage() will be called for each cache description to
     /// allow derived classes to clean up any associated resources.
@@ -302,7 +306,6 @@ class ImageHandler
     {
         return -1;
     }
-
 
   protected:
     /// Cache an image for reuse.

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -59,6 +59,10 @@ class GLTextureHandler : public ImageHandler
     /// @return true if succeded to bind
     bool bindImage(const FilePath& filePath, const ImageSamplingProperties& samplingProperties) override;
 
+    /// Unbind an image. 
+    /// @param filePath File path to image description to unbind
+    virtual bool unbindImage(const FilePath& filePath) override;
+
     /// Utility to map an address mode enumeration to an OpenGL address mode
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);
 
@@ -69,6 +73,9 @@ class GLTextureHandler : public ImageHandler
     int getBoundTextureLocation(unsigned int resourceId) override;
 
   protected:
+    /// Unbind an image.
+    bool unbindImage(const ImageDesc& imageDesc);
+
     /// Delete an image
     /// @param imageDesc Image description indicate which image to delete.
     /// Any OpenGL texture resource and as well as any CPU side reosurce memory will be deleted.

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -539,12 +539,14 @@ bool GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation, con
     {
         if (imageHandler->acquireImage(resolvedFilePath, desc, generateMipMaps, &(samplingProperties.defaultColor)))
         {
-            // Map location to a texture unit
-            int textureLocation = imageHandler->getBoundTextureLocation(desc.resourceId);
-            if (textureLocation >= 0) 
+            textureBound = imageHandler->bindImage(resolvedFilePath, samplingProperties);
+            if (textureBound)
             {
-               glUniform1i(uniformLocation, textureLocation);
-               textureBound = imageHandler->bindImage(resolvedFilePath, samplingProperties);
+                int textureLocation = imageHandler->getBoundTextureLocation(desc.resourceId);
+                if (textureLocation >= 0)
+                {
+                    glUniform1i(uniformLocation, textureLocation);
+                }
             }
         }
         checkErrors();

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -131,9 +131,12 @@ class Material
                     const mx::FileSearchPath& searchPath,
                     const std::string& udim);
 
+    /// Unbbind all images for this material.
+    void unbindImages(mx::GLTextureHandlerPtr imageHandler);
+
     /// Bind a single image.
-    bool bindImage(const mx::FilePath& filename, const std::string& uniformName, mx::GLTextureHandlerPtr imageHandler,
-                   mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const std::string& udim = mx::EMPTY_STRING, mx::Color4* fallbackColor = nullptr);
+    mx::FilePath bindImage(const mx::FilePath& filename, const std::string& uniformName, mx::GLTextureHandlerPtr imageHandler,
+                           mx::ImageDesc& desc, const mx::ImageSamplingProperties& samplingProperties, const std::string& udim = mx::EMPTY_STRING, mx::Color4* fallbackColor = nullptr);
 
     /// Bind lights to shader.
     void bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandlerPtr imageHandler, const mx::FileSearchPath& imagePath, 
@@ -168,6 +171,8 @@ class Material
     std::string _udim;
     bool _hasTransparency;
     mx::StringSet _uniformNames;
+
+    std::vector<mx::FilePath> _boundImages;
 };
 
 #endif // MATERIALXVIEW_MATERIAL_H

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1147,6 +1147,7 @@ void Viewer::drawScene3D()
                              _specularEnvironmentMethod, _envSamples);
         material->bindImages(_imageHandler, _searchPath, material->getUdim());
         material->drawPartition(geom);
+        material->unbindImages(_imageHandler);
     }
 
     // Transparent pass
@@ -1168,6 +1169,7 @@ void Viewer::drawScene3D()
                              _specularEnvironmentMethod, _envSamples);
         material->bindImages(_imageHandler, _searchPath, material->getUdim());
         material->drawPartition(geom);
+        material->unbindImages(_imageHandler);
     }
     
     // Ambient occlusion pass
@@ -1192,6 +1194,7 @@ void Viewer::drawScene3D()
                                         _specularEnvironmentMethod, _envSamples);
             _ambOccMaterial->bindImages(_imageHandler, _searchPath, material->getUdim());
             _ambOccMaterial->drawPartition(geom);
+            _ambOccMaterial->unbindImages(_imageHandler);
         }
     }
     


### PR DESCRIPTION
Update #502 

Fix logic of managing used texture units. 
* Was just constantly using slots until full and then would stop allowing images to even load.
* Rework texture unit location handler to update on bind and newly added unbind. 
* Remove all updates from acquire as acquiring has nothing to do with binding. 
* Update viewer to use new logic by caching bound image names when drawing and then clearing the cache.