### PR TITLE
Some coating fixes

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -73,26 +73,44 @@
       <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
     </roughness_anisotropy>
 
-    <!-- Colors influenced by coat ("coat gamma") -->
+    <!-- Colors influenced by coat -->
     <clamp name="coat_clamped" type="float">
       <input name="in" type="float" interfacename="coat" />
     </clamp>
-    <multiply name="coat_gamma_multiply" type="float">
-      <input name="in1" type="float" nodename="coat_clamped" />
-      <input name="in2" type="float" interfacename="coat_affect_color" />
+    <mix name="coat_tint" type="color3">
+      <input name="fg" type="color3" interfacename="coat_color" />
+      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="mix" type="float" interfacename="coat_affect_color" />
+    </mix>
+    <fresnel name="coat_fresnel" type="float">
+      <input name="ior" type="float" interfacename="coat_IOR" />
+      <input name="normal" type="vector3" interfacename="coat_normal" />
+    </fresnel>
+    <invert name="coat_fresnel_inv" type="float">
+      <input name="in" type="float" nodename="coat_fresnel" />
+    </invert>
+    <multiply name="coat_tint_total" type="color3">
+      <input name="in1" type="color3" nodename="coat_tint" />
+      <input name="in2" type="float" nodename="coat_fresnel_inv" />
     </multiply>
-    <add name="coat_gamma" type="float">
-      <input name="in1" type="float" nodename="coat_gamma_multiply" />
-      <input name="in2" type="float" value="1.0" />
-    </add>
-    <power name="coat_affected_diffuse_color" type="color3">
+    <mix name="coat_tint_with_fresnel" type="color3">
+      <input name="fg" type="color3" nodename="coat_tint_total" />
+      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="mix" type="float" nodename="coat_clamped" />
+    </mix>
+
+    <multiply name="coat_affected_diffuse_color" type="color3">
       <input name="in1" type="color3" interfacename="base_color" />
-      <input name="in2" type="float" nodename="coat_gamma" />
-    </power>
-    <power name="coat_affected_subsurface_color" type="color3">
+      <input name="in2" type="color3" nodename="coat_tint_with_fresnel" />
+    </multiply>
+    <multiply name="coat_affected_subsurface_color" type="color3">
       <input name="in1" type="color3" interfacename="subsurface_color" />
-      <input name="in2" type="float" nodename="coat_gamma" />
-    </power>
+      <input name="in2" type="color3" nodename="coat_tint_with_fresnel" />
+    </multiply>
+    <multiply name="coat_affected_emission_color" type="color3">
+      <input name="in1" type="color3" interfacename="emission_color" />
+      <input name="in2" type="color3" nodename="coat_tint_with_fresnel" />
+    </multiply>
 
     <!-- Diffuse Layer -->
     <diffuse_brdf name="diffuse_bsdf" type="BSDF">
@@ -188,17 +206,12 @@
       <input name="bg" type="BSDF" nodename="specular_bsdf" />
       <input name="mix" type="float" interfacename="metalness" />
     </mix>
-
-    <!-- Coat Layer -->
-    <mix name="coat_attenuation" type="color3" >
-      <input name="fg" type="color3" interfacename="coat_color" />
-      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="mix" type="float" interfacename="coat" />
-    </mix>
     <multiply name="metalness_mix_attenuated" type="BSDF">
       <input name="in1" type="BSDF" nodename="metalness_mix" />
-      <input name="in2" type="color3" nodename="coat_attenuation" />
+      <input name="in2" type="color3" nodename="coat_tint_with_fresnel" />
     </multiply>
+
+    <!-- Coat Layer -->
     <roughness_anisotropy name="coat_roughness" type="vector2">
       <input name="roughness" type="float" interfacename="coat_roughness" />
       <input name="anisotropy" type="float" interfacename="coat_anisotropy" />
@@ -215,31 +228,11 @@
 
     <!-- Emission Layer -->
     <multiply name="emission_weight" type="color3">
-      <input name="in1" type="color3" interfacename="emission_color" />
+      <input name="in1" type="color3" nodename="coat_affected_emission_color" />
       <input name="in2" type="float" interfacename="emission" />
     </multiply>
-    <fresnel name="coat_fresnel" type="float">
-      <input name="ior" type="float" interfacename="coat_IOR" />
-      <input name="normal" type="vector3" interfacename="coat_normal" />
-    </fresnel>
-    <invert name="coat_fresnel_inv" type="float">
-      <input name="in" type="float" nodename="coat_fresnel" />
-    </invert>
-    <multiply name="coat_color_fresnel" type="color3">
-      <input name="in1" type="color3" interfacename="coat_color" />
-      <input name="in2" type="float" nodename="coat_fresnel_inv" />
-    </multiply>
-    <mix name="coat_emission_attenuation" type="color3" >
-      <input name="fg" type="color3" nodename="coat_color_fresnel" />
-      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="mix" type="float" interfacename="coat" />
-    </mix>
-    <multiply name="emission_weight_attenuated" type="color3">
-      <input name="in1" type="color3" nodename="emission_weight" />
-      <input name="in2" type="color3" nodename="coat_emission_attenuation" />
-    </multiply>
     <uniform_edf name="emission_edf" type="EDF">
-      <input name="intensity" type="color3" nodename="emission_weight_attenuated" />
+      <input name="intensity" type="color3" nodename="emission_weight" />
     </uniform_edf>
 
     <!-- Surface construction with opacity -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2300,68 +2300,68 @@
   -->
   <nodedef name="ND_smoothstep_float" node="smoothstep" type="float" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="float" value="0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color2" node="smoothstep" type="color2" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <parameter name="low" type="color2" value="0.0, 0.0"/>
-    <parameter name="high" type="color2" value="1.0, 1.0"/>
+    <input name="low" type="color2" value="0.0, 0.0"/>
+    <input name="high" type="color2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color3" node="smoothstep" type="color3" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="low" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="high" type="color3" value="1.0, 1.0, 1.0"/>
+    <input name="low" type="color3" value="0.0, 0.0, 0.0"/>
+    <input name="high" type="color3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color4" node="smoothstep" type="color4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
+    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector2" node="smoothstep" type="vector2" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <parameter name="low" type="vector2" value="0.0, 0.0"/>
-    <parameter name="high" type="vector2" value="1.0, 1.0"/>
+    <input name="low" type="vector2" value="0.0, 0.0"/>
+    <input name="high" type="vector2" value="1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector3" node="smoothstep" type="vector3" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="low" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="high" type="vector3" value="1.0, 1.0, 1.0"/>
+    <input name="low" type="vector3" value="0.0, 0.0, 0.0"/>
+    <input name="high" type="vector3" value="1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector4" node="smoothstep" type="vector4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
+    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
+    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color2FA" node="smoothstep" type="color2" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color3FA" node="smoothstep" type="color3" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_color4FA" node="smoothstep" type="color4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" type="vector2" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" type="vector3" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
   <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" type="vector4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <parameter name="low" type="float" value="0.0"/>
-    <parameter name="high" type="float" value="1.0"/>
+    <input name="low" type="float" value="0.0"/>
+    <input name="high" type="float" value="1.0"/>
   </nodedef>
 
   <!--
@@ -2408,14 +2408,14 @@
   <nodedef name="ND_luminance_color3" node="luminance" type="color3" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
-	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+  enum="acescg, rec709, rec2020, rec2100"
+  enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
   <nodedef name="ND_luminance_color4" node="luminance" type="color4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
-	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+  enum="acescg, rec709, rec2020, rec2100"
+  enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
 
   <!--
@@ -2653,15 +2653,15 @@
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
-	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+  enum="acescg, rec709, rec2020, rec2100"
+  enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
   <nodedef name="ND_saturate_color4" node="saturate" type="color4" nodegroup="adjustment" defaultinput="in">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
-	enum="acescg, rec709, rec2020, rec2100"
-	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
+  enum="acescg, rec709, rec2020, rec2100"
+  enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
   </nodedef>
 
 


### PR DESCRIPTION
This change is supposed to help with the behavior of coat tinting.

I forwarded some issues on the standardsurface github about what coat should be doing, according to my best interpretation of the spec. 

This change makes it
1. Affect all lower layers, no exception
2. Respect correctly the affect_color parameter
3. Keep the affect_color math linear.