### PR TITLE
Improve search path for document load + filter to not try and render nodedefs

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -45,7 +45,7 @@ bool readFile(const string& filename, string& contents)
     return false;
 }
 
-void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const StringSet& includeFiles,
+void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, const StringSet& skipFiles, const StringSet& includeFiles,
                    vector<DocumentPtr>& documents, StringVec& documentsPaths, StringVec& errors)
 {
     for (const FilePath& dir : rootPath.getSubDirectories())
@@ -59,7 +59,9 @@ void loadDocuments(const FilePath& rootPath, const StringSet& skipFiles, const S
                 const FilePath filePath = dir / file;
                 try
                 {
-                    readFromXmlFile(doc, filePath, dir);
+                    FileSearchPath readSearchPath = searchPath;
+                    readSearchPath.append(dir);
+                    readFromXmlFile(doc, filePath, readSearchPath.asString());
                     documents.push_back(doc);
                     documentsPaths.push_back(filePath.asString());
                 }
@@ -540,7 +542,8 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
     for (NodeGraphPtr nodeGraph : doc->getNodeGraphs())
     {
         // Skip anything from an include file including libraries.
-        if (!nodeGraph->hasSourceUri())
+        // Skip any nodegraph which is a definition
+        if (!nodeGraph->hasSourceUri() && !nodeGraph->hasAttribute("nodedef"))
         {
             for (OutputPtr output : nodeGraph->getOutputs())
             {

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -543,7 +543,7 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
     {
         // Skip anything from an include file including libraries.
         // Skip any nodegraph which is a definition
-        if (!nodeGraph->hasSourceUri() && !nodeGraph->hasAttribute("nodedef"))
+        if (!nodeGraph->hasSourceUri() && !nodeGraph->hasAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE))
         {
             for (OutputPtr output : nodeGraph->getOutputs())
             {

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -30,6 +30,7 @@ bool readFile(const string& filename, string& content);
 
 /// Scans for all documents under a root path and returns documents which can be loaded
 void loadDocuments(const FilePath& rootPath, 
+                   const FileSearchPath& searchPath,
                    const StringSet& skipFiles, const StringSet& includeFiles,
                    vector<DocumentPtr>& documents, StringVec& documentsPaths, 
                    StringVec& errorLog);

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -555,9 +555,10 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
 
     // Load in all documents to test
     mx::StringVec errorLog;
+    mx::FileSearchPath searchPath(_libSearchPath);
     for (auto testRoot : _testRootPaths)
     {
-        mx::loadDocuments(testRoot, _skipFiles, overrideFiles, _documents, _documentPaths, errorLog);
+        mx::loadDocuments(testRoot, searchPath, _skipFiles, overrideFiles, _documents, _documentPaths, errorLog);
     }
     CHECK(errorLog.empty());
     for (auto error : errorLog)

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -213,7 +213,9 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             mx::DocumentPtr doc = mx::createDocument();
             try
             {
-                mx::readFromXmlFile(doc, filename, dir);
+                mx::FileSearchPath readSearchPath = searchPath;
+                readSearchPath.append(dir);
+                mx::readFromXmlFile(doc, filename, readSearchPath.asString());
             }
             catch (mx::Exception& e)
             {


### PR DESCRIPTION
Update #460 
- Add a search path for read so that includes can be searched for via… set of use paths + the current document path (previous)
- Filter out trying to render nodegraphs which are nodedefs.
