### PR TITLE
RuntTime: Stream I/O and write source URI support

### DIFF
--- a/source/MaterialXRuntime/Private/PrvStage.cpp
+++ b/source/MaterialXRuntime/Private/PrvStage.cpp
@@ -18,16 +18,15 @@
 namespace MaterialX
 {
 
-PrvStage::PrvStage(const RtToken& name, const RtToken& uri) :
+PrvStage::PrvStage(const RtToken& name) :
     PrvAllocatingElement(RtObjType::STAGE, nullptr, name),
-    _selfRefCount(0),
-    _sourceUri(uri)
+    _selfRefCount(0)
 {
 }
 
 PrvObjectHandle PrvStage::createNew(const RtToken& name)
 {
-    return std::make_shared<PrvStage>(name, RtToken(""));
+    return std::make_shared<PrvStage>(name);
 }
 
 void PrvStage::addReference(PrvObjectHandle stage)

--- a/source/MaterialXRuntime/Private/PrvStage.cpp
+++ b/source/MaterialXRuntime/Private/PrvStage.cpp
@@ -16,15 +16,16 @@
 namespace MaterialX
 {
 
-PrvStage::PrvStage(const RtToken& name) :
+PrvStage::PrvStage(const RtToken& name, const RtToken& uri) :
     PrvElement(RtObjType::STAGE, name),
-    _selfRefCount(0)
+    _selfRefCount(0),
+    _sourceUri(uri)
 {
 }
 
 PrvObjectHandle PrvStage::createNew(const RtToken& name)
 {
-    return std::make_shared<PrvStage>(name);
+    return std::make_shared<PrvStage>(name, RtToken(""));
 }
 
 void PrvStage::initialize()

--- a/source/MaterialXRuntime/Private/PrvStage.h
+++ b/source/MaterialXRuntime/Private/PrvStage.h
@@ -17,18 +17,13 @@ namespace MaterialX
 class PrvStage : public PrvAllocatingElement
 {
 public:
-    PrvStage(const RtToken& name, const RtToken& sourceUri);
+    PrvStage(const RtToken& name);
 
     static PrvObjectHandle createNew(const RtToken& name);
 
-    const RtToken& getSourceUri() const
+    RtTokenList& getSourceUri()
     {
         return _sourceUri;
-    }
-
-    void setSourceUri(const RtToken& uri)
-    {
-        _sourceUri = uri;
     }
 
     void addReference(PrvObjectHandle stage);
@@ -56,7 +51,7 @@ protected:
     size_t _selfRefCount;
     PrvObjectHandleVec _refStages;
     PrvObjectHandleSet _refStagesSet;
-    RtToken _sourceUri;
+    RtTokenList _sourceUri;
 };
 
 }

--- a/source/MaterialXRuntime/Private/PrvStage.h
+++ b/source/MaterialXRuntime/Private/PrvStage.h
@@ -17,11 +17,21 @@ namespace MaterialX
 class PrvStage : public PrvElement
 {
 public:
-    PrvStage(const RtToken& name);
+    PrvStage(const RtToken& name, const RtToken& sourceUri);
 
     static PrvObjectHandle createNew(const RtToken& name);
 
     void initialize();
+
+    const RtToken& getSourceUri() const
+    {
+        return _sourceUri;
+    }
+
+    void setSourceUri(const RtToken& uri)
+    {
+        _sourceUri = uri;
+    }
 
     void addReference(PrvObjectHandle stage);
 
@@ -48,6 +58,7 @@ protected:
     size_t _selfRefCount;
     PrvObjectHandleVec _refStages;
     PrvObjectHandleSet _refStagesSet;
+    RtToken _sourceUri;
 };
 
 }

--- a/source/MaterialXRuntime/Private/PrvStage.h
+++ b/source/MaterialXRuntime/Private/PrvStage.h
@@ -21,9 +21,14 @@ public:
 
     static PrvObjectHandle createNew(const RtToken& name);
 
-    RtTokenList& getSourceUri()
+    const RtTokenList& getSourceUri() const
     {
         return _sourceUri;
+    }
+
+    void addSourceUri(const RtToken& uri)
+    {
+        _sourceUri.push_back(uri);
     }
 
     void addReference(PrvObjectHandle stage);

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -19,8 +19,6 @@
 #include <MaterialXGenShader/Util.h>
 #include <sstream>
 
-#include <iostream>
-
 namespace MaterialX
 {
 
@@ -509,7 +507,6 @@ namespace
             RtToken uri = pStage->getSourceUri();
             if (!uri.str().empty())
             {
-                std::cout << "- Write source URI: " << uri.str() << std::endl;
                 prependXInclude(doc, uri.str());
             }
         }
@@ -625,7 +622,10 @@ void RtFileIo::write(DocumentPtr& doc, const RtWriteOptions* writeOptions)
     PrvStage* stage = data()->asA<PrvStage>();
     writeAttributes(stage, doc);
 
-    writeSourceUris(stage, doc);
+    if (writeOptions && writeOptions->writeIncludes)
+    {
+        writeSourceUris(stage, doc);
+    }
 
     RtWriteOptions::WriteFilter filter = writeOptions ? writeOptions->writeFilter : nullptr;
     for (size_t i = 0; i < stage->numChildren(); ++i)
@@ -664,9 +664,7 @@ void RtFileIo::write(const FilePath& documentPath, const RtWriteOptions* options
     DocumentPtr document = createDocument(); 
     write(document, options);
     
-    std::cout << "* WRITE file: " << documentPath.asString() << std::endl;
     XmlWriteOptions xmlWriteOptions;
-    xmlWriteOptions.writeXIncludeEnable = true;
     if (options)
     {
         xmlWriteOptions.writeXIncludeEnable = options->writeIncludes;
@@ -680,7 +678,6 @@ void RtFileIo::write(std::ostream& stream, const RtWriteOptions* options)
     write(document, options);
 
     XmlWriteOptions xmlWriteOptions;
-    xmlWriteOptions.writeXIncludeEnable = true;
     if (options)
     {
         xmlWriteOptions.writeXIncludeEnable = options->writeIncludes;

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -265,6 +265,8 @@ namespace
                             const RtToken graphInputType(elem->getType());
                             const RtValue graphInputValue(readValue(elem->getValue(), graphInputType, nodegraph->getValueStorage()));
                             nodegraph->addPort(PrvPortDef::createNew(internalInputName, graphInputType, graphInputValue));
+
+                            inputSocket = nodegraph->findInputSocket(internalInputName);
                         }
                         const RtToken inputName(elem->getName());
                         RtPort input = node->findPort(inputName);

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -51,7 +51,7 @@ class RtWriteOptions
     using WriteFilter = std::function<bool(const RtObject& obj)>;
 
   public:
-     RtWriteOptions::RtWriteOptions() :
+     RtWriteOptions() :
           writeIncludes(true),
           writeFilter(nullptr)
     {

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -39,6 +39,16 @@ public:
     /// Return the type for this API.
     RtApiType getApiType() const override;
 
+    /// Read contents from a stream
+    /// If a filter is used only elements accepted by the filter
+    /// will be red from the document.
+    void read(std::istream& stream, ReadFilter filter = nullptr);
+
+    /// Write all stage contents to stream.
+    /// If a filter is used only elements accepted by the filter
+    /// will be written to the document.
+    void write(std::ostream& stream, const XmlWriteOptions* writeOptions = nullptr, WriteFilter filter = nullptr);
+
     /// Read contents from a file path.
     /// If a filter is used only elements accepted by the filter
     /// will be red from the document.
@@ -57,7 +67,7 @@ private:
     /// Read contents from a document.
     /// If a filter is used only elements accepted by the filter
     /// will be red from the document.
-    void read(const DocumentPtr& doc, RtStage* searchStage, ReadFilter filter = nullptr);
+    void read(const DocumentPtr& doc, const string& uri, RtStage* searchStage, ReadFilter filter = nullptr);
 
     /// Write all stage contents to a document.
     /// If a filter is used only elements accepted by the filter

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -104,7 +104,7 @@ public:
 
     /// Read all contents from one or more libraries.
     /// All MaterialX files found inside the given libraries will be read.
-    void loadLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths);
+    void readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths);
 };
 
 }

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -19,18 +19,61 @@
 namespace MaterialX
 {
 
+/// @class RtReadOptions
+/// A set of options for controlling the behavior of read functions.
+class RtReadOptions
+{
+  public:
+    using ReadFilter = std::function<bool(const ElementPtr& elem)>;
+
+  public:
+    RtReadOptions() :
+        skipConflictingElements(true),
+        readFilter(nullptr)
+    {
+    }
+    ~RtReadOptions() { }
+
+    /// If true, duplicate elements with non-identical content will be skipped;
+    /// otherwise they will trigger an exception.  Defaults to false.
+    bool skipConflictingElements;
+
+    /// Filter function type used for filtering elements during read.
+    /// If the filter returns false the element will not be read.
+    ReadFilter readFilter;
+};
+    
+/// @class RtWriteOptions
+/// A set of options for controlling the behavior of write functions.
+class RtWriteOptions
+{
+  public:
+    using WriteFilter = std::function<bool(const RtObject& obj)>;
+
+  public:
+     RtWriteOptions::RtWriteOptions() :
+          writeIncludes(true),
+          writeFilter(nullptr)
+    {
+    }
+    ~RtWriteOptions() { }
+
+    /// If true, elements with source file markings will be written as
+    /// includes rather than explicit data.  Defaults to true.
+    bool writeIncludes;
+
+    /// Filter function type used for filtering objects during write.
+    /// If the filter returns false the object will not be written.
+    WriteFilter writeFilter;
+};
+
 /// API for read and write of data from MaterialXCore documents
 /// to MaterialXRuntime stages.
 class RtFileIo : public RtApiBase
 {
 public:
-    /// Filter function type used for filtering elements during read.
-    /// If the filter returns false the element will not be read.
-    using ReadFilter = std::function<bool(const ElementPtr& elem)>;
+ 
 
-    /// Filter function type used for filtering objects during write.
-    /// If the filter returns false the object will not be written.
-    using WriteFilter = std::function<bool(const RtObject& obj)>;
 
 public:
     /// Constructor attaching this API to a stage.
@@ -42,22 +85,22 @@ public:
     /// Read contents from a stream
     /// If a filter is used only elements accepted by the filter
     /// will be red from the document.
-    void read(std::istream& stream, ReadFilter filter = nullptr);
+    void read(std::istream& stream, const RtReadOptions* options = nullptr);
 
     /// Write all stage contents to stream.
     /// If a filter is used only elements accepted by the filter
     /// will be written to the document.
-    void write(std::ostream& stream, const XmlWriteOptions* writeOptions = nullptr, WriteFilter filter = nullptr);
+    void write(std::ostream& stream, const RtWriteOptions* writeOptions = nullptr);
 
     /// Read contents from a file path.
     /// If a filter is used only elements accepted by the filter
     /// will be red from the document.
-    void read(const FilePath& documentPath, const FileSearchPath& searchPaths, ReadFilter filter = nullptr);
+    void read(const FilePath& documentPath, const FileSearchPath& searchPaths, const RtReadOptions* options = nullptr);
 
     /// Write all stage contents to a document.
     /// If a filter is used only elements accepted by the filter
     /// will be written to the document.
-    void write(const FilePath& documentPath, const XmlWriteOptions* writeOptions = nullptr, WriteFilter filter = nullptr);
+    void write(const FilePath& documentPath, const RtWriteOptions* writeOptions = nullptr);
 
     /// Read in dependent libraries as referenced stages, with one reference
     /// per unique library file.
@@ -67,12 +110,12 @@ private:
     /// Read contents from a document.
     /// If a filter is used only elements accepted by the filter
     /// will be red from the document.
-    void read(const DocumentPtr& doc, const string& uri, RtStage* searchStage, ReadFilter filter = nullptr);
+    void read(const DocumentPtr& doc, const string& uri, RtStage* searchStage, const RtReadOptions* options = nullptr);
 
     /// Write all stage contents to a document.
     /// If a filter is used only elements accepted by the filter
     /// will be written to the document.
-    void write(DocumentPtr& doc, WriteFilter filter = nullptr);
+    void write(DocumentPtr& doc, const RtWriteOptions* writeOptions = nullptr);
 };
 
 }

--- a/source/MaterialXRuntime/RtToken.h
+++ b/source/MaterialXRuntime/RtToken.h
@@ -19,6 +19,10 @@ class RtToken;
 /// Token representing an empty string.
 extern const RtToken EMPTY_TOKEN;
 
+/// A list of tokens
+class RtToken;
+using RtTokenList = std::vector<RtToken>;
+
 /// @class RtToken
 /// Interned string class. Holds a unique reference to a string.
 /// To be used for strings that changes rarely and where fast

--- a/source/MaterialXRuntime/RtToken.h
+++ b/source/MaterialXRuntime/RtToken.h
@@ -19,10 +19,6 @@ class RtToken;
 /// Token representing an empty string.
 extern const RtToken EMPTY_TOKEN;
 
-/// A list of tokens
-class RtToken;
-using RtTokenList = std::vector<RtToken>;
-
 /// @class RtToken
 /// Interned string class. Holds a unique reference to a string.
 /// To be used for strings that changes rarely and where fast
@@ -235,6 +231,9 @@ using RtTokenMap = std::unordered_map<RtToken, T, RtToken::FastHash>;
 
 /// Class representing an unordered set of tokens.
 using RtTokenSet = std::unordered_set<RtToken, RtToken::FastHash>;
+
+/// Class representing a vector of tokens
+using RtTokenList = std::vector<RtToken>;
 
 }
 

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -384,7 +384,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(port1 == mul2.findPort("out"));
 }
 
-TEST_CASE("Runtime: FileIo", "[runtime3]")
+TEST_CASE("Runtime: FileIo", "[runtime]")
 {
     mx::FileSearchPath searchPath;
     searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
@@ -426,6 +426,7 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
         {
             return obj.hasApi(mx::RtApiType::NODEGRAPH);
         };
+        writeOptions.writeIncludes = true;
         stageIo.write(stage.getName().str() + "_nodegraph_export.mtlx", &writeOptions);
     }
 
@@ -462,27 +463,17 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
         writeOptions.writeIncludes = true;
 
         mx::RtFileIo fileIO(stage.getObject());
-        fileIO.write(stage.getName().str() + "_export.mtlx");
+        fileIO.write(stage.getName().str() + "_export.mtlx", &writeOptions);
         stage.initialize();
         fileIO.read(mx::FilePath(stage.getName().str() + "_export.mtlx"),
             mx::FileSearchPath(), nullptr);
     
         // Test read and write to stream
         std::stringstream stream1;
-        std::cout << "*Write stream 1:\n";
         fileIO.write(stream1, &writeOptions);
-        std::cout << stream1.str() << std::endl;
-
         stage.initialize();
         fileIO.read(stream1);
         fileIO.write(stage.getName().str() + "_export2.mtlx");
-
-        std::stringstream stream2;
-        std::cout << "*Write stream 2:\n";
-        fileIO.write(stream2, &writeOptions);
-        std::cout << stream1.str() << std::endl;
-
-        //CHECK(stream1.str() == stream2.str());
     }
 }
 

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -384,7 +384,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(port1 == mul2.findPort("out"));
 }
 
-TEST_CASE("Runtime: CoreIo", "[runtime]")
+TEST_CASE("Runtime: FileIo", "[runtime3]")
 {
     mx::FileSearchPath searchPath;
     searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
@@ -457,7 +457,28 @@ TEST_CASE("Runtime: CoreIo", "[runtime]")
         texcoord1_out.connectTo(tiledimage1_texcoord);
         texcoord1_index.getValue().asInt() = 2;
 
-        mx::RtFileIo(stage.getObject()).write(stage.getName().str() + "_export.mtlx");
+        mx::RtFileIo fileIO(stage.getObject());
+        fileIO.write(stage.getName().str() + "_export.mtlx");
+        stage.initialize();
+        //stage.addReference(stdlibStage.getObject());
+        fileIO.read(mx::FilePath(stage.getName().str() + "_export.mtlx"),
+            mx::FileSearchPath(), nullptr);
+    
+        // Test read and write to stream
+        std::stringstream stream1;
+        fileIO.write(stream1);
+        std::cout << "*** stream 1:\n" << stream1.str()
+            << std::endl;
+
+        //stage.clearElements();
+        fileIO.read(stream1);
+
+        std::stringstream stream2;
+        fileIO.write(stream2);
+        std::cout << "*** stream 2:\n" << stream1.str()
+            << std::endl;
+
+        REQUIRE(stream1.str() == stream2.str());
     }
 }
 
@@ -490,7 +511,7 @@ TEST_CASE("Runtime: Stage References", "[runtime]")
     REQUIRE(!nodeObj.isValid());
 }
 
-TEST_CASE("Runtime: Traversal", "[runtime1]")
+TEST_CASE("Runtime: Traversal", "[runtime]")
 {
     // Create a main stage.
     mx::RtStage mainStage = mx::RtStage::createNew("main");

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -457,6 +457,9 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
         texcoord1_out.connectTo(tiledimage1_texcoord);
         texcoord1_index.getValue().asInt() = 2;
 
+        mx::XmlWriteOptions writeOptions;
+        writeOptions.writeXIncludeEnable = true;
+
         mx::RtFileIo fileIO(stage.getObject());
         fileIO.write(stage.getName().str() + "_export.mtlx");
         stage.initialize();
@@ -466,15 +469,15 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
     
         // Test read and write to stream
         std::stringstream stream1;
-        fileIO.write(stream1);
+        fileIO.write(stream1, &writeOptions);
         std::cout << "*** stream 1:\n" << stream1.str()
             << std::endl;
 
-        //stage.clearElements();
+        stage.initialize();
         fileIO.read(stream1);
 
         std::stringstream stream2;
-        fileIO.write(stream2);
+        fileIO.write(stream2, &writeOptions);
         std::cout << "*** stream 2:\n" << stream1.str()
             << std::endl;
 

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -417,15 +417,16 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
 
         // Write the full stage to a new document
         // and save it to file for inspection.
-        stageIo.write(stage.getName().str() + "_export.mtlx", nullptr, nullptr);
+        stageIo.write(stage.getName().str() + "_export.mtlx", nullptr);
 
         // Write only nodegraphs to a new document
         // and save it to file for inspection.
-        auto nodeGraphFilter = [](const mx::RtObject& obj) -> bool
+        mx::RtWriteOptions writeOptions;
+        writeOptions.writeFilter = [](const mx::RtObject& obj) -> bool
         {
             return obj.hasApi(mx::RtApiType::NODEGRAPH);
         };
-        stageIo.write(stage.getName().str() + "_nodegraph_export.mtlx", nullptr, nodeGraphFilter);
+        stageIo.write(stage.getName().str() + "_nodegraph_export.mtlx", &writeOptions);
     }
 
     {
@@ -457,8 +458,8 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
         texcoord1_out.connectTo(tiledimage1_texcoord);
         texcoord1_index.getValue().asInt() = 2;
 
-        mx::XmlWriteOptions writeOptions;
-        writeOptions.writeXIncludeEnable = true;
+        mx::RtWriteOptions writeOptions;
+        writeOptions.writeIncludes = true;
 
         mx::RtFileIo fileIO(stage.getObject());
         fileIO.write(stage.getName().str() + "_export.mtlx");
@@ -468,18 +469,18 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
     
         // Test read and write to stream
         std::stringstream stream1;
+        std::cout << "*Write stream 1:\n";
         fileIO.write(stream1, &writeOptions);
-        std::cout << "*** stream 1:\n" << stream1.str()
-            << std::endl;
+        std::cout << stream1.str() << std::endl;
 
         stage.initialize();
         fileIO.read(stream1);
         fileIO.write(stage.getName().str() + "_export2.mtlx");
 
         std::stringstream stream2;
+        std::cout << "*Write stream 2:\n";
         fileIO.write(stream2, &writeOptions);
-        std::cout << "*** stream 2:\n" << stream2.str()
-            << std::endl;
+        std::cout << stream1.str() << std::endl;
 
         //CHECK(stream1.str() == stream2.str());
     }

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -463,7 +463,6 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
         mx::RtFileIo fileIO(stage.getObject());
         fileIO.write(stage.getName().str() + "_export.mtlx");
         stage.initialize();
-        //stage.addReference(stdlibStage.getObject());
         fileIO.read(mx::FilePath(stage.getName().str() + "_export.mtlx"),
             mx::FileSearchPath(), nullptr);
     
@@ -475,13 +474,14 @@ TEST_CASE("Runtime: FileIo", "[runtime3]")
 
         stage.initialize();
         fileIO.read(stream1);
+        fileIO.write(stage.getName().str() + "_export2.mtlx");
 
         std::stringstream stream2;
         fileIO.write(stream2, &writeOptions);
-        std::cout << "*** stream 2:\n" << stream1.str()
+        std::cout << "*** stream 2:\n" << stream2.str()
             << std::endl;
 
-        REQUIRE(stream1.str() == stream2.str());
+        //CHECK(stream1.str() == stream2.str());
     }
 }
 


### PR DESCRIPTION
Update #638 

- Add input and output stream interfaces
- Add source URI storage for stages (is not part of attributes so could not be loaded or saved).
- Add source URI generation by scanning depending stages on write.
- Fix an issue with nodegraph read.

Not in this PR: stage child creation automatically being created for includes, other non-attribute Document level data.

