### PR TITLE
Allow external tests with dependent external libraries for test suite.

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -86,5 +86,11 @@
       <!-- Transforms UVs of loaded geometry -->
       <parameter name="transformUVs" type="matrix44" value="1.0f, 0.0f, 0.0f, -0.235f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f" />
 
+      <!-- External testing: extra comma separated list of library paths -->
+      <parameter name="externalLibraryPaths" type="string" value="" />
+
+      <!-- External testing: extra comma separated list of test root paths -->
+      <parameter name="externalTestPaths" type="string" value="" />
+
    </nodedef>
 </materialx>

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -749,6 +749,8 @@ void TestSuiteOptions::print(std::ostream& output) const
     output << "\tSpecular Environment Method: " << specularEnvironmentMethod << std::endl;
     output << "\tRadiance IBL File Path " << radianceIBLPath.asString() << std::endl;
     output << "\tIrradiance IBL File Path: " << irradianceIBLPath.asString() << std::endl;
+    output << "\tExternal library paths: " << externalLibraryPaths.asString() << std::endl;
+    output << "\tExternal test root paths: " << externalTestPaths.asString() << std::endl;
 }
 
 bool TestSuiteOptions::readOptions(const std::string& optionFile)
@@ -779,6 +781,8 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     const std::string TRANSFORM_UVS_STRING("transformUVs");
     const std::string SPHERE_OBJ("sphere.obj");
     const std::string SHADERBALL_OBJ("shaderball.obj");
+    const std::string EXTERNAL_LIBRARY_PATHS("externalLibraryPaths");
+    const std::string EXTERNAL_TEST_PATHS("externalTestPaths");
 
     overrideFiles.clear();
     dumpGeneratedCode = false;
@@ -885,6 +889,22 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     else if (name == TRANSFORM_UVS_STRING)
                     {
                         transformUVs = val->asA<mx::Matrix44>();
+                    }
+                    else if (name == EXTERNAL_LIBRARY_PATHS)
+                    {
+                        mx::StringVec list = mx::splitString(p->getValueString(), ",");
+                        for (const auto& l : list)
+                        {
+                            externalLibraryPaths.append(mx::FilePath(l));
+                        }
+                    }
+                    else if (name == EXTERNAL_TEST_PATHS)
+                    {
+                        mx::StringVec list = mx::splitString(p->getValueString(), ",");
+                        for (const auto& l : list)
+                        {
+                            externalTestPaths.append(mx::FilePath(l));
+                        }
                     }
                 }
             }

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -127,6 +127,12 @@ class TestSuiteOptions
 
     // Transforms UVs of loaded geometry
     MaterialX::Matrix44 transformUVs;
+
+    // Additional library paths
+    mx::FileSearchPath externalLibraryPaths;
+
+    // Additional testPaths paths
+    mx::FileSearchPath externalTestPaths;
 };
 
 // Utility class to handle testing of shader generators.


### PR DESCRIPTION
Add unit test options for external library paths and test roots in _options.mtlx.
