### PR TITLE
Mass change "auto" -> "const auto&" in for loops to avoid unnecessary copying and resulting confusion.

### DIFF
--- a/source/MaterialXContrib/Handlers/SampleObjLoader.cpp
+++ b/source/MaterialXContrib/Handlers/SampleObjLoader.cpp
@@ -284,7 +284,7 @@ bool SampleObjLoader::load(const FilePath& filePath, MeshList& meshList)
 
     // Set up flattened contiguous indexing for all partitions
     unsigned int startIndex = 0;
-    for (auto partition : partitions)
+    for (const auto& partition : partitions)
     {
         MeshIndexBuffer& indexing = partition->getIndices();
         size_t indexCount = partition->getFaceCount() * 3;

--- a/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
+++ b/source/MaterialXContrib/OGSXMLFragmentWrapper.cpp
@@ -581,7 +581,7 @@ void OGSXMLFragmentWrapper::generate(const string& shaderName, ElementPtr elemen
 
     // Scan outputs and create "outputs"
     pugi::xml_node xmlOutputs = xmlRoot.append_child(OGS_OUTPUTS.c_str());
-    for (auto uniformMap : ps.getOutputBlocks())
+    for (const auto& uniformMap : ps.getOutputBlocks())
     {
         const VariableBlock& uniforms = *uniformMap.second;
         for (size_t i = 0; i < uniforms.size(); ++i)

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -206,7 +206,7 @@ void GraphElement::flattenSubgraphs(const string& target)
         processNodeVec.clear();
 
         // Iterate through nodes with graph implementations.
-        for (auto pair : graphImplMap)
+        for (const auto& pair : graphImplMap)
         {
             NodePtr processNode = pair.first;
             NodeGraphPtr sourceSubGraph = pair.second;
@@ -260,7 +260,7 @@ void GraphElement::flattenSubgraphs(const string& target)
             }
 
             // Transfer internal connections between subgraphs.
-            for (auto subNodePair : subNodeMap)
+            for (const auto& subNodePair : subNodeMap)
             {
                 NodePtr sourceSubNode = subNodePair.first;
                 NodePtr destSubNode = subNodePair.second;

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -93,7 +93,7 @@ StringVec splitString(const string& str, const string& sep)
 
 string replaceSubstrings(string str, const StringMap& stringMap)
 {
-    for (auto& pair : stringMap)
+    for (const auto& pair : stringMap)
     {
         if (pair.first.empty())
             continue;

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -552,13 +552,13 @@ BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         HwLightShadersPtr lightShaders = context.getUserData<HwLightShaders>(HW::USER_DATA_LIGHT_SHADERS);
         if (lightShaders)
         {
-            for (auto it : lightShaders->get())
+            for (const auto& it : lightShaders->get())
             {
                 emitFunctionDefinition(*it.second, context, stage);
             }
         }
         // Emit functions for light sampling
-        for (auto it : _lightSamplingNodes)
+        for (const auto& it : _lightSamplingNodes)
         {
             emitFunctionDefinition(*it, context, stage);
         }

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
@@ -37,7 +37,7 @@ void LightSamplerNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext&
         if (lightShaders)
         {
             string ifstatement = "if ";
-            for (auto it : lightShaders->get())
+            for (const auto& it : lightShaders->get())
             {
                 shadergen.emitLine(ifstatement + "(light.type == " + std::to_string(it.first) + ")", stage, false);
                 shadergen.emitScopeBegin(stage);

--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
@@ -479,7 +479,7 @@ ShaderPtr OgsFxShaderGenerator::createShader(const string& name, ElementPtr elem
     {
         ShaderStage& stage = shader->getStage(i);
 
-        for (auto it : stage.getInputBlocks())
+        for (const auto& it : stage.getInputBlocks())
         {
             VariableBlock& block = *it.second;
             for (size_t j = 0; j < block.size(); ++j)

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -282,7 +282,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     if (lightShaders && graph->hasClassification(ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE))
     {
         // Create shader variables for all bound light shaders
-        for (auto it : lightShaders->get())
+        for (const auto& it : lightShaders->get())
         {
             ShaderNode* node = it.second.get();
             node->getImplementation().createVariables(*node, context, *shader);
@@ -299,7 +299,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     std::deque<ShaderGraph*> graphQueue = { graph.get() };
     if (lightShaders)
     {
-        for (auto it : lightShaders->get())
+        for (const auto& it : lightShaders->get())
         {
             ShaderNode* node = it.second.get();
             ShaderGraph* lightGraph = node->getImplementation().getGraph();

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -125,7 +125,7 @@ void ShaderGenerator::emitFunctionCalls(const ShaderGraph& graph, GenContext& co
 void ShaderGenerator::emitTypeDefinitions(GenContext&, ShaderStage& stage) const
 {
     // Emit typedef statements for all data types that have an alias
-    for (auto syntax : _syntax->getTypeSyntaxes())
+    for (const auto& syntax : _syntax->getTypeSyntaxes())
     {
         if (!syntax->getTypeAlias().empty())
         {
@@ -233,13 +233,13 @@ void ShaderGenerator::resetIdentifiers(GenContext& context) const
     context.clearIdentifiers();
 
     // Add in the restricted names as taken names.
-    for (auto name : _syntax->getRestrictedNames())
+    for (const auto& name : _syntax->getRestrictedNames())
     {
         context.addIdentifier(name);
     }
 
     // Add in the token substitution identifiers as taken names
-    for (auto it : _tokenSubstitutions)
+    for (const auto& it : _tokenSubstitutions)
     {
         context.addIdentifier(it.second);
     }
@@ -321,7 +321,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
     {
         replace(substitutions, stage._constants[i]);
     }
-    for (auto it : stage._uniforms)
+    for (const auto& it : stage._uniforms)
     {
         VariableBlock& uniforms = *it.second;
         for (size_t i = 0; i < uniforms.size(); ++i)
@@ -329,7 +329,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
             replace(substitutions, uniforms[i]);
         }
     }
-    for (auto it : stage._inputs)
+    for (const auto& it : stage._inputs)
     {
         VariableBlock& inputs = *it.second;
         for (size_t i = 0; i < inputs.size(); ++i)
@@ -337,7 +337,7 @@ void ShaderGenerator::replaceTokens(const StringMap& substitutions, ShaderStage&
             replace(substitutions, inputs[i]);
         }
     }
-    for (auto it : stage._outputs)
+    for (const auto& it : stage._outputs)
     {
         VariableBlock& outputs = *it.second;
         for (size_t i = 0; i < outputs.size(); ++i)

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -695,11 +695,11 @@ const ShaderNode* ShaderGraph::getNode(const string& name) const
 void ShaderGraph::finalize(GenContext& context)
 {
     // Insert color transformation nodes where needed
-    for (auto it : _inputColorTransformMap)
+    for (const auto& it : _inputColorTransformMap)
     {
         addColorTransformNode(it.first, it.second, context);
     }
-    for (auto it : _outputColorTransformMap)
+    for (const auto& it : _outputColorTransformMap)
     {
         addColorTransformNode(it.first, it.second, context);
     }
@@ -931,7 +931,7 @@ void ShaderGraph::topologicalSort()
     // Calculate in-degrees for all nodes, and enqueue those with degree 0.
     std::unordered_map<ShaderNode*, int> inDegree(_nodeMap.size());
     std::deque<ShaderNode*> nodeQueue;
-    for (auto it : _nodeMap)
+    for (const auto& it : _nodeMap)
     {
         ShaderNode* node = it.second.get();
 
@@ -964,9 +964,9 @@ void ShaderGraph::topologicalSort()
 
         // Find connected nodes and decrease their in-degree,
         // adding node to the queue if in-degrees becomes 0.
-        for (auto output : node->getOutputs())
+        for (const auto& output : node->getOutputs())
         {
-            for (auto input : output->getConnections())
+            for (const auto& input : output->getConnections())
             {
                 if (input->getNode() != this)
                 {

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -504,9 +504,9 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
 {
     std::unordered_set<OutputPtr> processedOutputs;
 
-    for (auto material : doc->getMaterials())
+    for (const auto& material : doc->getMaterials())
     {
-        for (auto shaderRef : material->getShaderRefs())
+        for (const auto& shaderRef : material->getShaderRefs())
         {
             if (!shaderRef->hasSourceUri())
             {
@@ -525,7 +525,7 @@ void findRenderableElements(ConstDocumentPtr doc, vector<TypedElementPtr>& eleme
                 if (!includeReferencedGraphs)
                 {
                     // Track outputs already used by the shaderref
-                    for (auto bindInput : shaderRef->getBindInputs())
+                    for (const auto& bindInput : shaderRef->getBindInputs())
                     {
                         OutputPtr outputPtr = bindInput->getConnectedOutput();
                         if (outputPtr)

--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -11,7 +11,7 @@ namespace MaterialX
 void GeometryHandler::addLoader(GeometryLoaderPtr loader)
 {
     const StringSet& extensions = loader->supportedExtensions();
-    for (auto extension : extensions)
+    for (const auto& extension : extensions)
     {
         _geometryLoaders.insert(std::pair<std::string, GeometryLoaderPtr>(extension, loader));
     }
@@ -20,7 +20,7 @@ void GeometryHandler::addLoader(GeometryLoaderPtr loader)
 void GeometryHandler::supportedExtensions(StringSet& extensions)
 {
     extensions.clear();
-    for (auto loader : _geometryLoaders)
+    for (const auto& loader : _geometryLoaders)
     {
         const StringSet& loaderExtensions = loader.second->supportedExtensions();
         extensions.insert(loaderExtensions.begin(), loaderExtensions.end());
@@ -35,7 +35,7 @@ void GeometryHandler::clearGeometry()
 
 bool GeometryHandler::hasGeometry(const string& location)
 {
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         if (mesh->getSourceUri() == location)
         {
@@ -48,7 +48,7 @@ bool GeometryHandler::hasGeometry(const string& location)
 void GeometryHandler::getGeometry(MeshList& meshes, const string& location)
 {
     meshes.clear();
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         if (mesh->getSourceUri() == location)
         {
@@ -62,7 +62,7 @@ void GeometryHandler::computeBounds()
     const float MAX_FLOAT = std::numeric_limits<float>::max();
     _minimumBounds = { MAX_FLOAT, MAX_FLOAT, MAX_FLOAT };
     _maximumBounds = { -MAX_FLOAT, -MAX_FLOAT, -MAX_FLOAT };
-    for (auto mesh : _meshes)
+    for (const auto& mesh : _meshes)
     {
         const Vector3& minMesh = mesh->getMinimumBounds();
         _minimumBounds[0] = std::min(minMesh[0], _minimumBounds[0]);

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -59,7 +59,7 @@ void ImageHandler::addLoader(ImageLoaderPtr loader)
     if (loader)
     {
         const StringSet& extensions = loader->supportedExtensions();
-        for (auto extension : extensions)
+        for (const auto& extension : extensions)
         {
             _imageLoaders.insert(std::pair<string, ImageLoaderPtr>(extension, loader));
         }
@@ -69,7 +69,7 @@ void ImageHandler::addLoader(ImageLoaderPtr loader)
 void ImageHandler::supportedExtensions(StringSet& extensions)
 {
     extensions.clear();
-    for (auto loader : _imageLoaders)
+    for (const auto& loader : _imageLoaders)
     {
         const StringSet& loaderExtensions = loader.second->supportedExtensions();
         extensions.insert(loaderExtensions.begin(), loaderExtensions.end());

--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -27,7 +27,7 @@ void LightHandler::mapNodeDefToIdentiers(const std::vector<NodePtr>& nodes,
                                            std::unordered_map<string, unsigned int>& ids)
 {
     unsigned int id = 1;
-    for (auto node : nodes)
+    for (const auto& node : nodes)
     {
         auto nodedef = node->getNodeDef();
         if (nodedef)
@@ -65,7 +65,7 @@ void LightHandler::registerLights(DocumentPtr doc, const std::vector<NodePtr>& l
     {
         // Create a list of unique nodedefs and ids for them
         mapNodeDefToIdentiers(lights, _lightIdentifierMap);
-        for (auto id : _lightIdentifierMap)
+        for (const auto& id : _lightIdentifierMap)
         {
             NodeDefPtr nodeDef = doc->getNodeDef(id.first);
             if (nodeDef)

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -200,7 +200,7 @@ void Mesh::splitByUdims()
     }
 
     _partitions.clear();
-    for (auto pair : udimMap)
+    for (const auto& pair : udimMap)
     {
         addPartition(pair.second);
     }

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -252,7 +252,7 @@ class Mesh
     /// @return Reference to a mesh stream if found
     MeshStreamPtr getStream(const string& name) const
     {
-        for (auto stream : _streams)
+        for (const auto& stream : _streams)
         {
             if (stream->getName() == name)
             {
@@ -268,7 +268,7 @@ class Mesh
     /// @return Reference to a mesh stream if found
     MeshStreamPtr getStream(const string& type, unsigned int index) const
     {
-        for (auto stream : _streams)
+        for (const auto& stream : _streams)
         {
             if (stream->getType() == type &&
                 stream->getIndex() == index)

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -182,7 +182,7 @@ void createUIPropertyGroups(ElementPtr uniformElement, DocumentPtr contentDocume
 void createUIPropertyGroups(const VariableBlock& block, DocumentPtr contentDocument, TypedElementPtr materialElement,
                           const string& pathSeparator, UIPropertyGroup& groups, UIPropertyGroup& unnamedGroups)
 {
-    for (auto uniform : block.getVariableOrder())
+    for (const auto& uniform : block.getVariableOrder())
     {
         if (!uniform->getPath().empty() && uniform->getValue())
         {

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -120,7 +120,7 @@ unsigned int GlslProgram::build()
 
     unsigned int stagesBuilt = 0;
     unsigned int desiredStages = 0;
-    for (auto it : _stages)
+    for (const auto& it : _stages)
     {
         if (it.second.length())
             desiredStages++;
@@ -283,7 +283,7 @@ void GlslProgram::bindInputs(ViewHandlerPtr viewHandler,
 
     // Bind based on inputs found
     bindViewInformation(viewHandler);
-    for (auto mesh : geometryHandler->getMeshes())
+    for (const auto& mesh : geometryHandler->getMeshes())
     {
         bindStreams(mesh);
     }
@@ -328,7 +328,7 @@ void GlslProgram::bindAttribute(const GlslProgram::InputMap& inputs, MeshPtr mes
 
     const size_t FLOAT_SIZE = sizeof(float);
 
-    for (auto input : inputs)
+    for (const auto& input : inputs)
     {
         int location = input.second->location;
         unsigned int index = input.second->value ? input.second->value->asA<int>() : 0;
@@ -459,7 +459,7 @@ void GlslProgram::bindStreams(MeshPtr mesh)
     // Bind any named attribute information
     const GlslProgram::InputMap& uniformList = getUniformsList();
     findInputs(HW::GEOMATTR + "_", uniformList, foundList, false);
-    for (auto Input : foundList)
+    for (const auto& Input : foundList)
     {
         // Only handle float1-4 types for now
         switch (Input.second->gltype)
@@ -509,7 +509,7 @@ void GlslProgram::unbindGeometry()
         glDeleteBuffers(1, &_indexBuffer);
         _indexBuffer = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
     }
-    for (auto attributeBufferId : _attributeBufferIds)
+    for (const auto& attributeBufferId : _attributeBufferIds)
     {
         unsigned int bufferId = attributeBufferId.second;
         if (bufferId > 0)
@@ -587,7 +587,7 @@ void GlslProgram::bindTextures(ImageHandlerPtr imageHandler)
     // Bind textures based on uniforms found in the program
     const GlslProgram::InputMap& uniformList = getUniformsList();
     const std::string IMAGE_SEPARATOR("_");
-    for (auto uniform : uniformList)
+    for (const auto& uniform : uniformList)
     {
         GLenum uniformType = uniform.second->gltype;
         GLint uniformLocation = uniform.second->location;
@@ -697,7 +697,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         { HW::ENV_IRRADIANCE, lightHandler->getLightEnvIrradiancePath() }
     };
 
-    for (auto ibl : iblList)
+    for (const auto& ibl : iblList)
     {
         auto iblUniform = uniformList.find(ibl.first);
         GlslProgram::InputPtr inputPtr = iblUniform != uniformList.end() ? iblUniform->second : nullptr;
@@ -731,7 +731,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
     const std::unordered_map<string, unsigned int>& ids = lightHandler->getLightIdentifierMap();
 
     size_t index = 0;
-    for (auto light : lightList)
+    for (const auto& light : lightList)
     {
         auto nodeDef = light->getNodeDef();
         if (!nodeDef)
@@ -763,7 +763,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         }
 
         // Set all inputs
-        for (auto lightInput : light->getInputs())
+        for (const auto& lightInput : light->getInputs())
         {
             // Make sure we have a value to set
             if (lightInput->hasValue())
@@ -777,7 +777,7 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
         }
 
         // Set all parameters. Note that upstream connections are not currently handled.
-        for (auto param : light->getParameters())
+        for (const auto& param : light->getParameters())
         {
             // Make sure we have a value to set
             if (param->hasValue())
@@ -1464,7 +1464,7 @@ void GlslProgram::findInputs(const std::string& variable,
 void GlslProgram::printUniforms(std::ostream& outputStream)
 {
     updateUniformsList();
-    for (auto input : _uniformList)
+    for (const auto& input : _uniformList)
     {
         unsigned int gltype = input.second->gltype;
         int location = input.second->location;
@@ -1491,7 +1491,7 @@ void GlslProgram::printUniforms(std::ostream& outputStream)
 void GlslProgram::printAttributes(std::ostream& outputStream)
 {
     updateAttributesList();
-    for (auto input : _attributeList)
+    for (const auto& input : _attributeList)
     {
         unsigned int gltype = input.second->gltype;
         int location = input.second->location;

--- a/source/MaterialXRenderGlsl/GlslValidator.cpp
+++ b/source/MaterialXRenderGlsl/GlslValidator.cpp
@@ -306,7 +306,7 @@ void GlslValidator::validateCreation(const StageMap& stages)
         throw ExceptionShaderValidationError(errorType, errors);
     }
 
-    for (auto it : stages)
+    for (const auto& it : stages)
     {
         _program->addStage(it.first, it.second);
     }
@@ -423,7 +423,7 @@ void GlslValidator::validateRender()
                 _program->bindInputs(_viewHandler, _geometryHandler, _imageHandler, _lightHandler);
 
                 // Draw all the partitions of all the meshes in the handler
-                for (auto mesh : _geometryHandler->getMeshes())
+                for (const auto& mesh : _geometryHandler->getMeshes())
                 {
                     for (size_t i = 0; i < mesh->getPartitionCount(); i++)
                     {

--- a/source/MaterialXRenderOsl/OslValidator.cpp
+++ b/source/MaterialXRenderOsl/OslValidator.cpp
@@ -120,12 +120,12 @@ void OslValidator::renderOSL(const FilePath& dirPath, const string& shaderName, 
     replacementMap[OUTPUT_SHADER_INPUT_STRING] = OUTPUT_SHADER_INPUT_VALUE_STRING;
     replacementMap[INPUT_SHADER_TYPE_STRING] = shaderName;
     string overrideString;
-    for (auto param : _oslShaderParameterOverrides)
+    for (const auto& param : _oslShaderParameterOverrides)
     {
         overrideString.append(param);
     }
     string envOverrideString;
-    for (auto param : _envOslShaderParameterOverrides)
+    for (const auto& param : _envOslShaderParameterOverrides)
     {
         envOverrideString.append(param);
     }
@@ -253,7 +253,7 @@ void OslValidator::shadeOSL(const FilePath& dirPath, const string& shaderName, c
         errors.push_back("Command string: " + command);
         errors.push_back("Command return code: " + std::to_string(returnValue));
         errors.push_back("Shader failed to render:");
-        for (auto resultLine : results)
+        for (const auto& resultLine : results)
         {
             errors.push_back(resultLine);
         }

--- a/source/MaterialXTest/GenOgsXml.cpp
+++ b/source/MaterialXTest/GenOgsXml.cpp
@@ -38,13 +38,13 @@ TEST_CASE("GenShader: OGS XML Generation", "[genogsxml]")
     mx::StringVec testGraphs = { };
     mx::StringVec testMaterials = { "Tiled_Brass", "Brass_Wire_Mesh" };
 
-    for (auto testGraph : testGraphs)
+    for (const auto& testGraph : testGraphs)
     {
         mx::NodeGraphPtr graph = doc->getNodeGraph(testGraph);
         if (graph)
         {
             std::vector<mx::OutputPtr> outputs = graph->getOutputs();
-            for (auto output : outputs)
+            for (const auto& output : outputs)
             {
                 const std::string name = graph->getName() + "_" + output->getName();
                 mx::ShaderPtr shader = glslGenerator->generate(name, output, glslContext);
@@ -56,13 +56,13 @@ TEST_CASE("GenShader: OGS XML Generation", "[genogsxml]")
         }
     }
 
-    for (auto testMaterial : testMaterials)
+    for (const auto& testMaterial : testMaterials)
     {
         mx::MaterialPtr mtrl = doc->getMaterial(testMaterial);
         if (mtrl)
         {
             std::vector<mx::ShaderRefPtr> shaderRefs = mtrl->getShaderRefs();
-            for (auto shaderRef : shaderRefs)
+            for (const auto& shaderRef : shaderRefs)
             {
                 mx::ShaderPtr shader = glslGenerator->generate(shaderRef->getName(), shaderRef, glslContext);
                 std::ofstream file(shaderRef->getName() + ".xml");

--- a/source/MaterialXTest/GenShader.cpp
+++ b/source/MaterialXTest/GenShader.cpp
@@ -137,7 +137,7 @@ TEST_CASE("GenShader: OSL Reference Implementation Check", "[genshader]")
     std::vector<mx::ImplementationPtr> impls = doc->getImplementations();
     implDumpStream << "Existing implementations: " << std::to_string(impls.size()) << std::endl;
     implDumpStream << "-----------------------------------------------------------------------" << std::endl;
-    for (auto impl : impls)
+    for (const auto& impl : impls)
     {
         if (language == impl->getLanguage() && impl->getTarget().empty())
         {

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -103,7 +103,7 @@ void checkImplementations(mx::GenContext& context,
     std::vector<mx::ImplementationPtr> impls = doc->getImplementations();
     implDumpStream << "Existing implementations: " << std::to_string(impls.size()) << std::endl;
     implDumpStream << "-----------------------------------------------------------------------" << std::endl;
-    for (auto impl : impls)
+    for (const auto& impl : impls)
     {
         if (language == impl->getLanguage())
         {
@@ -170,7 +170,7 @@ void checkImplementations(mx::GenContext& context,
             missing_str += "Missing nodeDef implementation: " + nodeDefName + ", Node: " + nodeName + ".\n";
 
             std::vector<mx::InterfaceElementPtr> inters = doc->getMatchingImplementations(nodeDefName);
-            for (auto inter2 : inters)
+            for (const auto& inter2 : inters)
             {
                 mx::ImplementationPtr impl = inter2->asA<mx::Implementation>();
                 if (impl)
@@ -184,7 +184,7 @@ void checkImplementations(mx::GenContext& context,
                 }
             }
 
-            for (auto childImpl : impls)
+            for (const auto& childImpl : impls)
             {
                 if (childImpl->getNodeDefString() == nodeDefName)
                 {
@@ -303,7 +303,7 @@ void ShaderGeneratorTester::checkImplementationUsage(mx::StringSet& usedImpls,
     // Get list of implementations a given langauge.
     std::set<mx::ImplementationPtr> libraryImpls;
     const std::vector<mx::ElementPtr>& children = _dependLib->getChildren();
-    for (auto child : children)
+    for (const auto& child : children)
     {
         mx::ImplementationPtr impl = child->asA<mx::Implementation>();
         if (!impl)
@@ -323,13 +323,13 @@ void ShaderGeneratorTester::checkImplementationUsage(mx::StringSet& usedImpls,
     unsigned int implementationUseCount = 0;
     mx::StringVec skippedImplementations;
     mx::StringVec missedImplementations;
-    for (auto libraryImpl : libraryImpls)
+    for (const auto& libraryImpl : libraryImpls)
     {
         const std::string& implName = libraryImpl->getName();
 
         // Skip white-list items
         bool inWhiteList = false;
-        for (auto w : whiteList)
+        for (const auto& w : whiteList)
         {
             if (implName.find(w) != std::string::npos)
             {
@@ -363,7 +363,7 @@ void ShaderGeneratorTester::checkImplementationUsage(mx::StringSet& usedImpls,
     stream << "Skipped: " << skippedImplementations.size() << " implementations." << std::endl;
     if (skippedImplementations.size())
     {
-        for (auto implName : skippedImplementations)
+        for (const auto& implName : skippedImplementations)
         {
             stream << "\t" << implName << std::endl;
         }
@@ -371,7 +371,7 @@ void ShaderGeneratorTester::checkImplementationUsage(mx::StringSet& usedImpls,
     stream << "Untested: " << missedImplementations.size() << " implementations." << std::endl;
     if (missedImplementations.size())
     {
-        for (auto implName : missedImplementations)
+        for (const auto& implName : missedImplementations)
         {
             stream << "\t" << implName << std::endl;
         }
@@ -401,7 +401,7 @@ bool ShaderGeneratorTester::generateCode(mx::GenContext& context, const std::str
     }
     
     bool stageFailed = false;
-    for (auto stage : testStages)
+    for (const auto& stage : testStages)
     {
         const std::string& code = shader->getSourceCode(stage);
         sourceCode.push_back(code);
@@ -463,7 +463,7 @@ void ShaderGeneratorTester::mapNodeDefToIdentiers(const std::vector<mx::NodePtr>
                                                   std::unordered_map<std::string, unsigned int>& ids)
 {
     unsigned int id = 1;
-    for (auto node : nodes)
+    for (const auto& node : nodes)
     {
         auto nodedef = node->getNodeDef();
         if (nodedef)
@@ -502,7 +502,7 @@ void ShaderGeneratorTester::registerLights(mx::DocumentPtr doc, const std::vecto
     {
         // Create a list of unique nodedefs and ids for them
         mapNodeDefToIdentiers(lights, _lightIdentifierMap);
-        for (auto id : _lightIdentifierMap)
+        for (const auto& id : _lightIdentifierMap)
         {
             mx::NodeDefPtr nodeDef = doc->getNodeDef(id.first);
             if (nodeDef)
@@ -535,7 +535,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
 
     // Add files to override the files in the test suite to be examined.
     mx::StringSet overrideFiles;
-    for (auto filterFile : options.overrideFiles)
+    for (const auto& filterFile : options.overrideFiles)
     {
         overrideFiles.insert(filterFile);
     }
@@ -556,12 +556,12 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     // Load in all documents to test
     mx::StringVec errorLog;
     mx::FileSearchPath searchPath(_libSearchPath);
-    for (auto testRoot : _testRootPaths)
+    for (const auto& testRoot : _testRootPaths)
     {
         mx::loadDocuments(testRoot, searchPath, _skipFiles, overrideFiles, _documents, _documentPaths, errorLog);
     }
     CHECK(errorLog.empty());
-    for (auto error : errorLog)
+    for (const auto& error : errorLog)
     {
         _logFile << error << std::endl;
     }
@@ -583,7 +583,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     size_t documentIndex = 0;
     mx::CopyOptions copyOptions;
     copyOptions.skipConflictingElements = true;
-    for (auto doc : _documents)
+    for (const auto& doc : _documents)
     {
         // Add in dependent libraries
         bool importedLibrary = false;
@@ -636,7 +636,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
         int missingNodeDefs = 0;
         int missingImplementations = 0;
         int codeGenerationFailures = 0;
-        for (auto element : elements)
+        for (const auto& element : elements)
         {
             mx::OutputPtr output = element->asA<mx::Output>();
             mx::ShaderRefPtr shaderRef = element->asA<mx::ShaderRef>();
@@ -719,13 +719,13 @@ void TestSuiteOptions::print(std::ostream& output) const
 {
     output << "Render Test Options:" << std::endl;
     output << "\tOverride Files: { ";
-    for (auto overrideFile : overrideFiles) { output << overrideFile << " "; }
+    for (const auto& overrideFile : overrideFiles) { output << overrideFile << " "; }
     output << "} " << std::endl;
     output << "\tLight Setup Files: { ";
-    for (auto lightFile : lightFiles) { output << lightFile << " "; }
+    for (const auto& lightFile : lightFiles) { output << lightFile << " "; }
     output << "} " << std::endl;
     output << "\tLanguage / Targets to run: " << std::endl;
-    for (auto l : languageAndTargets)
+    for (const auto& l : languageAndTargets)
     {
         mx::StringVec languageAndTarget = mx::splitString(l, "_");
         size_t count = languageAndTarget.size();
@@ -837,7 +837,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     else if (name == LANGUAGE_AND_TARGETS_STRING)
                     {
                         mx::StringVec list = mx::splitString(p->getValueString(), ",");
-                        for (auto l : list)
+                        for (const auto& l : list)
                         {
                             languageAndTargets.insert(l);
                         }

--- a/source/MaterialXTest/Render.cpp
+++ b/source/MaterialXTest/Render.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Render: Geometry Handler Load", "[rendercore]")
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             geomHandlerLog << e.what() << " " << error << std::endl;
         }
@@ -203,7 +203,7 @@ TEST_CASE("Render: Image Handler Load", "[rendercore]")
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             imageHandlerLog << e.what() << " " << error << std::endl;
         }

--- a/source/MaterialXTest/RenderArnold.cpp
+++ b/source/MaterialXTest/RenderArnold.cpp
@@ -78,7 +78,7 @@ bool ArnoldShaderRenderTester::runValidator(const std::string& shaderName,
     {
         log << "------------ Run OSL validation with element: " << element->getNamePath() << "-------------------" << std::endl;
 
-        for (auto options : optionsList)
+        for (const auto& options : optionsList)
         {
             profileTimes.elementsTested++;
 

--- a/source/MaterialXTest/RenderGLSL.cpp
+++ b/source/MaterialXTest/RenderGLSL.cpp
@@ -73,7 +73,7 @@ void GlslShaderRenderTester::loadAdditionalLibraries(mx::DocumentPtr document,
                                                      GenShaderUtil::TestSuiteOptions& options)
 {
     mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
-    for (auto lightFile : options.lightFiles)
+    for (const auto& lightFile : options.lightFiles)
     {
         loadLibrary(lightDir / mx::FilePath(lightFile), document);
     }
@@ -116,7 +116,7 @@ void GlslShaderRenderTester::createValidator(std::ostream& log)
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             log << e.what() << " " << error << std::endl;
         }
@@ -415,7 +415,7 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
                     log << "* Uniform UI Properties:" << std::endl;
                     const std::string& target = shadergen.getTarget();
                     const MaterialX::GlslProgram::InputMap& uniforms = program->getUniformsList();
-                    for (auto uniform : uniforms)
+                    for (const auto& uniform : uniforms)
                     {
                         const std::string& path = uniform.second->path;
                         if (path.empty())
@@ -483,7 +483,7 @@ bool GlslShaderRenderTester::runValidator(const std::string& shaderName,
                 file << shader->getSourceCode(mx::Stage::PIXEL);
                 file.close();
 
-                for (auto error : e.errorLog())
+                for (const auto& error : e.errorLog())
                 {
                     log << e.what() << " " << error << std::endl;
                 }

--- a/source/MaterialXTest/RenderOSL.cpp
+++ b/source/MaterialXTest/RenderOSL.cpp
@@ -74,7 +74,7 @@ void OslShaderRenderTester::createValidator(std::ostream& log)
 
             const std::string OSL_EXTENSION("osl");
             mx::FilePathVec files = shaderPath.getFilesInDirectory(OSL_EXTENSION);
-            for (auto file : files)
+            for (const auto& file : files)
             {
                 mx::FilePath filePath = shaderPath / file;
                 _validator->compileOSL(filePath.asString());
@@ -86,7 +86,7 @@ void OslShaderRenderTester::createValidator(std::ostream& log)
     }
     catch (mx::ExceptionShaderValidationError& e)
     {
-        for (auto error : e.errorLog())
+        for (const auto& error : e.errorLog())
         {
             log << e.what() << " " << error << std::endl;
         }
@@ -127,7 +127,7 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
     {
         log << "------------ Run OSL validation with element: " << element->getNamePath() << "-------------------" << std::endl;
 
-        for (auto options : optionsList)
+        for (const auto& options : optionsList)
         {
             profileTimes.elementsTested++;
 
@@ -288,7 +288,7 @@ bool OslShaderRenderTester::runValidator(const std::string& shaderName,
                 file << shader->getSourceCode();
                 file.close();
 
-                for (auto error : e.errorLog())
+                for (const auto& error : e.errorLog())
                 {
                     log << e.what() << " " << error << std::endl;
                 }

--- a/source/MaterialXTest/RenderOgsFx.cpp
+++ b/source/MaterialXTest/RenderOgsFx.cpp
@@ -54,7 +54,7 @@ void OgsFxShaderRenderTester::loadAdditionalLibraries(mx::DocumentPtr document,
     GenShaderUtil::TestSuiteOptions& options)
 {
     mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/Utilities/Lights");
-    for (auto lightFile : options.lightFiles)
+    for (const auto& lightFile : options.lightFiles)
     {
         loadLibrary(lightDir / mx::FilePath(lightFile), document);
     }

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -116,14 +116,14 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     // Add files to override the files in the test suite to be tested.
     mx::StringSet testfileOverride;
-    for (auto filterFile : options.overrideFiles)
+    for (const auto& filterFile : options.overrideFiles)
     {
         testfileOverride.insert(filterFile);
     }
 
     RenderUtil::AdditiveScopedTimer ioTimer(profileTimes.ioTime, "Global I/O time");
     mx::FilePathVec dirs;
-    for (auto testRoot : testRootPaths)
+    for (const auto& testRoot : testRootPaths)
     {
         mx::FilePathVec testRootDirs = testRoot.getSubDirectories();
         dirs.insert(std::end(dirs), std::begin(testRootDirs), std::end(testRootDirs));
@@ -183,7 +183,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     copyOptions.skipConflictingElements = true;
 
     const std::string MTLX_EXTENSION("mtlx");
-    for (auto dir : dirs)
+    for (const auto& dir : dirs)
     {
         ioTimer.startTimer();
         mx::FilePathVec files;
@@ -256,7 +256,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
             std::string outputPath = mx::FilePath(dir) / mx::FilePath(mx::removeExtension(file));
             mx::FileSearchPath imageSearchPath(dir);
-            for (auto element : elements)
+            for (const auto& element : elements)
             {
                 mx::OutputPtr output = element->asA<mx::Output>();
                 mx::ShaderRefPtr shaderRef = element->asA<mx::ShaderRef>();

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -694,7 +694,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                                 mx::StringSet extensions;
                                 handler->supportedExtensions(extensions);
                                 std::vector<std::pair<std::string, std::string>> filetypes;
-                                for (auto extension : extensions)
+                                for (const auto& extension : extensions)
                                 {
                                     filetypes.push_back(std::make_pair(extension, extension));
                                 }

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* const argv[])
     { 
         mx::FilePath("libraries")
     };
-    for (auto libraryPath : libraryPaths)
+    for (const auto& libraryPath : libraryPaths)
     {
         mx::FilePath fullPath(currentPath / libraryPath);
         if (!fullPath.exists())

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -303,7 +303,7 @@ void Material::bindViewInformation(const mx::Matrix44& world, const mx::Matrix44
 
 void Material::unbindImages(mx::GLTextureHandlerPtr imageHandler)
 {
-    for (auto filePath : _boundImages)
+    for (const auto& filePath : _boundImages)
     {
         imageHandler->unbindImage(filePath);
     }
@@ -320,7 +320,7 @@ void Material::bindImages(mx::GLTextureHandlerPtr imageHandler, const mx::FileSe
 
     const mx::VariableBlock* publicUniforms = getPublicUniforms();
     mx::Color4 fallbackColor(0, 0, 0, 1);
-    for (auto uniform : publicUniforms->getVariableOrder())
+    for (const auto& uniform : publicUniforms->getVariableOrder())
     {
         if (uniform->getType() != MaterialX::Type::FILENAME)
         {
@@ -468,7 +468,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandler
     };
     const std::string udim;
     mx::Color4 fallbackColor(0, 0, 0, 1);
-    for (auto pair : lightTextures)
+    for (const auto& pair : lightTextures)
     {
         if (_glShader->uniform(pair.first, false) != -1)
         {
@@ -529,7 +529,7 @@ void Material::bindLights(mx::LightHandlerPtr lightHandler, mx::GLTextureHandler
         }
 
         // Set all inputs
-        for (auto input : light->getInputs())
+        for (const auto& input : light->getInputs())
         {
             // Make sure we have a value to set
             if (input->hasValue())

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -396,7 +396,7 @@ void Viewer::setupLights(mx::DocumentPtr doc)
             // Create a list of unique nodedefs and ids for them
             std::unordered_map<std::string, unsigned int> identifiers;
             _lightHandler->mapNodeDefToIdentiers(lights, identifiers);
-            for (auto id : identifiers)
+            for (const auto& id : identifiers)
             {
                 mx::NodeDefPtr nodeDef = doc->getNodeDef(id.first);
                 if (nodeDef)
@@ -677,7 +677,7 @@ void Viewer::updateGeometrySelections()
 void Viewer::updateMaterialSelections()
 {
     std::vector<std::string> items;
-    for (auto material : _materials)
+    for (const auto& material : _materials)
     {
         mx::ElementPtr displayElem = material->getElement();
         if (displayElem->isA<mx::ShaderRef>())
@@ -789,7 +789,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::ValuePtr udimSetValue = doc->getGeomAttrValue("udimset");
 
         // Create new materials.
-        for (auto renderablePath : renderablePaths)
+        for (const auto& renderablePath : renderablePaths)
         {
             mx::ElementPtr elem = doc->getDescendant(renderablePath);
             mx::TypedElementPtr typedElem = elem ? elem->asA<mx::TypedElement>() : nullptr;
@@ -1044,7 +1044,7 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         if (!extensions.empty())
         {
             std::vector<std::pair<std::string, std::string>> filetypes;
-            for (auto extension : extensions)
+            for (const auto& extension : extensions)
             {
                 filetypes.push_back(std::make_pair(extension, extension));
             }
@@ -1126,7 +1126,7 @@ void Viewer::drawScene3D()
 
     // Opaque pass
     glDisable(GL_BLEND);
-    for (auto assignment : _materialAssignments)
+    for (const auto& assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
         MaterialPtr material = assignment.second;
@@ -1148,7 +1148,7 @@ void Viewer::drawScene3D()
     // Transparent pass
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    for (auto assignment : _materialAssignments)
+    for (const auto& assignment : _materialAssignments)
     {
         mx::MeshPartitionPtr geom = assignment.first;
         MaterialPtr material = assignment.second;
@@ -1172,7 +1172,7 @@ void Viewer::drawScene3D()
     {
         glEnable(GL_BLEND);
         glBlendFunc(GL_DST_COLOR, GL_ZERO);
-        for (auto assignment : _materialAssignments)
+        for (const auto& assignment : _materialAssignments)
         {
             mx::MeshPartitionPtr geom = assignment.first;
             MaterialPtr material = assignment.second;


### PR DESCRIPTION
I know this is not related for the functional changes we're working on but it had to be done sooner or later.

auto isn't deduced to a reference in these cases, so copying happens. This is not only a performance overhead (e.g. a lot of these values are string pairs) but also obscures the intent: we do need local copies in other cases to modify and use them in some way.