### PR TITLE
UDIM fixes for Viewer

### DIFF
--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -90,6 +90,13 @@ class Material
     /// Generate a shader from the given inputs.
     bool generateShader(mx::GenContext& context);
 
+    /// Copy shader from one material to this one
+    void copyShader(MaterialPtr material)
+    {
+        _hwShader = material->_hwShader;
+        _glShader = material->_glShader;
+    }
+
     /// Generate a constant color shader
     bool generateConstantShader(mx::GenContext& context,
                                 mx::DocumentPtr stdLib,


### PR DESCRIPTION
- Clear node definitions before calling generate for each material. Fix…es the case of UDIM load getting confused by reusing previous definitions. 
- Also fix so that if a material has a udim and it's using the same
materialX material element then only generate once and copy over the shaders references. Thus when editing in the property editor editing one edits all udim regions