### PR TITLE
Restore skip element checks

### DIFF
--- a/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXNode/MaterialXUtil.cpp
@@ -45,7 +45,9 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
     loadLibraries(libraries, librarySearchPath, document);
 
     // Read document contents from disk
-    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING);
+    mx::XmlReadOptions readOptions;
+    readOptions.skipConflictingElements = true;
+    mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
 
     return document;
 }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -79,12 +79,14 @@ mx::DocumentPtr loadLibraries(const mx::StringVec& libraryFolders, const mx::Fil
         mx::FilePathVec filenames = path.getFilesInDirectory("mtlx");
 
         mx::CopyOptions copyOptions;
+        copyOptions.skipConflictingElements = true;
 
+        mx::XmlReadOptions readOptions;
+        readOptions.skipConflictingElements = true;
         for (const std::string& filename : filenames)
         {
             mx::FilePath file = path / filename;
             mx::DocumentPtr libDoc = mx::createDocument();
-            mx::XmlReadOptions readOptions;
             mx::readFromXmlFile(libDoc, file, mx::EMPTY_STRING, &readOptions);
             libDoc->setSourceUri(file);
             doc->importLibrary(libDoc, &copyOptions);
@@ -360,10 +362,12 @@ void Viewer::setupLights(mx::DocumentPtr doc)
         try
         {
             mx::XmlReadOptions readOptions;
+            readOptions.skipConflictingElements = true;
             mx::readFromXmlFile(lightDoc, path.asString(), mx::EMPTY_STRING, &readOptions);
             lightDoc->setSourceUri(path);
 
             mx::CopyOptions copyOptions;
+            copyOptions.skipConflictingElements = true;
             doc->importLibrary(lightDoc, &copyOptions);
         }
         catch (std::exception& e)
@@ -721,6 +725,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
 {
     // Set up read options.
     mx::XmlReadOptions readOptions;
+    readOptions.skipConflictingElements = true;
     readOptions.readXIncludeFunction = [](mx::DocumentPtr doc, const std::string& filename,
                                           const std::string& searchPath, const mx::XmlReadOptions* options)
     {
@@ -759,7 +764,8 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         mx::readFromXmlFile(doc, filename, _searchPath.asString(), &readOptions);
 
         // Import libraries.
-        mx::CopyOptions copyOptions;
+        mx::CopyOptions copyOptions; 
+        copyOptions.skipConflictingElements = true;
         doc->importLibrary(libraries, &copyOptions);
 
         // Add lighting 


### PR DESCRIPTION
Restore element conflict code lost in merge accidentally.
Required when include std libraries more than once.