### PR TITLE
Dev to MaterialXNode Merge 

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -83,12 +83,12 @@ def main(args=None):
                 fh.write("    <tr>\n")
                 if glslFile:
                     if args.ENABLE_TIMESTAMPS:
-                        fh.write("        <td align='center'>" + glslFile + " (" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullGlslPath))) + ")</td>\n")
+                        fh.write("        <td align='center'><p>" + glslFile + "</p>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullGlslPath))) + ")</td>\n")
                     else:
                         fh.write("        <td align='center'>" + glslFile + "</td>\n")
                 if oslFile:
                     if args.ENABLE_TIMESTAMPS:
-                        fh.write("        <td align='center'>" + oslFile + " (" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullOslPath))) + ")</td>\n")
+                        fh.write("        <td align='center'><p>" + oslFile + "</p>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullOslPath))) + ")</td>\n")
                     else:
                         fh.write("        <td align='center'>" + oslFile + "</td>\n")
                 if diffPath:

--- a/resources/Materials/TestSuite/libraries/sd/floor.mtlx
+++ b/resources/Materials/TestSuite/libraries/sd/floor.mtlx
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <materialx version="1.36">
-   <xi:include href="alglib_defs.mtlx" />
+   <!-- xi:include href="alglib_defs.mtlx" /> -->
    <xi:include href="alglib_ng.mtlx" />
    <xi:include href="bxdf/ubershader_defs.mtlx" />
-   <xi:include href="bxdf/standard_surface.mtlx" />
+   <!-- <xi:include href="bxdf/standard_surface.mtlx" /> -->
    <nodedef name="ND_MtlxShader" type="multioutput" node="MtlxShader">
       <parameter name="rust_tiling" type="float" value="1.0" uifolder="Material Parameters" uimin="0.0" uimax="2.0" />
       <parameter name="rust_roughness" type="float" value="1.0" uifolder="Material Parameters" uimin="0.0" uimax="2.0" />

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -13,9 +13,7 @@ namespace MaterialXMaya
 void loadLibrary(const mx::FilePath& filePath, mx::DocumentPtr doc)
 {
 	mx::DocumentPtr libDoc = mx::createDocument();
-    mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
-	mx::readFromXmlFile(libDoc, filePath, mx::EMPTY_STRING, &readOptions);
+	mx::readFromXmlFile(libDoc, filePath, mx::EMPTY_STRING);
 	doc->importLibrary(libDoc);
 }
 
@@ -74,9 +72,7 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
     MaterialXMaya::loadLibraries(libraries, librarySearchPath, document);
 
     // Read document contents from disk
-    mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
-    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
+    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING);
 
     return document;
 }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -14,7 +14,9 @@ void loadLibrary(const mx::FilePath& filePath, mx::DocumentPtr doc)
 {
 	mx::DocumentPtr libDoc = mx::createDocument();
 	mx::readFromXmlFile(libDoc, filePath, mx::EMPTY_STRING);
-	doc->importLibrary(libDoc);
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
+    doc->importLibrary(libDoc, &copyOptions);
 }
 
 void loadLibraries(const mx::StringVec& libraryNames,

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -150,6 +150,14 @@ void Document::importLibrary(const ConstDocumentPtr& library, const CopyOptions*
     for (const ConstElementPtr& child : library->getChildren())
     {
         string childName = child->getQualifiedName(child->getName());
+
+        // Skip elements from a previous import of the same library.
+        ConstElementPtr previous = getChild(childName);
+        if (previous && previous->getActiveSourceUri() == library->getSourceUri())
+        {
+            continue;
+        }
+
         if (skipDuplicateElements && getChild(childName))
         {
             continue;

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -144,21 +144,19 @@ void Document::initialize()
     setVersionString(DOCUMENT_VERSION_STRING);
 }
 
-void Document::importLibrary(const ConstDocumentPtr& library)
+void Document::importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions)
 {
+    bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
     for (const ConstElementPtr& child : library->getChildren())
     {
         string childName = child->getQualifiedName(child->getName());
-
-        // Skip elements from a previous import of the same library.
-        ConstElementPtr previous = getChild(childName);
-        if (previous && previous->getActiveSourceUri() == library->getSourceUri())
+        if (skipDuplicateElements && getChild(childName))
         {
             continue;
         }
 
         ElementPtr childCopy = addChildOfCategory(child->getCategory(), childName);
-        childCopy->copyContentFrom(child);
+        childCopy->copyContentFrom(child, copyOptions);
         if (!childCopy->hasFilePrefix() && library->hasFilePrefix())
         {
             childCopy->setFilePrefix(library->getFilePrefix());

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -60,7 +60,10 @@ class Document : public GraphElement
     /// The contents of the library document are copied into this one, and
     /// are assigned the source URI of the library.
     /// @param library The library document to be imported.
-    void importLibrary(const ConstDocumentPtr& library);
+    /// @param copyOptions An optional pointer to a CopyOptions object.
+    ///    If provided, then the given options will affect the behavior of the
+    ///    import function.  Defaults to a null pointer.
+    void importLibrary(const ConstDocumentPtr& library, const CopyOptions* copyOptions = nullptr);
 
     /// @}
     /// @name NodeGraph Elements

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -373,9 +373,10 @@ InheritanceIterator Element::traverseInheritance() const
     return InheritanceIterator(getSelf());
 }
 
-void Element::copyContentFrom(const ConstElementPtr& source)
+void Element::copyContentFrom(const ConstElementPtr& source, const CopyOptions* copyOptions)
 {
     DocumentPtr doc = getDocument();
+    bool skipDuplicateElements = copyOptions && copyOptions->skipDuplicateElements;
 
     // Handle change notifications.
     ScopedUpdate update(doc);
@@ -387,7 +388,12 @@ void Element::copyContentFrom(const ConstElementPtr& source)
 
     for (const ConstElementPtr& child : source->getChildren())
     {
-        ElementPtr childCopy = addChildOfCategory(child->getCategory(), child->getName());
+        const string& name = child->getName();
+        if (skipDuplicateElements && getChild(name))
+        {
+            continue;
+        }
+        ElementPtr childCopy = addChildOfCategory(child->getCategory(), name);
         childCopy->copyContentFrom(child);
     }
 }

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -25,6 +25,7 @@ class Token;
 class StringResolver;
 class Document;
 class Material;
+class CopyOptions;
 
 /// A shared pointer to an Element
 using ElementPtr = shared_ptr<Element>;
@@ -767,7 +768,10 @@ class Element : public std::enable_shared_from_this<Element>
 
     /// Copy all attributes and descendants from the given element to this one.
     /// @param source The element from which content is copied.
-    void copyContentFrom(const ConstElementPtr& source);
+    /// @param copyOptions An optional pointer to a CopyOptions object.
+    ///    If provided, then the given options will affect the behavior of the
+    ///    copy function.  Defaults to a null pointer.
+    void copyContentFrom(const ConstElementPtr& source, const CopyOptions* copyOptions = nullptr);
 
     /// Clear all attributes and descendants from this element.
     void clearContent();
@@ -1273,6 +1277,22 @@ class StringResolver
     string _geomPrefix;
     StringMap _filenameMap;
     StringMap _geomNameMap;
+};
+
+/// @class CopyOptions
+/// A set of options for controlling the behavior of element copy operations.
+class CopyOptions
+{
+  public:
+    CopyOptions() :
+        skipDuplicateElements(false)
+    {
+    }
+    ~CopyOptions() { }
+
+    /// If true, elements at the same scope with duplicate names will be skipped;
+    /// otherwise, they will trigger an exception.  Defaults to false.
+    bool skipDuplicateElements;
 };
 
 /// @class ExceptionOrphanedElement

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -48,9 +48,6 @@ bool readFile(const string& filename, string& contents)
 void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const StringSet& includeFiles,
                    vector<DocumentPtr>& documents, StringVec& documentsPaths, StringVec& errors)
 {
-    errors.clear();
-    XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
     for (const FilePath& dir : rootPath.getSubDirectories())
     {
         for (const FilePath& file : dir.getFilesInDirectory(MTLX_EXTENSION))
@@ -62,7 +59,7 @@ void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const S
                 const FilePath filePath = dir / file;
                 try
                 {
-                    readFromXmlFile(doc, filePath, dir, &readOptions);
+                    readFromXmlFile(doc, filePath, dir);
                     documents.push_back(doc);
                     documentsPaths.push_back(filePath.asString());
                 }

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -20,10 +20,10 @@ namespace GenShaderUtil
 void loadLibrary(const mx::FilePath& file, mx::DocumentPtr doc)
 {
     mx::DocumentPtr libDoc = mx::createDocument();
-    mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
-    mx::readFromXmlFile(libDoc, file, mx::EMPTY_STRING, &readOptions);
-    doc->importLibrary(libDoc);
+    mx::readFromXmlFile(libDoc, file);
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
+    doc->importLibrary(libDoc, &copyOptions);
 }
 
 void loadLibraries(const mx::StringVec& libraryNames,
@@ -596,10 +596,25 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     context.registerSourceCodeSearchPath(_srcSearchPath);
 
     size_t documentIndex = 0;
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
     for (auto doc : _documents)
     {
         // Add in dependent libraries
-        doc->importLibrary(_dependLib);
+        bool importedLibrary = false;
+        try
+        {
+            doc->importLibrary(_dependLib, &copyOptions);
+            importedLibrary = true;
+        }
+        catch (mx::Exception& e)
+        {
+            _logFile << "Failed to import library into file: " 
+                    << _documentPaths[documentIndex] << ". Error: "
+                    << e.what() << std::endl;
+            CHECK(importedLibrary);
+            continue;
+        }
 
         // Find and register lights
         findLights(doc, _lights);

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -175,6 +175,9 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     mx::StringSet usedImpls;
 
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
+
     const std::string MTLX_EXTENSION("mtlx");
     for (auto dir : dirs)
     {
@@ -214,7 +217,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                 WARN("Failed to load in file: " + filename + "See: " + docValidLogFilename + " for details.");                    
             }
 
-            doc->importLibrary(dependLib);
+            doc->importLibrary(dependLib, &copyOptions);
             ioTimer.endTimer();
 
             validateTimer.startTimer();

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -180,11 +180,13 @@ TEST_CASE("Load content", "[xmlio]")
     REQUIRE(imageElementCount == 0);
 
     // Import duplicate libraries into document.
+    mx::CopyOptions copyOptions;
+    copyOptions.skipDuplicateElements = true;
     mx::DocumentPtr dupDoc = mx::createDocument();
     for (mx::DocumentPtr lib : libs)
     {
         dupDoc->importLibrary(lib);
-        dupDoc->importLibrary(lib);
+        dupDoc->importLibrary(lib, &copyOptions);
     }
     REQUIRE(dupDoc->validate());
 

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -9,8 +9,6 @@
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/XmlIo.h>
 
-#include <fstream> 
-
 namespace mx = MaterialX;
 
 TEST_CASE("Load content", "[xmlio]")
@@ -164,7 +162,7 @@ TEST_CASE("Load content", "[xmlio]")
     writeOptions.writeXIncludeEnable = false;
     writeOptions.elementPredicate = skipImages;
     std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
-     
+        
     // Reconstruct and verify that the document contains no images.
     mx::DocumentPtr writtenDoc = mx::createDocument();
     mx::readFromXmlString(writtenDoc, xmlString);
@@ -180,13 +178,11 @@ TEST_CASE("Load content", "[xmlio]")
     REQUIRE(imageElementCount == 0);
 
     // Import duplicate libraries into document.
-    mx::CopyOptions copyOptions;
-    copyOptions.skipDuplicateElements = true;
     mx::DocumentPtr dupDoc = mx::createDocument();
     for (mx::DocumentPtr lib : libs)
     {
         dupDoc->importLibrary(lib);
-        dupDoc->importLibrary(lib, &copyOptions);
+        dupDoc->importLibrary(lib);
     }
     REQUIRE(dupDoc->validate());
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -83,7 +83,6 @@ mx::DocumentPtr loadLibraries(const mx::StringVec& libraryFolders, const mx::Fil
             mx::FilePath file = path / filename;
             mx::DocumentPtr libDoc = mx::createDocument();
             mx::XmlReadOptions readOptions;
-            readOptions.skipDuplicateElements = true;
             mx::readFromXmlFile(libDoc, file, mx::EMPTY_STRING, &readOptions);
             libDoc->setSourceUri(file);
             doc->importLibrary(libDoc);
@@ -359,7 +358,6 @@ void Viewer::setupLights(mx::DocumentPtr doc)
         try
         {
             mx::XmlReadOptions readOptions;
-            readOptions.skipDuplicateElements = true;                
             mx::readFromXmlFile(lightDoc, path.asString(), mx::EMPTY_STRING, &readOptions);
             lightDoc->setSourceUri(path);
             doc->importLibrary(lightDoc);
@@ -719,7 +717,6 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
 {
     // Set up read options.
     mx::XmlReadOptions readOptions;
-    readOptions.skipDuplicateElements = true;
     readOptions.readXIncludeFunction = [](mx::DocumentPtr doc, const std::string& filename,
                                           const std::string& searchPath, const mx::XmlReadOptions* options)
     {

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -17,7 +17,8 @@ void bindPyDocument(py::module& mod)
     py::class_<mx::Document, mx::DocumentPtr, mx::GraphElement>(mod, "Document")
         .def("initialize", &mx::Document::initialize)
         .def("copy", &mx::Document::copy)
-        .def("importLibrary", &mx::Document::importLibrary)
+        .def("importLibrary", &mx::Document::importLibrary, 
+            py::arg("library"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("addNodeGraph", &mx::Document::addNodeGraph,
             py::arg("name") = mx::EMPTY_STRING)
         .def("getNodeGraph", &mx::Document::getNodeGraph)

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -26,6 +26,10 @@ namespace mx = MaterialX;
 
 void bindPyElement(py::module& mod)
 {
+    py::class_<mx::CopyOptions>(mod, "CopyOptions")
+        .def(py::init())
+        .def_readwrite("skipDuplicateElements", &mx::CopyOptions::skipDuplicateElements);
+
     py::class_<mx::Element, mx::ElementPtr>(mod, "Element")
         .def(py::self == py::self)
         .def(py::self != py::self)
@@ -101,7 +105,8 @@ void bindPyElement(py::module& mod)
                 bool res = elem.validate(&message);
                 return std::pair<bool, std::string>(res, message);
             })
-        .def("copyContentFrom", &mx::Element::copyContentFrom)
+        .def("copyContentFrom", &mx::Element::copyContentFrom,
+            py::arg("source"), py::arg("copyOptions") = (const mx::CopyOptions*) nullptr)
         .def("clearContent", &mx::Element::clearContent)
         .def("createValidChildName", &mx::Element::createValidChildName)
         .def("createStringResolver", &mx::Element::createStringResolver,


### PR DESCRIPTION
Update #460 

- Merge from /dev to /materialx_node
- Need to keep CopyOptions for now as code will load libraries first and then import. There
does not appear to be a way to have the source URI comparison skip existing nodes as the imported document has no source URI.
- Also need to temporarily remove any references to xinclude files that occur more than once from different parents as well as includes which include some elements already in the document but have a different source URI.

