### PR TITLE
Append to search paths instead of replacing

### DIFF
--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* const argv[])
         }
         if (token == "--path" && !nextToken.empty())
         {
-            searchPath = mx::FileSearchPath(nextToken);
+            searchPath.append(mx::FileSearchPath(nextToken));
         }
         if (token == "--mesh" && !nextToken.empty())
         {


### PR DESCRIPTION
Minor change to allow specifying additional search paths. I'm using this for texture lookup at the moment. We need to do something similar for test config.
e.g.
--library adsklib --library adsklib/genglsl --path _path_to_library_ --path _path to textures_

The current implementation will overwrite the previous `-path` specified.