### PR TITLE
Sanitize OSL shader names in code generation

### DIFF
--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -220,7 +220,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
         emitString("shader ", stage);
     }
 
-    // Begin shader signature.
+    // Begin shader signature. Note that makeIdentifier() will sanitize the name.
     string functionName = shader->getName();
     context.makeIdentifier(functionName);
     setFunctionName(functionName, stage);

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -40,6 +40,7 @@ void GenContext::addIdentifier(const string& name)
 
 void GenContext::makeIdentifier(string& name)
 {
+    name = createValidName(name, '_');
     string id = name;
     while (_identifiers.count(id))
     {


### PR DESCRIPTION
Fix #557.
Sanitize shader name for OSL (and in general any identifier). but have the identifier creator always perform name sanitizing. In case an attempt is made to create invalid identifiers elsewhere in the code.
