### PR TITLE
Update logic for finding renderable elements if none is explicitly defined.

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.cpp
@@ -165,8 +165,12 @@ MStatus CreateMaterialXNodeCmd::doIt( const MArgList &args )
             CHECK_MSTATUS(argData.getFlagArgument(kElementFlag, 0, elementPath));
             if (elementPath.length())
             {
-                renderableElements.clear();
-                mx::ElementPtr desiredElement = MaterialXMaya::getRenderableElement(document, renderableElements, elementPath.asChar());
+                mx::TypedElementPtr desiredElement = MaterialXMaya::getRenderableElement(document, renderableElements, elementPath.asChar());
+                if (desiredElement)
+                {
+                    renderableElements.clear();
+                    renderableElements.push_back(desiredElement);
+                }
             }
         }
 

--- a/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.h
+++ b/source/MaterialXContrib/MaterialXNode/CreateMaterialXNodeCmd.h
@@ -27,6 +27,16 @@ class CreateMaterialXNodeCmd : MPxCommand
     static MString NAME;
 
   private:
+    /// Create a new Maya node for a given renderable element
+    /// @param document Document containing the element
+    /// @param renderableElement Element to use
+    /// @param createAsTexture Create texture node. If set to false will type found based on associated shader code.
+    /// @param documentFilePath Path to document
+    /// @param searchPath Shader generation source paths
+    /// @return Name of Maya node created
+    std::string createNode(MaterialX::DocumentPtr document, MaterialX::TypedElementPtr renderableElement, bool createAsTexture,
+                           const MString& documentFilePath, const MaterialX::FileSearchPath& searchPath);
+
     MDGModifier _dgModifier;
 };
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.cpp
@@ -8,55 +8,20 @@
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenOgsXml/OgsXmlGenerator.h>
 
-MaterialXData::MaterialXData(   mx::DocumentPtr document,
-                                const std::string& elementPath,
-                                const MaterialX::FileSearchPath& librarySearchPath )
-    : _document(document)
+MaterialXData::MaterialXData(mx::DocumentPtr document,
+                             mx::ElementPtr element,
+                             const MaterialX::FileSearchPath& librarySearchPath ) :
+    _document(document),
+    _element(element)
 {
     if (!_document)
     {
         throw mx::Exception("No document specified");
     }
 
-    std::vector<mx::TypedElementPtr> renderableElements;
-    mx::findRenderableElements(_document, renderableElements);
-
-    // Nothing specified. Find the first renderable element and use that
-    if (elementPath.empty())
+    if (!_element)
     {
-        if (renderableElements.empty())
-        {
-            throw mx::Exception(
-                "No element path specified and no renderable elements in the document."
-            );
-        }
-
-        _element = renderableElements.front();
-    }
-    else
-    {
-        _element = _document->getDescendant(elementPath);
-        if (!_element)
-        {
-            std::string message = "Element '";
-            message += elementPath;
-            message += "' not found in the document.";
-            throw mx::Exception(message);
-        }
-
-        auto it = std::find_if(
-            renderableElements.begin(),
-            renderableElements.end(),
-            [this](mx::TypedElementPtr renderableElement) -> bool
-            {
-                return _element->getNamePath() == renderableElement->getNamePath();
-            }
-        );
-
-        if (it == renderableElements.end())
-        {
-            throw mx::Exception("The specified element is not renderable");
-        }
+        throw mx::Exception("No element specified");
     }
 
     try

--- a/source/MaterialXContrib/MaterialXNode/MaterialXData.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXData.h
@@ -23,12 +23,10 @@ namespace mx = MaterialX;
 class MaterialXData
 {
   public:
-    /// The element path and document that the element resides in are passed in
+    /// The element and document that the element resides in are passed in
     /// as input arguments.
-    /// If the element specified is an empty string then an attempt will be
-    /// made to find the first renderable element.
     MaterialXData(  mx::DocumentPtr document,
-                    const std::string& elementPath,
+                    mx::ElementPtr element,
                     const mx::FileSearchPath& librarySearchPath);
 
     MaterialXData(const MaterialXData&) = delete;

--- a/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXNode.cpp
@@ -136,12 +136,7 @@ void MaterialXNode::createAndRegisterFragment()
 
         if (_elementPath.length() == 0)
         {
-            // When an empty element path is passed to MaterialXData's
-            // constructor, the first renderable element is selected, which is
-            // a handy feature when creating the node with the command.
-            // However this automatic behavior would complicate state
-            // transitions on attribute edits after the node has been created.
-            // So if the element path attribute is empty, bail early and don't
+            // If the element path attribute is empty, bail early and don't
             // attempt to create a MaterialXData.
             //
             return;
@@ -149,7 +144,7 @@ void MaterialXNode::createAndRegisterFragment()
 
         _materialXData.reset(new MaterialXData(
             _document,
-            _elementPath.asChar(),
+            _document->getDescendant(_elementPath.asChar()),
             Plugin::instance().getLibrarySearchPath()
         ));
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -50,45 +50,35 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
     return document;
 }
 
-std::vector<mx::TypedElementPtr> getRenderableElements(mx::DocumentPtr document, const std::string &desiredElementPath)
+mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document, 
+                                         const std::vector<mx::TypedElementPtr> renderableElements, 
+                                         const std::string &desiredElementPath)
 {
-    std::vector<mx::TypedElementPtr> renderableElements;
-    mx::findRenderableElements(document, renderableElements);
-    if (renderableElements.empty())
-    {
-        throw mx::Exception("There are no renderable elements in the document.");
-    }
+  
 
-    // Nothing specified. Find all renderable elements
     if (!desiredElementPath.empty())
     {
         mx::ElementPtr element = document->getDescendant(desiredElementPath);
         if (!element)
         {
-            std::string message = "Element '";
-            message += desiredElementPath;
-            message += "' not found in the document.";
-            throw mx::Exception(message);
+            throw mx::Exception("The specified element " + desiredElementPath + " does not exist in the document");
         }
 
-        auto it = std::find_if(
-            renderableElements.begin(),
-            renderableElements.end(),
-            [element](mx::TypedElementPtr renderableElement) -> bool
-        {
-            return (element->getNamePath() == renderableElement->getNamePath());
-        }
-        );
+        auto it = std::find_if(renderableElements.begin(),
+                               renderableElements.end(),
+                               [element](mx::TypedElementPtr renderableElement) -> bool
+                               {
+                                    return (element->getNamePath() == renderableElement->getNamePath());
+                               });
 
         if (it == renderableElements.end())
         {
-            throw mx::Exception("The specified element is not renderable");
+            throw mx::Exception("The specified element " + desiredElementPath + "is not renderable");
         }
-        renderableElements.clear();
-        renderableElements.push_back(element->asA<mx::TypedElement>());
+        
+        return element->asA<mx::TypedElement>();
     }
-
-    return renderableElements;
+    return nullptr;
 }
 
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -50,5 +50,47 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
     return document;
 }
 
+std::vector<mx::TypedElementPtr> getRenderableElements(mx::DocumentPtr document, const std::string &desiredElementPath)
+{
+    std::vector<mx::TypedElementPtr> renderableElements;
+    mx::findRenderableElements(document, renderableElements);
+    if (renderableElements.empty())
+    {
+        throw mx::Exception("There are no renderable elements in the document.");
+    }
+
+    // Nothing specified. Find all renderable elements
+    if (!desiredElementPath.empty())
+    {
+        mx::ElementPtr element = document->getDescendant(desiredElementPath);
+        if (!element)
+        {
+            std::string message = "Element '";
+            message += desiredElementPath;
+            message += "' not found in the document.";
+            throw mx::Exception(message);
+        }
+
+        auto it = std::find_if(
+            renderableElements.begin(),
+            renderableElements.end(),
+            [element](mx::TypedElementPtr renderableElement) -> bool
+        {
+            return (element->getNamePath() == renderableElement->getNamePath());
+        }
+        );
+
+        if (it == renderableElements.end())
+        {
+            throw mx::Exception("The specified element is not renderable");
+        }
+        renderableElements.clear();
+        renderableElements.push_back(element->asA<mx::TypedElement>());
+    }
+
+    return renderableElements;
+}
+
+
 } // namespace MaterialXMaya
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
@@ -19,9 +19,13 @@ mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
 mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
                              const MaterialX::FileSearchPath& librarySearchPath);
 
-/// Find renderable elements in a document. If a specific element is desired then this will
-/// be checked to see if it is renderable.
-std::vector<mx::TypedElementPtr> getRenderableElements(mx::DocumentPtr document, const std::string &desiredElementPath);
+/// Given an element path return a pointer to it within a document if it is considered to be renderable.
+/// @param document Document to examine
+/// @param renderableElements List of elements in the document that are considered to be renderable.
+/// @param elementPath Path to element to find
+mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document,
+                                        const std::vector<mx::TypedElementPtr> renderableElements,
+                                        const std::string &desiredElementPath);
 
 } // namespace MaterialXMaya
 

--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.h
@@ -15,8 +15,13 @@ namespace MaterialXMaya
 mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
                                   const mx::FilePath& filePath);
 
+/// Load in a document and associated libraries from library search path
 mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
                              const MaterialX::FileSearchPath& librarySearchPath);
+
+/// Find renderable elements in a document. If a specific element is desired then this will
+/// be checked to see if it is renderable.
+std::vector<mx::TypedElementPtr> getRenderableElements(mx::DocumentPtr document, const std::string &desiredElementPath);
 
 } // namespace MaterialXMaya
 


### PR DESCRIPTION
Migrate selection of renderable logic outside of constructor for MaterialXData.
Allow to iterate over all renderables if no explicit element name set.