### PR TITLE
Renamed optionVar  MAYA_MATERIALX_EDITOR to materialXEditorPath.

### DIFF
--- a/source/MaterialXContrib/MaterialXMaya/README.md
+++ b/source/MaterialXContrib/MaterialXMaya/README.md
@@ -106,10 +106,10 @@ optionVar -stringValueAppend materialXLibraryNames "stdlib"
 
 ## LookdevX integration
 
-The MaterialXMaya plug-in integrates with LookdevX or any other editor that can open MaterialX document files. To enable the integration with the LookdexX editor, set the `MAYA_MATERIALX_EDITOR` option variable to the path of the editor executable, for example:
+The MaterialXMaya plug-in integrates with LookdevX or any other editor that can open MaterialX document files. To enable the integration with the LookdexX editor, set the `materialXEditorPath` option variable to the path of the editor executable, for example:
 
 ```MEL
-optionVar -stringValue MAYA_MATERIALX_EDITOR "D:/LookdevX/bin/LookdevX.exe"
+optionVar -stringValue materialXEditorPath "D:/LookdevX/bin/LookdevX.exe"
 ```
 
 To open the MaterialX document in the editor, press **Edit** in the Attribute Editor of the MaterialX node. Once the document has been edited and saved, press **Reload** in the Attribute Editor which executes the `reloadMaterialXNode` command and refreshes the shader in the viewport.

--- a/source/MaterialXContrib/MaterialXMaya/scripts/MaterialXNodeUtil.py
+++ b/source/MaterialXContrib/MaterialXMaya/scripts/MaterialXNodeUtil.py
@@ -16,11 +16,11 @@ def editMaterialXDocument(documentPath, element, editor):
 def editMaterialXNode(nodeName):
     documentFilePath = cmds.getAttr(nodeName + "documentFilePath")
     elementPath = cmds.getAttr(nodeName + "elementPath")
-    if cmds.optionVar(exists='MAYA_MATERIALX_EDITOR'):
-        editor = cmds.optionVar(q='MAYA_MATERIALX_EDITOR')
+    if cmds.optionVar(exists='materialXEditorPath'):
+        editor = cmds.optionVar(q='materialXEditorPath')
         editMaterialXDocument(documentFilePath, elementPath, editor)
     else:
-        print "Please set optionVar: 'MAYA_MATERIALX_EDITOR'"
+        print "Please set optionVar: 'materialXEditorPath'"
 
 def getMaterialXNodesForDocument(documentPath):
     nodes = cmds.ls(type="MaterialXNode")


### PR DESCRIPTION
While editing the readme I noticed that optionVar naming was inconsistent (cf. `materialXLibrarySearchPaths`). Searching in the Maya codebase shows that camelCase is standard for optionVars.