### PR TITLE
Fix macOS deprecation error 

### DIFF
--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.h
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.h
@@ -31,7 +31,6 @@ void NSOpenGLClearDrawable(void* pContext);
 void NSOpenGLDescribePixelFormat(void* pPixelFormat, int attrib, int* vals);
 void NSOpenGLGetInteger(void* pContext, int param, int* vals);
 void NSOpenGLUpdate(void* pContext);
-void* NSOpenGLCGLContextObj(void* pContext);
 void* NSOpenGLGetWindow(void* pView);
 void NSOpenGLInitializeGLLibrary();
 

--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.m
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.m
@@ -196,13 +196,6 @@ void NSOpenGLUpdate(void* pContext)
     [context update];
 }
 
-void* NSOpenGLCGLContextObj(void* pContext)
-{
-  NSOpenGLContext *context = (NSOpenGLContext*)pContext;
-    NSOpenGLContextAuxiliary* contextAuxiliary =  [context CGLContextObj];
-    return contextAuxiliary;
-}
-
 void* NSOpenGLGetWindow(void* pView)
 {
   NSView *view = (NSView*)pView;


### PR DESCRIPTION
for NSOpenGLContextAuxiliary in NSOpenGLContextObj
<img width="713" alt="Screen Shot 2019-11-01 at 3 48 39 PM" src="https://user-images.githubusercontent.com/1727158/68061482-587db880-fcc2-11e9-8906-c7df11851dbc.png">
