### PR TITLE
Use xinclude predicate versus xinclude list for write filtering

### DIFF
--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -76,7 +76,6 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
 void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions* writeOptions)
 {
     bool writeXIncludeEnable = writeOptions ? writeOptions->writeXIncludeEnable : true;
-    const StringVec& ignoredXIncludes = writeOptions ? writeOptions->ignoredXIncludes : StringVec();
     ElementPredicate elementPredicate = writeOptions ? writeOptions->elementPredicate : nullptr;
 
     // Store attributes in XML.
@@ -107,11 +106,6 @@ void elementToXml(ConstElementPtr elem, xml_node& xmlNode, const XmlWriteOptions
             {
                 if (!writtenSourceFiles.count(sourceUri))
                 {
-                    // Check to see if we have flagged this XInclude to be ignored, if so skip it.
-                    if (std::find(ignoredXIncludes.begin(), ignoredXIncludes.end(), sourceUri) != ignoredXIncludes.end())
-                    {
-                        continue;
-                    }
                     xml_node includeNode = xmlNode.append_child(XINCLUDE_TAG.c_str());
                     xml_attribute includeAttr = includeNode.append_attribute("href");
                     includeAttr.set_value(sourceUri.c_str());

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -56,10 +56,6 @@ class XmlWriteOptions
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
-
-    /// The vector of XIncludes to ignore saving out.  Defaults to an empty
-    /// vector.
-    StringVec ignoredXIncludes;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -205,6 +205,40 @@ TEST_CASE("Load content", "[xmlio]")
     }
     REQUIRE(imageElementCount == 0);
 
+    // Serialize to XML with a custom predicate to remove xincludes.
+    auto skipLibIncludes = [libs](mx::ConstElementPtr elem)
+    {
+        if (elem->hasSourceUri())
+        {
+            for (auto doc : libs)
+            {
+                if (doc->getSourceUri() == elem->getSourceUri())
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    };
+    writeOptions.writeXIncludeEnable = true;
+    writeOptions.elementPredicate = skipLibIncludes;
+    xmlString = mx::writeToXmlString(doc, &writeOptions);
+
+    // Reconstruct and verify that the document contains no xincludes.
+    writtenDoc = mx::createDocument();
+    mx::readFromXmlString(writtenDoc, xmlString);
+    REQUIRE(*writtenDoc != *doc);
+    bool hasSourceUri = false;
+    for (mx::ElementPtr elem : writtenDoc->traverseTree())
+    {
+        if (elem->hasSourceUri())
+        {
+            hasSourceUri = true;
+            break;
+        }
+    }
+    REQUIRE(!hasSourceUri);
+
     // Read a non-existent document.
     mx::DocumentPtr nonExistentDoc = mx::createDocument();
     REQUIRE_THROWS_AS(mx::readFromXmlFile(nonExistentDoc, "NonExistent.mtlx"), mx::ExceptionFileMissing&);

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -210,9 +210,9 @@ TEST_CASE("Load content", "[xmlio]")
     {
         if (elem->hasSourceUri())
         {
-            for (auto doc : libs)
+            for (auto lib : libs)
             {
-                if (doc->getSourceUri() == elem->getSourceUri())
+                if (lib->getSourceUri() == elem->getSourceUri())
                 {
                     return false;
                 }
@@ -222,12 +222,10 @@ TEST_CASE("Load content", "[xmlio]")
     };
     writeOptions.writeXIncludeEnable = true;
     writeOptions.elementPredicate = skipLibIncludes;
-    xmlString = mx::writeToXmlString(doc, &writeOptions);
-
-    // Reconstruct and verify that the document contains no xincludes.
+    xmlString = mx::writeToXmlString(writtenDoc, &writeOptions);
+    // Verify that the document contains no xincludes.
     writtenDoc = mx::createDocument();
     mx::readFromXmlString(writtenDoc, xmlString);
-    REQUIRE(*writtenDoc != *doc);
     bool hasSourceUri = false;
     for (mx::ElementPtr elem : writtenDoc->traverseTree())
     {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -532,8 +532,18 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
         if (!filename.empty() && !_materials.empty())
         {
             mx::DocumentPtr doc = _materials.front()->getDocument();
+            // Add element predicate to prune out writing elements from included files
+            auto skipXincludes = [this](mx::ConstElementPtr elem)
+            {
+                if (elem->hasSourceUri())
+                {
+                    return (std::find(_xincludeFiles.begin(), _xincludeFiles.end(), elem->getSourceUri()) == _xincludeFiles.end());
+                }
+                return true;
+            };
             mx::XmlWriteOptions writeOptions;
-            writeOptions.ignoredXIncludes = _xincludeFiles;
+            writeOptions.writeXIncludeEnable = true;
+            writeOptions.elementPredicate = skipXincludes;
             MaterialX::writeToXmlFile(doc, filename, &writeOptions);
         }
 
@@ -855,16 +865,6 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             }
             if (udimSetValue && udimSetValue->isA<mx::StringVec>())
             {
-                for (const std::string& udim : udimSetValue->asA<mx::StringVec>())
-                {
-                    MaterialPtr mat = Material::create();
-                    mat->setDocument(doc);
-                    mat->setElement(typedElem);
-                    mat->setUdim(udim);
-                    newMaterials.push_back(mat);
-                    
-                    udimElement = typedElem;
-                }
             }
             else
             {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -865,6 +865,16 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             }
             if (udimSetValue && udimSetValue->isA<mx::StringVec>())
             {
+                for (const std::string& udim : udimSetValue->asA<mx::StringVec>())
+                {
+                    MaterialPtr mat = Material::create();
+                    mat->setDocument(doc);
+                    mat->setElement(typedElem);
+                    mat->setUdim(udim);
+                    newMaterials.push_back(mat);
+                    
+                    udimElement = typedElem;
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes: #556 

Remove development API which is a list of extra include files to check as part of write options.
- Instead have the application create it's own predicate which will filter out xincludes as it desires which is more flexible and basically performs the same action.
- Modify viewer to use this new logic and add in a unit test.
