### PR TITLE
Fixed the outColor attribute

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -190,8 +190,6 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
         }
 
         materialXNode->setData(documentFilePath, elementPath, std::move(materialXData));
-        materialXNode->createOutputAttr(_dgModifier);
-
         _dgModifier.doIt();
 
         MString message("Created ");

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -19,7 +19,7 @@ MaterialXData::MaterialXData(   mx::DocumentPtr document,
     mx::findRenderableElements(_document, renderableElements);
 
     // Nothing specified. Find the first renderable element and use that
-    if (elementPath.length() == 0)
+    if (elementPath.empty())
     {
         if (renderableElements.empty())
         {
@@ -33,6 +33,13 @@ MaterialXData::MaterialXData(   mx::DocumentPtr document,
     else
     {
         _element = _document->getDescendant(elementPath);
+        if (!_element)
+        {
+            std::string message = "Element '";
+            message += elementPath;
+            message += "' not found in the document.";
+            throw mx::Exception(message);
+        }
 
         auto it = std::find_if(
             renderableElements.begin(),

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -3,31 +3,22 @@
 #include "MaterialXUtil.h"
 
 #include <maya/MFnNumericAttribute.h>
-#include <maya/MStringArray.h>
-#include <maya/MPlugArray.h>
 #include <maya/MDGModifier.h>
 #include <maya/MFnStringData.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MGlobal.h>
 
-#include <MaterialXCore/Document.h>
-#include <MaterialXFormat/XmlIo.h>
-#include <MaterialXGenOgsXml/OgsXmlGenerator.h>
-
-#include <maya/MRenderUtil.h>
-#include <maya/MFloatVector.h>
-
 #define MAKE_INPUT(attr) \
-	CHECK_MSTATUS(attr.setKeyable(true)); \
-	CHECK_MSTATUS(attr.setStorable(true)); \
-	CHECK_MSTATUS(attr.setReadable(true)); \
-	CHECK_MSTATUS(attr.setWritable(true));
+    CHECK_MSTATUS(attr.setKeyable(true)); \
+    CHECK_MSTATUS(attr.setStorable(true)); \
+    CHECK_MSTATUS(attr.setReadable(true)); \
+    CHECK_MSTATUS(attr.setWritable(true));
 
 #define MAKE_OUTPUT(attr) \
-	CHECK_MSTATUS(attr.setKeyable(false)); \
-	CHECK_MSTATUS(attr.setStorable(false)); \
-	CHECK_MSTATUS(attr.setReadable(true)); \
-	CHECK_MSTATUS(attr.setWritable(false));
+    CHECK_MSTATUS(attr.setKeyable(false)); \
+    CHECK_MSTATUS(attr.setStorable(false)); \
+    CHECK_MSTATUS(attr.setReadable(true)); \
+    CHECK_MSTATUS(attr.setWritable(false));
 
 const MTypeId MaterialXNode::MATERIALX_NODE_TYPEID(0x00042402);
 const MString MaterialXNode::MATERIALX_NODE_TYPENAME("MaterialXNode");
@@ -48,44 +39,38 @@ const MString MaterialXSurfaceNode::MATERIALX_SURFACE_NODE_TYPENAME("MaterialXSu
 
 MaterialXNode::MaterialXNode()
 {
-	std::cout << "MaterialXNode::MaterialXNode" << std::endl;
 }
 
 MaterialXNode::~MaterialXNode()
 {
-	std::cout << "MaterialXNode::~MaterialXNode" << std::endl;
 }
 
 void* MaterialXNode::creator()
 {
-	std::cout.rdbuf(std::cerr.rdbuf());
-	std::cout << "MaterialXNode::creator" << std::endl;
-	return new MaterialXNode();
+    return new MaterialXNode();
 }
 
 MStatus MaterialXNode::initialize()
 {
-	std::cout << "MaterialXNode::initialize" << std::endl;
+    MFnTypedAttribute typedAttr;
+    MFnStringData stringData;
 
-	MFnTypedAttribute typedAttr;
-	MFnStringData stringData;
+    MObject theString = stringData.create();
 
-	MObject theString = stringData.create();
-
-	DOCUMENT_ATTRIBUTE = typedAttr.create(DOCUMENT_ATTRIBUTE_LONG_NAME, DOCUMENT_ATTRIBUTE_SHORT_NAME, MFnData::kString, theString);
+    DOCUMENT_ATTRIBUTE = typedAttr.create(DOCUMENT_ATTRIBUTE_LONG_NAME, DOCUMENT_ATTRIBUTE_SHORT_NAME, MFnData::kString, theString);
     CHECK_MSTATUS(typedAttr.setInternal(true));
     CHECK_MSTATUS(typedAttr.setKeyable(false));
     CHECK_MSTATUS(typedAttr.setAffectsAppearance(true));
     CHECK_MSTATUS(typedAttr.setUsedAsFilename(true));
-	CHECK_MSTATUS(addAttribute(DOCUMENT_ATTRIBUTE));
+    CHECK_MSTATUS(addAttribute(DOCUMENT_ATTRIBUTE));
 
-	ELEMENT_ATTRIBUTE = typedAttr.create(ELEMENT_ATTRIBUTE_LONG_NAME, ELEMENT_ATTRIBUTE_SHORT_NAME, MFnData::kString, theString);
+    ELEMENT_ATTRIBUTE = typedAttr.create(ELEMENT_ATTRIBUTE_LONG_NAME, ELEMENT_ATTRIBUTE_SHORT_NAME, MFnData::kString, theString);
     CHECK_MSTATUS(typedAttr.setInternal(true));
     CHECK_MSTATUS(typedAttr.setKeyable(false));
     CHECK_MSTATUS(typedAttr.setAffectsAppearance(true));
-	CHECK_MSTATUS(addAttribute(ELEMENT_ATTRIBUTE));
+    CHECK_MSTATUS(addAttribute(ELEMENT_ATTRIBUTE));
 
-	return MS::kSuccess;
+    return MS::kSuccess;
 }
 
 void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
@@ -108,13 +93,13 @@ void MaterialXNode::createOutputAttr(MDGModifier& mdgModifier)
 
 MStatus MaterialXNode::setDependentsDirty(const MPlug &/*plugBeingDirtied*/, MPlugArray & affectedPlugs)
 {
-	if (!_outAttr.isNull())
-	{
-		MPlug outPlug(thisMObject(), _outAttr);
-		affectedPlugs.append(outPlug);
-	}
+    if (!_outAttr.isNull())
+    {
+        MPlug outPlug(thisMObject(), _outAttr);
+        affectedPlugs.append(outPlug);
+    }
 
-	return MS::kSuccess;
+    return MS::kSuccess;
 }
 
 MTypeId MaterialXNode::typeId() const
@@ -124,7 +109,7 @@ MTypeId MaterialXNode::typeId() const
 
 MPxNode::SchedulingType MaterialXNode::schedulingType() const
 {
-	return MPxNode::SchedulingType::kParallel;
+    return MPxNode::SchedulingType::kParallel;
 }
 
 bool MaterialXNode::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
@@ -249,17 +234,12 @@ MTypeId MaterialXTextureNode::typeId() const
 
 void* MaterialXTextureNode::creator()
 {
-    std::cout.rdbuf(std::cerr.rdbuf());
-    std::cout << "MaterialXTextureNode::creator" << std::endl;
     return new MaterialXTextureNode();
 }
 
 MStatus MaterialXTextureNode::initialize()
 {
-    std::cout << "MaterialXTextureNode::initialize" << std::endl;
-
     CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME));
-
     return MS::kSuccess;
 }
 
@@ -270,15 +250,11 @@ MTypeId MaterialXSurfaceNode::typeId() const
 
 void* MaterialXSurfaceNode::creator()
 {
-    std::cout.rdbuf(std::cerr.rdbuf());
-    std::cout << "MaterialXSurfaceNode::creator" << std::endl;
     return new MaterialXSurfaceNode();
 }
 
 MStatus MaterialXSurfaceNode::initialize()
 {
-    std::cout << "MaterialXSurfaceNode::initialize" << std::endl;
-
     CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME));
 
     return MS::kSuccess;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -81,15 +81,6 @@ MStatus MaterialXNode::initialize()
     OUT_ATTRIBUTE = nAttr.create(outColorName, "oc", outColorR, outColorG, outColorB);
     MAKE_OUTPUT(nAttr);
     CHECK_MSTATUS(nAttr.setUsedAsColor(true));
-    
-    /*
-    OUT_ATTRIBUTE = nAttr.createColor(outColorName, outColorName);
-    CHECK_MSTATUS(nAttr.setStorable(false));
-    CHECK_MSTATUS(nAttr.setInternal(false));
-    CHECK_MSTATUS(nAttr.setReadable(true));
-    CHECK_MSTATUS(nAttr.setWritable(false));
-    CHECK_MSTATUS(nAttr.setCached(true));
-    CHECK_MSTATUS(nAttr.setHidden(false));*/
 
     CHECK_MSTATUS(addAttribute(OUT_ATTRIBUTE));
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.h
@@ -18,8 +18,6 @@ class MaterialXNode : public MPxNode
     static void* creator();
     static MStatus initialize();
 
-    void createOutputAttr(MDGModifier& mdgModifier);
-    MStatus setDependentsDirty(const MPlug& plugBeingDirtied, MPlugArray& affectedPlugs) override;
     MTypeId	typeId() const override;
     SchedulingType schedulingType() const override;
 
@@ -46,12 +44,11 @@ class MaterialXNode : public MPxNode
     static MString ELEMENT_ATTRIBUTE_SHORT_NAME;
     static MObject ELEMENT_ATTRIBUTE;
 
+    static MObject OUT_ATTRIBUTE;
+
   private:
     MString _documentFilePath, _elementPath;
-
     std::unique_ptr<MaterialXData> _materialXData;
-
-    MObject _outAttr;
 };
 
 class MaterialXTextureNode : public MaterialXNode

--- a/source/MaterialXGenOgsXml/OgsXmlGenerator.cpp
+++ b/source/MaterialXGenOgsXml/OgsXmlGenerator.cpp
@@ -250,7 +250,7 @@ namespace
     }
 }
 
-const string OgsXmlGenerator::OUTPUT_NAME = "out";
+const string OgsXmlGenerator::OUTPUT_NAME = "outColor";
 const string OgsXmlGenerator::SAMPLER_SUFFIX = "Sampler";
 
 OgsXmlGenerator::OgsXmlGenerator()


### PR DESCRIPTION
Maya expects surface nodes to have an outColor output attribute and complains if it's missing when creating our nodes in Hypershade.

It's also created statically now and no matter how the node is created (previously dynamically and from the command).

Also some cleanup.