### PR TITLE
OSX: Fix build error related to declaration already in scope

### DIFF
--- a/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.cpp
@@ -19,12 +19,6 @@
 
 namespace mx = MaterialX;
 
-namespace MHWRender
-{
-    class MPxShadingNodeOverride;
-    class MPxSurfaceShadingNodeOverride;
-};
-
 namespace MaterialXMaya
 {
 


### PR DESCRIPTION
Looks like Clang is more picky than Microsoft compiler since building on Mac is returning following error: `error: declaration conflicts with target of using declaration already in scope`

Removing forward declaration of MPxShadingNodeOverride and MPxSurfaceShadingNodeOverride fix the problem.