### PR TITLE
ILM Merge for 1.36.3 official release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.36.3] - Development
+## [1.36.3] - 2019-08-02
 
 Merged shader code generation and physically-based shading nodes from Autodesk's ShaderX extensions.  Added a default MaterialX viewer based on GLSL shader generation.
 
@@ -9,11 +9,13 @@ Merged shader code generation and physically-based shading nodes from Autodesk's
 - Added the MaterialXRender library, providing helper functionality for rendering MaterialX content.
 - Added the MaterialXView library, providing a default MaterialX viewer.
 - Added the physically-based shading node library (libraries/pbrlib).
-- Added a root-level 'resources' folder.
-- Added support for the 'place2d' node.
+- Added a root-level 'cmake' folder, including a standard FindMaterialX module.
+- Added a root-level 'resources' folder, including example materials and meshes.
+- Added documents for the 1.37 specification.
 
 ### Changed
 - Moved the MaterialX data libraries from 'documents/Libraries' to 'libraries'.
+- Updated MaterialX node definitions to the 1.37 specification.
 - Updated the PyBind11 library to version 2.2.4.
 
 ### Removed

--- a/libraries/pbrlib/genglsl/mx_roughness_dual.glsl
+++ b/libraries/pbrlib/genglsl/mx_roughness_dual.glsl
@@ -1,5 +1,9 @@
 void mx_roughness_dual(vec2 roughness, out vec2 result)
 {
+    if (roughness.y < 0.0)
+    {
+        roughness.y = roughness.x;
+    }
     result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
     result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
 }

--- a/libraries/pbrlib/genosl/mx_roughness_dual.osl
+++ b/libraries/pbrlib/genosl/mx_roughness_dual.osl
@@ -1,5 +1,9 @@
 void mx_roughness_dual(vector2 roughness, output vector2 result)
 {
+    if (roughness.y < 0.0)
+    {
+        roughness.y = roughness.x;
+    }
     result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
     result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
 }

--- a/libraries/pbrlib/genosl/mx_roughness_dual.osl
+++ b/libraries/pbrlib/genosl/mx_roughness_dual.osl
@@ -1,9 +1,12 @@
 void mx_roughness_dual(vector2 roughness, output vector2 result)
 {
+    result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
     if (roughness.y < 0.0)
     {
-        roughness.y = roughness.x;
+        result.y = roughness.x;
     }
-    result.x = clamp(roughness.x * roughness.x, M_FLOAT_EPS, 1.0);
-    result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
+    else
+    {
+        result.y = clamp(roughness.y * roughness.y, M_FLOAT_EPS, 1.0);
+    }
 }


### PR DESCRIPTION
Update #460 
- Restore isotropic fallback for roughness_dual
  - Fix OSL implementation to avoid possible selt-modification of non-modifiable parameter. Test affected: shader_ops.mtlx

![image](https://user-images.githubusercontent.com/14275104/62658773-94111c80-b937-11e9-9351-7b0f27f137e7.png)

- Finalize changelog for v1.36.3
