### PR TITLE
MATX-195 - Fixed refreshing VP2 on document and element attribute changes.

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.cpp
@@ -235,6 +235,20 @@ MaterialXShadingNodeImpl<BASE>::fragmentName() const
 }
 
 template <class BASE>
+bool
+MaterialXShadingNodeImpl<BASE>::valueChangeRequiresFragmentRebuild(const MPlug* plug) const
+{
+    if (   *plug == MaterialXNode::DOCUMENT_ATTRIBUTE
+        || *plug == MaterialXNode::ELEMENT_ATTRIBUTE
+    )
+    {
+        return true;
+    }
+
+    return BASE::valueChangeRequiresFragmentRebuild(plug);
+}
+
+template <class BASE>
 void MaterialXShadingNodeImpl<BASE>::updateDG()
 {
 }

--- a/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXShadingNodeImpl.h
@@ -21,10 +21,7 @@ class MaterialXShadingNodeImpl : public BASE
         const MHWRender::MAttributeParameterMappingList&
     ) override;
 
-    bool valueChangeRequiresFragmentRebuild(const MPlug*) const override
-    {
-        return false;
-    }
+    bool valueChangeRequiresFragmentRebuild(const MPlug*) const override;
 
   protected:
     ~MaterialXShadingNodeImpl() override;


### PR DESCRIPTION
With this change, the node updates correctly when the document or the element attribute values change. We should be able to make this work for the reload button as well - I'll investigate tomorrow.