### PR TITLE
Renamed Maya node types and document and element attributes.

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -26,16 +26,13 @@ namespace mx = MaterialX;
 namespace
 {
 const char* const kDocumentFlag     = "d";
-const char* const kDocumentFlagLong = "document";
-
 const char* const kElementFlag      = "e";
-const char* const kElementFlagLong  = "element";
 
 const char* const kTextureFlag      = "t";
-const char* const kTextureFlagLong  = "texture";
+const char* const kTextureFlagLong  = "asTexture";
 
 const char* const kOgsXmlFlag       = "x";
-const char* const kOgsXmlFlagLong   = "ogsxml";
+const char* const kOgsXmlFlagLong   = "ogsXml";
 
 void registerFragment(const MaterialXData& materialData, const std::string& ogsXmlFileName)
 {
@@ -186,6 +183,13 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
         materialXNode->createOutputAttr(_dgModifier);
 
         _dgModifier.doIt();
+
+        MString message("Created ");
+        message += materialXNode->typeName();
+        message += " node: ";
+        message += materialXNode->name();
+        MGlobal::displayInfo(message);
+        return MS::kSuccess;
     }
     catch (std::exception& e)
     {
@@ -194,18 +198,13 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
         MGlobal::displayError(message);
         return MS::kFailure;
     }
-
-    MString message("Created MaterialX node: ");
-    message += elementPath;
-    MGlobal::displayInfo(message);
-    return MS::kSuccess;
  }
 
 MSyntax CreateMaterialXNodeCmd::newSyntax()
 {
 	MSyntax syntax;
-	syntax.addFlag(kDocumentFlag, kDocumentFlagLong, MSyntax::kString);
-	syntax.addFlag(kElementFlag, kElementFlagLong, MSyntax::kString);
+	syntax.addFlag(kDocumentFlag, MaterialXNode::DOCUMENT_ATTRIBUTE_LONG_NAME.asChar(), MSyntax::kString);
+	syntax.addFlag(kElementFlag, MaterialXNode::ELEMENT_ATTRIBUTE_LONG_NAME.asChar(), MSyntax::kString);
     syntax.addFlag(kOgsXmlFlag, kOgsXmlFlagLong, MSyntax::kString);
     syntax.addFlag(kTextureFlag, kTextureFlagLong, MSyntax::kNoArg);
 	return syntax;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -32,19 +32,19 @@
 const MTypeId MaterialXNode::MATERIALX_NODE_TYPEID(0x00042402);
 const MString MaterialXNode::MATERIALX_NODE_TYPENAME("MaterialXNode");
 
-MString MaterialXNode::DOCUMENT_ATTRIBUTE_LONG_NAME("document");
+MString MaterialXNode::DOCUMENT_ATTRIBUTE_LONG_NAME("documentFilePath");
 MString MaterialXNode::DOCUMENT_ATTRIBUTE_SHORT_NAME("doc");
 MObject MaterialXNode::DOCUMENT_ATTRIBUTE;
 
-MString MaterialXNode::ELEMENT_ATTRIBUTE_LONG_NAME("element");
+MString MaterialXNode::ELEMENT_ATTRIBUTE_LONG_NAME("elementPath");
 MString MaterialXNode::ELEMENT_ATTRIBUTE_SHORT_NAME("ele");
 MObject MaterialXNode::ELEMENT_ATTRIBUTE;
 
 const MTypeId MaterialXTextureNode::MATERIALX_TEXTURE_NODE_TYPEID(0x00042403);
-const MString MaterialXTextureNode::MATERIALX_TEXTURE_NODE_TYPENAME("MaterialXTextureNode");
+const MString MaterialXTextureNode::MATERIALX_TEXTURE_NODE_TYPENAME("MaterialXTexture");
 
 const MTypeId MaterialXSurfaceNode::MATERIALX_SURFACE_NODE_TYPEID(0x00042404);
-const MString MaterialXSurfaceNode::MATERIALX_SURFACE_NODE_TYPENAME("MaterialXSurfaceNode");
+const MString MaterialXSurfaceNode::MATERIALX_SURFACE_NODE_TYPENAME("MaterialXSurface");
 
 MaterialXNode::MaterialXNode()
 {


### PR DESCRIPTION
Just wanted to clean up the node and attribute names before making the interface final and exposing it to MtoA.