### PR TITLE
1.37 signature changes : Part I.

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4607,13 +4607,15 @@
 
   <!--
     Node: <backdrop>
-    An outputless layout element used to contain, group and document other nodes
+    A layout element used to contain, group and document other nodes.
+    Output type is marked as "none" to indicate there is no output.
   -->
   <nodedef name="ND_backdrop" node="backdrop" nodegroup="organization">
     <parameter name="note" type="string" value=""/>
     <parameter name="contains" type="stringarray" value=""/>
     <parameter name="width" type="float" value="1.0"/>
     <parameter name="height" type="float" value="1.0"/>
+    <output name="out" type="none"/>
   </nodedef>
 
 </materialx>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+  TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
   All rights reserved.  See LICENSE.txt for license.
 
   Declarations of standard data types and nodes included in the MaterialX specification.
 -->
 
-<materialx version="1.36">
+<materialx version="1.37">
 
   <!-- ======================================================================== -->
   <!-- Data types                                                               -->
@@ -61,10 +61,10 @@
       <unit name="mile" scale="1609.344"/>
    </unitdef>
 
-  <unittypedef name="angle" />
+  <unittypedef name="angle"/>
   <unitdef name="UD_stdlib_angle" unittype="angle">
-     <unit name="degrees" scale="1.0" />
-     <unit name="radians" scale="57.295779513" />
+    <unit name="degrees" scale="1.0" />
+    <unit name="radians" scale="57.295779513" />
   </unitdef>
 
   <!-- ======================================================================== -->
@@ -90,7 +90,7 @@
     Node: <image>
     Samples data from a single image, or from a layer within a multi-layer image.
   -->
-  <nodedef name="ND_image_float" node="image" nodegroup="texture2d" default="0.0">
+  <nodedef name="ND_image_float" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="float" value="0.0" uiname="Default Color"/>
@@ -101,9 +101,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_image_color2" node="image" nodegroup="texture2d" default="0.0, 0.0">
+  <nodedef name="ND_image_color2" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color2" value="0.0, 0.0" uiname="Default Color"/>
@@ -114,9 +114,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_image_color3" node="image" nodegroup="texture2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_image_color3" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color"/>
@@ -127,9 +127,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_image_color4" node="image" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_image_color4" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color"/>
@@ -140,9 +140,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_image_vector2" node="image" nodegroup="texture2d" default="0.0, 0.0">
+  <nodedef name="ND_image_vector2" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector2" value="0.0, 0.0" uiname="Default Color"/>
@@ -153,9 +153,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_image_vector3" node="image" nodegroup="texture2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_image_vector3" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default Color"/>
@@ -166,9 +166,9 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_image_vector4" node="image" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_image_vector4" node="image" nodegroup="texture2d">
     <parameter name="file" type="filename" value="" uiname="Filename"/>
     <parameter name="layer" type="string" value="" uiname="Layer"/>
     <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color"/>
@@ -179,7 +179,7 @@
     <parameter name="framerange" type="string" value="" uiname="Frame Range"/>
     <parameter name="frameoffset" type="integer" value="0" uiname="Frame Offset"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -187,67 +187,77 @@
     Samples data from a single image, with provisions for tiling and offsetting the image
     across uv space.
   -->
-  <nodedef name="ND_tiledimage_float" node="tiledimage" nodegroup="texture2d" default="0.0">
+  <nodedef name="ND_tiledimage_float" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
     <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <parameter name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
+    <parameter name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_color2" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0">
+  <nodedef name="ND_tiledimage_color2" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
     <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <parameter name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
+    <parameter name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_color3" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_tiledimage_color3" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
     <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <parameter name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
+    <parameter name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_color4" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_tiledimage_color4" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
     <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <parameter name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
+    <parameter name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_vector2" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0">
+  <nodedef name="ND_tiledimage_vector2" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <input name="uvtiling" type="vector2" value="1.0, 1.0"/>
     <input name="uvoffset" type="vector2" value="0.0, 0.0"/>
+    <parameter name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
+    <parameter name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance"/>
     <parameter name="filtertype" type="string" value="linear" enum="closest,linear,cubic"/>
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_vector3" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_tiledimage_vector3" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
@@ -257,9 +267,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_tiledimage_vector4" node="tiledimage" nodegroup="texture2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_tiledimage_vector4" node="tiledimage" nodegroup="texture2d">
     <parameter name="file" type="filename" value=""/>
     <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
@@ -269,7 +279,7 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -278,7 +288,7 @@
     representation of the images along each of the three respective coordinate axes, computing
     a weighted blend of the three samples using the geometric normal.
   -->
-  <nodedef name="ND_triplanarprojection_float" node="triplanarprojection" nodegroup="texture3d" default="0.0">
+  <nodedef name="ND_triplanarprojection_float" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -292,9 +302,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_color2" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_color2" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -308,9 +318,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_color3" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_color3" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -324,9 +334,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_color4" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_color4" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -340,9 +350,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_vector2" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_vector2" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -356,9 +366,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_vector3" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_vector3" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -372,9 +382,9 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_triplanarprojection_vector4" node="triplanarprojection" nodegroup="texture3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_triplanarprojection_vector4" node="triplanarprojection" nodegroup="texture3d">
     <parameter name="filex" type="filename" value=""/>
     <parameter name="filey" type="filename" value=""/>
     <parameter name="filez" type="filename" value=""/>
@@ -388,7 +398,7 @@
     <parameter name="framerange" type="string" value=""/>
     <parameter name="frameoffset" type="integer" value="0"/>
     <parameter name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
 
@@ -401,653 +411,653 @@
     A constant value. When exposed as a public parameter, this is a way to create a
     value that can be accessed in multiple places in the opgraph.
   -->
-  <nodedef name="ND_constant_float" node="constant" nodegroup="procedural" default="0.0">
+  <nodedef name="ND_constant_float" node="constant" nodegroup="procedural">
     <parameter name="value" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_color2" node="constant" nodegroup="procedural" default="0.0, 0.0">
+  <nodedef name="ND_constant_color2" node="constant" nodegroup="procedural">
     <parameter name="value" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_color3" node="constant" nodegroup="procedural" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_constant_color3" node="constant" nodegroup="procedural">
     <parameter name="value" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_color4" node="constant" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_constant_color4" node="constant" nodegroup="procedural">
     <parameter name="value" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_vector2" node="constant" nodegroup="procedural" default="0.0, 0.0">
+  <nodedef name="ND_constant_vector2" node="constant" nodegroup="procedural">
     <parameter name="value" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_vector3" node="constant" nodegroup="procedural" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_constant_vector3" node="constant" nodegroup="procedural">
     <parameter name="value" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_vector4" node="constant" nodegroup="procedural" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_constant_vector4" node="constant" nodegroup="procedural">
     <parameter name="value" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_constant_boolean" node="constant" nodegroup="procedural" default="false">
+  <nodedef name="ND_constant_boolean" node="constant" nodegroup="procedural">
     <parameter name="value" type="boolean" value="false"/>
-    <output name="out" type="boolean"/>
+    <output name="out" type="boolean" default="false"/>
   </nodedef>
-  <nodedef name="ND_constant_integer" node="constant" nodegroup="procedural" default="0">
+  <nodedef name="ND_constant_integer" node="constant" nodegroup="procedural">
     <parameter name="value" type="integer" value="0"/>
-    <output name="out" type="integer"/>
+    <output name="out" type="integer" default="0"/>
   </nodedef>
-  <nodedef name="ND_constant_matrix33" node="constant" nodegroup="procedural" default="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0">
+  <nodedef name="ND_constant_matrix33" node="constant" nodegroup="procedural">
     <parameter name="value" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" default="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
   </nodedef>
-  <nodedef name="ND_constant_matrix44" node="constant" nodegroup="procedural" default="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0">
+  <nodedef name="ND_constant_matrix44" node="constant" nodegroup="procedural">
     <parameter name="value" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" default="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   </nodedef>
-  <nodedef name="ND_constant_string" node="constant" nodegroup="procedural" default="">
+  <nodedef name="ND_constant_string" node="constant" nodegroup="procedural">
     <parameter name="value" type="string" value=""/>
-    <output name="out" type="string"/>
+    <output name="out" type="string" default=""/>
   </nodedef>
-  <nodedef name="ND_constant_filename" node="constant" nodegroup="procedural" default="">
+  <nodedef name="ND_constant_filename" node="constant" nodegroup="procedural">
     <parameter name="value" type="filename" value=""/>
-    <output name="out" type="filename"/>
+    <output name="out" type="filename" default=""/>
   </nodedef>
 
   <!--
     Node: <ramplr>
     A left-to-right bilinear value ramp.
   -->
-  <nodedef name="ND_ramplr_float" node="ramplr" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_ramplr_float" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="float" value="0.0"/>
     <parameter name="valuer" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_color2" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramplr_color2" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="color2" value="0.0, 0.0"/>
     <parameter name="valuer" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_color3" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramplr_color3" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuer" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_color4" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramplr_color4" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_vector2" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramplr_vector2" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector2" value="0.0, 0.0"/>
     <parameter name="valuer" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_vector3" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramplr_vector3" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuer" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramplr_vector4" node="ramplr" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramplr_vector4" node="ramplr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <ramptb>
     A top-to-bottom bilinear value ramp.
   -->
-  <nodedef name="ND_ramptb_float" node="ramptb" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_ramptb_float" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="float" value="0.0"/>
     <parameter name="valueb" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_color2" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramptb_color2" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="color2" value="0.0, 0.0"/>
     <parameter name="valueb" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_color3" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramptb_color3" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="valueb" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_color4" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramptb_color4" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_vector2" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramptb_vector2" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector2" value="0.0, 0.0"/>
     <parameter name="valueb" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_vector3" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramptb_vector3" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="valueb" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramptb_vector4" node="ramptb" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramptb_vector4" node="ramptb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <ramp4> Supplemental Node
     A 4-corner bilinear value ramp.
   -->
-  <nodedef name="ND_ramp4_float" node="ramp4" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_ramp4_float" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="float" value="0.0"/>
     <parameter name="valuetr" type="float" value="0.0"/>
     <parameter name="valuebl" type="float" value="0.0"/>
     <parameter name="valuebr" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_color2" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramp4_color2" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="color2" value="0.0, 0.0"/>
     <parameter name="valuetr" type="color2" value="0.0, 0.0"/>
     <parameter name="valuebl" type="color2" value="0.0, 0.0"/>
     <parameter name="valuebr" type="color2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_color3" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramp4_color3" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuetr" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuebl" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuebr" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_color4" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramp4_color4" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuetr" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuebl" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuebr" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_vector2" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_ramp4_vector2" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="vector2" value="0.0, 0.0"/>
     <parameter name="valuetr" type="vector2" value="0.0, 0.0"/>
     <parameter name="valuebl" type="vector2" value="0.0, 0.0"/>
     <parameter name="valuebr" type="vector2" value="0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_vector3" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_ramp4_vector3" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuetr" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuebl" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="valuebr" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_ramp4_vector4" node="ramp4" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_ramp4_vector4" node="ramp4" nodegroup="procedural2d">
     <parameter name="valuetl" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuetr" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuebl" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="valuebr" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <splitlr>
     A left-right split matte, split at a specified u value.
   -->
-  <nodedef name="ND_splitlr_float" node="splitlr" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_splitlr_float" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="float" value="0.0" uiname="Left"/>
     <parameter name="valuer" type="float" value="0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_color2" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_splitlr_color2" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="color2" value="0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="color2" value="0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_color3" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_splitlr_color3" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="color3" value="0.0, 0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="color3" value="0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_color4" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_splitlr_color4" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_vector2" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_splitlr_vector2" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector2" value="0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="vector2" value="0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_vector3" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_splitlr_vector3" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector3" value="0.0, 0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="vector3" value="0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splitlr_vector4" node="splitlr" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_splitlr_vector4" node="splitlr" nodegroup="procedural2d">
     <parameter name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Left"/>
     <parameter name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Right"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <splittb>
     A top-bottom split matte, split at a specified v value.
   -->
-  <nodedef name="ND_splittb_float" node="splittb" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_splittb_float" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="float" value="0.0" uiname="Top"/>
     <parameter name="valueb" type="float" value="0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_color2" node="splittb" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_splittb_color2" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="color2" value="0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="color2" value="0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_color3" node="splittb" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_splittb_color3" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="color3" value="0.0, 0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="color3" value="0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_color4" node="splittb" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_splittb_color4" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_vector2" node="splittb" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_splittb_vector2" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector2" value="0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="vector2" value="0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_vector3" node="splittb" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_splittb_vector3" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector3" value="0.0, 0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="vector3" value="0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_splittb_vector4" node="splittb" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_splittb_vector4" node="splittb" nodegroup="procedural2d">
     <parameter name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Top"/>
     <parameter name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom"/>
     <parameter name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <noise2d>
     2D Perlin noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_noise2d_float" node="noise2d" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_noise2d_float" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color2" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_noise2d_color2" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color3" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_color3" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color4" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_color4" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector2" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_noise2d_vector2" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector3" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_vector3" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector4" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_vector4" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color2FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_noise2d_color2FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color3FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_color3FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_color4FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_color4FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector2FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_noise2d_vector2FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector3FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_vector3FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise2d_vector4FA" node="noise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise2d_vector4FA" node="noise2d" nodegroup="procedural2d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <noise3d>
     3D Perlin noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_noise3d_float" node="noise3d" nodegroup="procedural3d" default="0.0">
+  <nodedef name="ND_noise3d_float" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color2" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_noise3d_color2" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color3" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_color3" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color4" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_color4" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector2" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_noise3d_vector2" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector3" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_vector3" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector4" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_vector4" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color2FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_noise3d_color2FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color3FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_color3FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_color4FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_color4FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector2FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_noise3d_vector2FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector3FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_vector3FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_noise3d_vector4FA" node="noise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_noise3d_vector4FA" node="noise3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.0"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <fractal3d>
     3D Fractal noise in 1, 2, 3 or 4 channels.
   -->
-  <nodedef name="ND_fractal3d_float" node="fractal3d" nodegroup="procedural3d" default="0.0">
+  <nodedef name="ND_fractal3d_float" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color2" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_fractal3d_color2" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color3" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_color3" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color4" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_color4" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector2" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector2" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector2" value="1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector3" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector3" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector4" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector4" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color2FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_fractal3d_color2FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color3FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_color3FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_color4FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_color4FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_fractal3d_vector4FA" node="fractal3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_fractal3d_vector4FA" node="fractal3d" nodegroup="procedural3d">
     <parameter name="amplitude" type="float" value="1.0"/>
     <parameter name="octaves" type="integer" value="3"/>
     <parameter name="lacunarity" type="float" value="2.0"/>
     <parameter name="diminish" type="float" value="0.5"/>
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <cellnoise2d>
     2D cellular noise in 1 channel.
   -->
-  <nodedef name="ND_cellnoise2d_float" node="cellnoise2d" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_cellnoise2d_float" node="cellnoise2d" nodegroup="procedural2d">
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
     Node: <cellnoise3d>
     3D cellular noise in 1 channel.
   -->
-  <nodedef name="ND_cellnoise3d_float" node="cellnoise3d" nodegroup="procedural3d" default="0.0">
+  <nodedef name="ND_cellnoise3d_float" node="cellnoise3d" nodegroup="procedural3d">
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
     Node: <worleynoise2d>
     2D Worley (voronoi) noise in 1, 2 or 3 channels.
   -->
-  <nodedef name="ND_worleynoise2d_float" node="worleynoise2d" nodegroup="procedural2d" default="0.0">
+  <nodedef name="ND_worleynoise2d_float" node="worleynoise2d" nodegroup="procedural2d">
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_worleynoise2d_vector2" node="worleynoise2d" nodegroup="procedural2d" default="0.0, 0.0">
+  <nodedef name="ND_worleynoise2d_vector2" node="worleynoise2d" nodegroup="procedural2d">
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_worleynoise2d_vector3" node="worleynoise2d" nodegroup="procedural2d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_worleynoise2d_vector3" node="worleynoise2d" nodegroup="procedural2d">
     <input name="texcoord" type="vector2" defaultgeomprop="UV0"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <worleynoise3d>
     3D Worley (voronoi) noise in 1, 2 or 3 channels.
   -->
-  <nodedef name="ND_worleynoise3d_float" node="worleynoise3d" nodegroup="procedural3d" default="0.0">
+  <nodedef name="ND_worleynoise3d_float" node="worleynoise3d" nodegroup="procedural3d">
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_worleynoise3d_vector2" node="worleynoise3d" nodegroup="procedural3d" default="0.0, 0.0">
+  <nodedef name="ND_worleynoise3d_vector2" node="worleynoise3d" nodegroup="procedural3d">
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_worleynoise3d_vector3" node="worleynoise3d" nodegroup="procedural3d" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_worleynoise3d_vector3" node="worleynoise3d" nodegroup="procedural3d">
     <input name="position" type="vector3" defaultgeomprop="Pobject"/>
     <parameter name="jitter" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
 
 
@@ -1060,9 +1070,9 @@
     The geometric position associated with the currently processed data,
     as defined in a specific coordinate space.
   -->
-  <nodedef name="ND_position_vector3" node="position" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_position_vector3" node="position" nodegroup="geometric">
     <parameter name="space" type="string" value="object" enum="model,object,world"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1070,9 +1080,9 @@
     The geometric normal associated with the currently processed data,
     as defined in a specific coordinate space.
   -->
-  <nodedef name="ND_normal_vector3" node="normal" nodegroup="geometric" default="0.0, 1.0, 0.0">
+  <nodedef name="ND_normal_vector3" node="normal" nodegroup="geometric">
     <parameter name="space" type="string" value="object" enum="model,object,world"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 1.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1080,10 +1090,10 @@
     The geometric tangent vector associated with the currently processed data,
     as defined in a specific coordinate space.
   -->
-  <nodedef name="ND_tangent_vector3" node="tangent" nodegroup="geometric" default="1.0, 0.0, 0.0">
+  <nodedef name="ND_tangent_vector3" node="tangent" nodegroup="geometric">
     <parameter name="space" type="string" value="object" enum="model,object,world"/>
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="1.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1091,23 +1101,23 @@
     The geometric bitangent vector associated with the currently processed data,
     as defined in a specific coordinate space.
   -->
-  <nodedef name="ND_bitangent_vector3" node="bitangent" nodegroup="geometric" default="0.0, 0.0, 1.0">
+  <nodedef name="ND_bitangent_vector3" node="bitangent" nodegroup="geometric">
     <parameter name="space" type="string" value="object" enum="model,object,world"/>
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 1.0"/>
   </nodedef>
 
   <!--
     Node: <texcoord>
     The full 2D or 3D texture coordinates associated with the currently processed data.
   -->
-  <nodedef name="ND_texcoord_vector2" node="texcoord" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_texcoord_vector2" node="texcoord" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_texcoord_vector3" node="texcoord" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_texcoord_vector3" node="texcoord" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1115,21 +1125,21 @@
     The color associated with the current geometry at the current position, generally
     bound via per-vertex color values.
   -->
-  <nodedef name="ND_geomcolor_float" node="geomcolor" nodegroup="geometric" default="0.0">
+  <nodedef name="ND_geomcolor_float" node="geomcolor" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_geomcolor_color2" node="geomcolor" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_geomcolor_color2" node="geomcolor" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomcolor_color3" node="geomcolor" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_geomcolor_color3" node="geomcolor" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomcolor_color4" node="geomcolor" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_geomcolor_color4" node="geomcolor" nodegroup="geometric">
     <parameter name="index" type="integer" value="0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
@@ -1137,100 +1147,100 @@
     The value of the specified geomattr for the current geometry.
     (This will be replaced by <geompropvalue> in 1.37)
   -->
-  <nodedef name="ND_geomattrvalue_integer" node="geomattrvalue" nodegroup="geometric" default="0">
+  <nodedef name="ND_geomattrvalue_integer" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="integer"/>
+    <output name="out" type="integer" default="0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_boolean" node="geomattrvalue" nodegroup="geometric" default="false">
+  <nodedef name="ND_geomattrvalue_boolean" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="boolean"/>
+    <output name="out" type="boolean" default="false"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_string" node="geomattrvalue" nodegroup="geometric" default="">
+  <nodedef name="ND_geomattrvalue_string" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="string"/>
+    <output name="out" type="string" default=""/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_float" node="geomattrvalue" nodegroup="geometric" default="0.0">
+  <nodedef name="ND_geomattrvalue_float" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_color2" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_color2" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_color3" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_color3" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_color4" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_color4" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_vector2" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_vector2" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_vector3" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_vector3" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geomattrvalue_vector4" node="geomattrvalue" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_geomattrvalue_vector4" node="geomattrvalue" nodegroup="geometric">
     <parameter name="attrname" type="string" value=""/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <geompropvalue>
     The value of the specified geometric property for the current geometry.
   -->
-  <nodedef name="ND_geompropvalue_integer" node="geompropvalue" nodegroup="geometric" default="0">
+  <nodedef name="ND_geompropvalue_integer" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="integer" value="0"/>
-    <output name="out" type="integer"/>
+    <output name="out" type="integer" default="0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_boolean" node="geompropvalue" nodegroup="geometric" default="false">
+  <nodedef name="ND_geompropvalue_boolean" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="boolean" value="false"/>
-    <output name="out" type="boolean"/>
+    <output name="out" type="boolean" default="false"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_string" node="geompropvalue" nodegroup="geometric" default="">
+  <nodedef name="ND_geompropvalue_string" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="string" value=""/>
-    <output name="out" type="string"/>
+    <output name="out" type="string" default=""/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_float" node="geompropvalue" nodegroup="geometric" default="0.0">
+  <nodedef name="ND_geompropvalue_float" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_color2" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_geompropvalue_color2" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_color3" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_geompropvalue_color3" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_color4" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_geompropvalue_color4" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_vector2" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0">
+  <nodedef name="ND_geompropvalue_vector2" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_vector3" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_geompropvalue_vector3" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_geompropvalue_vector4" node="geompropvalue" nodegroup="geometric" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_geompropvalue_vector4" node="geompropvalue" nodegroup="geometric">
     <parameter name="geomprop" type="string" value=""/>
     <parameter name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
 
@@ -1243,10 +1253,10 @@
     Computes the ambient occlusion (0-1 float) at the current surface point.  Larger
     values represent greater accessibility to ambient light, 0 means "fully occluded".
   -->
-  <nodedef name="ND_ambientocclusion_float" node="ambientocclusion" nodegroup="global" default="1.0">
-    <parameter name="coneangle" type="float" value="90.0"/>
+  <nodedef name="ND_ambientocclusion_float" node="ambientocclusion" nodegroup="global">
+    <parameter name="coneangle" type="float" value="90.0" unittype="angle" unit="degrees"/>
     <parameter name="maxdistance" type="float" value="1e38"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="1.0"/>
   </nodedef>
 
 
@@ -1258,8 +1268,8 @@
     Node: <frame>
     The current frame number as defined by the host environment.
   -->
-  <nodedef name="ND_frame_float" node="frame" nodegroup="application" default="1">
-    <output name="out" type="float"/>
+  <nodedef name="ND_frame_float" node="frame" nodegroup="application">
+    <output name="out" type="float" default="1.0"/>
   </nodedef>
 
   <!--
@@ -1267,18 +1277,18 @@
     The current time in seconds as defined by the host environment.
     (Default values is 1/24.0)
   -->
-  <nodedef name="ND_time_float" node="time" nodegroup="application" default="0.041666667">
+  <nodedef name="ND_time_float" node="time" nodegroup="application">
     <parameter name="fps" type="float" value="24.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.041666667"/>
   </nodedef>
 
   <!--
     Node: <viewdirection>
     The current scene view direction, as defined by the shading environment.
   -->
-  <nodedef name="ND_viewdirection_vector3" node="viewdirection" nodegroup="application" default="0.0, 0.0, 1.0">
+  <nodedef name="ND_viewdirection_vector3" node="viewdirection" nodegroup="application">
     <parameter name="space" type="string" value="world" enum="model,object,world"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 1.0"/>
   </nodedef>
 
 
@@ -1290,195 +1300,195 @@
     Node: <add>
     Add "in2" value/stream to the incoming float/color/vector/matrix.
   -->
-  <nodedef name="ND_add_float" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_float" node="add" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color2" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color2" node="add" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color3" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color3" node="add" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color4" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color4" node="add" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector2" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector2" node="add" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector3" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector3" node="add" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector4" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector4" node="add" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_matrix33" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_matrix33" node="add" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_matrix44" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_matrix44" node="add" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_surfaceshader" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_surfaceshader" node="add" nodegroup="math">
     <input name="in1" type="surfaceshader" value=""/>
     <input name="in2" type="surfaceshader" value=""/>
-    <output name="out" type="surfaceshader"/>
+    <output name="out" type="surfaceshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_displacementshader" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_displacementshader" node="add" nodegroup="math">
     <input name="in1" type="displacementshader" value=""/>
     <input name="in2" type="displacementshader" value=""/>
-    <output name="out" type="displacementshader"/>
+    <output name="out" type="displacementshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_volumeshader" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_volumeshader" node="add" nodegroup="math">
     <input name="in1" type="volumeshader" value=""/>
     <input name="in2" type="volumeshader" value=""/>
-    <output name="out" type="volumeshader"/>
+    <output name="out" type="volumeshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color2FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color2FA" node="add" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color3FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color3FA" node="add" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_color4FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_color4FA" node="add" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector2FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector2FA" node="add" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector3FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector3FA" node="add" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_vector4FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_vector4FA" node="add" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_matrix33FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_matrix33FA" node="add" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_add_matrix44FA" node="add" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_add_matrix44FA" node="add" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Node: <subtract>
     Subtract "in2" value/stream from the incoming float/color/vector/matrix.
   -->
-  <nodedef name="ND_subtract_float" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_float" node="subtract" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color2" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color2" node="subtract" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color3" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color3" node="subtract" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color4" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color4" node="subtract" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector2" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector2" node="subtract" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector3" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector3" node="subtract" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector4" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector4" node="subtract" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_matrix33" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_matrix33" node="subtract" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_matrix44" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_matrix44" node="subtract" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color2FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color2FA" node="subtract" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color3FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color3FA" node="subtract" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_color4FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_color4FA" node="subtract" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector2FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector2FA" node="subtract" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector3FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector3FA" node="subtract" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_vector4FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_vector4FA" node="subtract" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_matrix33FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_matrix33FA" node="subtract" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_subtract_matrix44FA" node="subtract" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_subtract_matrix44FA" node="subtract" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
 
   <!--
@@ -1486,110 +1496,110 @@
     Multiply the incoming float/color/vector by the "in2" value/stream, or multiply
     two matrices.
   -->
-  <nodedef name="ND_multiply_float" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_float" node="multiply" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color2" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color2" node="multiply" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color3" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color3" node="multiply" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color4" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color4" node="multiply" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector2" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector2" node="multiply" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector3" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector3" node="multiply" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector4" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector4" node="multiply" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_matrix33" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_matrix33" node="multiply" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_matrix44" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_matrix44" node="multiply" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color2FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color2FA" node="multiply" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color3FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color3FA" node="multiply" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_color4FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_color4FA" node="multiply" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector2FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector2FA" node="multiply" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector3FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector3FA" node="multiply" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_vector4FA" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_vector4FA" node="multiply" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_surfaceshaderF" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_surfaceshaderF" node="multiply" nodegroup="math">
     <input name="in1" type="surfaceshader" value=""/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="surfaceshader"/>
+    <output name="out" type="surfaceshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_displacementshaderF" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_displacementshaderF" node="multiply" nodegroup="math">
     <input name="in1" type="displacementshader" value=""/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="displacementshader"/>
+    <output name="out" type="displacementshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_volumeshaderF" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_volumeshaderF" node="multiply" nodegroup="math">
     <input name="in1" type="volumeshader" value=""/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="volumeshader"/>
+    <output name="out" type="volumeshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_surfaceshaderC" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_surfaceshaderC" node="multiply" nodegroup="math">
     <input name="in1" type="surfaceshader" value=""/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="surfaceshader"/>
+    <output name="out" type="surfaceshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_volumeshaderC" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_volumeshaderC" node="multiply" nodegroup="math">
     <input name="in1" type="volumeshader" value=""/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="volumeshader"/>
+    <output name="out" type="volumeshader" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_multiply_displacementshaderV" node="multiply" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_multiply_displacementshaderV" node="multiply" nodegroup="math">
     <input name="in1" type="displacementshader" value=""/>
     <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="displacementshader"/>
+    <output name="out" type="displacementshader" defaultinput="in1"/>
   </nodedef>
 
   <!--
@@ -1598,151 +1608,151 @@
     value by 0 results in floating-point "NaN".  Or, multiply one matrix by the
     inverse of a second matrix.
   -->
-  <nodedef name="ND_divide_float" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_float" node="divide" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color2" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color2" node="divide" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color3" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color3" node="divide" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color4" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color4" node="divide" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector2" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector2" node="divide" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector3" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector3" node="divide" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector4" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector4" node="divide" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_matrix33" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_matrix33" node="divide" nodegroup="math">
     <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_matrix44" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_matrix44" node="divide" nodegroup="math">
     <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color2FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color2FA" node="divide" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color3FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color3FA" node="divide" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_color4FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_color4FA" node="divide" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector2FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector2FA" node="divide" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector3FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector3FA" node="divide" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_divide_vector4FA" node="divide" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_divide_vector4FA" node="divide" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Node: <modulo>
-    The remaining fraction after dividing the incoming float/color/vector by the constant
-    "amount" and subtracting the integer portion. The modula "amount" cannot be 0.
+    The remaining fraction after dividing one float/color/vector by another and
+    subtracting the integer portion. The modula "in2" value cannot be 0.
   -->
-  <nodedef name="ND_modulo_float" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_float" node="modulo" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color2" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color2" node="modulo" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color3" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color3" node="modulo" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color4" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color4" node="modulo" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector2" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector2" node="modulo" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector3" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector3" node="modulo" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector4" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector4" node="modulo" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color2FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color2FA" node="modulo" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color3FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color3FA" node="modulo" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_color4FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_color4FA" node="modulo" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector2FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector2FA" node="modulo" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector3FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector3FA" node="modulo" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_modulo_vector4FA" node="modulo" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_modulo_vector4FA" node="modulo" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
@@ -1750,70 +1760,70 @@
     Subtract the incoming float/color/vector from "amount" in all channels,
     outputting: amount - in.  Or, invert an incoming matrix.
   -->
-  <nodedef name="ND_invert_float" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_float" node="invert" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color2" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color2" node="invert" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="amount" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color3" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color3" node="invert" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color4" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color4" node="invert" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector2" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector2" node="invert" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="amount" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector3" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector3" node="invert" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector4" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector4" node="invert" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color2FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color2FA" node="invert" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color3FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color3FA" node="invert" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_color4FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_color4FA" node="invert" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector2FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector2FA" node="invert" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector3FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector3FA" node="invert" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_invert_vector4FA" node="invert" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_invert_vector4FA" node="invert" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="amount" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_invert_matrix33" node="invert" nodegroup="math" defaultinput="in">
     <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
@@ -1828,647 +1838,647 @@
     Node: <absval>
     The per-channel absolute value of the incoming float/color/vector.
   -->
-  <nodedef name="ND_absval_float" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_float" node="absval" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_color2" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_color2" node="absval" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_color3" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_color3" node="absval" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_color4" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_color4" node="absval" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_vector2" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_vector2" node="absval" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_vector3" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_vector3" node="absval" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_absval_vector4" node="absval" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_absval_vector4" node="absval" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <floor>
     Find the nearest integer less than or equal to the parameter.
   -->
-  <nodedef name="ND_floor_float" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_float" node="floor" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_color2" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_color2" node="floor" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_color3" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_color3" node="floor" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_color4" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_color4" node="floor" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_vector2" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_vector2" node="floor" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_vector3" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_vector3" node="floor" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_floor_vector4" node="floor" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_floor_vector4" node="floor" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <ceil>
     Find the nearest integer greater than or equal to the parameter.
   -->
-  <nodedef name="ND_ceil_float" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_float" node="ceil" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_color2" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_color2" node="ceil" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_color3" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_color3" node="ceil" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_color4" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_color4" node="ceil" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_vector2" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_vector2" node="ceil" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_vector3" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_vector3" node="ceil" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ceil_vector4" node="ceil" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ceil_vector4" node="ceil" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <power>
     Raise incoming float/color/vector values to the "in2" power.
   -->
-  <nodedef name="ND_power_float" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_float" node="power" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color2" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color2" node="power" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color3" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color3" node="power" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color4" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color4" node="power" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector2" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector2" node="power" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector3" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector3" node="power" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector4" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector4" node="power" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color2FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color2FA" node="power" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color3FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color3FA" node="power" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_color4FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_color4FA" node="power" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector2FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector2FA" node="power" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector3FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector3FA" node="power" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_power_vector4FA" node="power" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_power_vector4FA" node="power" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Nodes: <sin>, <cos>, <tan>, <asin>, <acos>, <atan2>
     Standard trigonometric functions; angles are given in radians.
   -->
-  <nodedef name="ND_sin_float" node="sin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sin_float" node="sin" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_cos_float" node="cos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_cos_float" node="cos" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_tan_float" node="tan" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_tan_float" node="tan" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_asin_float" node="asin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_asin_float" node="asin" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_acos_float" node="acos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_acos_float" node="acos" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_atan2_float" node="atan2" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_atan2_float" node="atan2" nodegroup="math">
     <input name="in1" type="float" value="1.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_sin_vector2" node="sin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sin_vector2" node="sin" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_cos_vector2" node="cos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_cos_vector2" node="cos" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_tan_vector2" node="tan" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_tan_vector2" node="tan" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_asin_vector2" node="asin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_asin_vector2" node="asin" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_acos_vector2" node="acos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_acos_vector2" node="acos" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_atan2_vector2" node="atan2" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_atan2_vector2" node="atan2" nodegroup="math">
     <input name="in1" type="vector2" value="1.0, 1.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_sin_vector3" node="sin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sin_vector3" node="sin" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_cos_vector3" node="cos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_cos_vector3" node="cos" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_tan_vector3" node="tan" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_tan_vector3" node="tan" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_asin_vector3" node="asin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_asin_vector3" node="asin" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_acos_vector3" node="acos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_acos_vector3" node="acos" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_atan2_vector3" node="atan2" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_atan2_vector3" node="atan2" nodegroup="math">
     <input name="in1" type="vector3" value="1.0, 1.0, 1.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_sin_vector4" node="sin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sin_vector4" node="sin" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_cos_vector4" node="cos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_cos_vector4" node="cos" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_tan_vector4" node="tan" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_tan_vector4" node="tan" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_asin_vector4" node="asin" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_asin_vector4" node="asin" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_acos_vector4" node="acos" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_acos_vector4" node="acos" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_atan2_vector4" node="atan2" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_atan2_vector4" node="atan2" nodegroup="math">
     <input name="in1" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Nodes: <sqrt>, <ln>, <exp>
     Standard math functions.
   -->
-  <nodedef name="ND_sqrt_float" node="sqrt" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sqrt_float" node="sqrt" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ln_float" node="ln" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ln_float" node="ln" nodegroup="math">
     <input name="in" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_exp_float" node="exp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_exp_float" node="exp" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sqrt_vector2" node="sqrt" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sqrt_vector2" node="sqrt" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ln_vector2" node="ln" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ln_vector2" node="ln" nodegroup="math">
     <input name="in" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_exp_vector2" node="exp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_exp_vector2" node="exp" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sqrt_vector3" node="sqrt" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sqrt_vector3" node="sqrt" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ln_vector3" node="ln" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ln_vector3" node="ln" nodegroup="math">
     <input name="in" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_exp_vector3" node="exp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_exp_vector3" node="exp" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sqrt_vector4" node="sqrt" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sqrt_vector4" node="sqrt" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_ln_vector4" node="ln" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_ln_vector4" node="ln" nodegroup="math">
     <input name="in" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_exp_vector4" node="exp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_exp_vector4" node="exp" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <sign>
     Sign of eachinput channel: -1, 0 or +1
   -->
-  <nodedef name="ND_sign_float" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_float" node="sign" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_color2" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_color2" node="sign" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_color3" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_color3" node="sign" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_color4" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_color4" node="sign" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_vector2" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_vector2" node="sign" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_vector3" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_vector3" node="sign" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_sign_vector4" node="sign" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_sign_vector4" node="sign" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <clamp>
     Clamp incoming value to a specified range of values.
   -->
-  <nodedef name="ND_clamp_float" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_float" node="clamp" nodegroup="math">
     <input name="in" type="float" value="0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color2" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color2" node="clamp" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="low" type="color2" value="0.0, 0.0"/>
     <parameter name="high" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color3" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color3" node="clamp" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color4" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color4" node="clamp" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector2" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector2" node="clamp" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="low" type="vector2" value="0.0, 0.0"/>
     <parameter name="high" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector3" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector3" node="clamp" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector4" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector4" node="clamp" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color2FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color2FA" node="clamp" nodegroup="math">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color3FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color3FA" node="clamp" nodegroup="math">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_color4FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_color4FA" node="clamp" nodegroup="math">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector2FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector2FA" node="clamp" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector3FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector3FA" node="clamp" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_clamp_vector4FA" node="clamp" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_clamp_vector4FA" node="clamp" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="low" type="float" value="0.0"/>
     <parameter name="high" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <min>
     Select the minimum among incoming values.
   -->
-  <nodedef name="ND_min_float" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_float" node="min" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color2" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color2" node="min" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color3" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color3" node="min" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color4" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color4" node="min" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector2" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector2" node="min" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector3" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector3" node="min" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector4" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector4" node="min" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color2FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color2FA" node="min" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color3FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color3FA" node="min" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_color4FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_color4FA" node="min" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector2FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector2FA" node="min" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector3FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector3FA" node="min" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_min_vector4FA" node="min" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_min_vector4FA" node="min" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Node: <max>
     Select the maximum among incoming values.
   -->
-  <nodedef name="ND_max_float" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_float" node="max" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color2" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color2" node="max" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color3" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color3" node="max" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color4" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color4" node="max" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector2" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector2" node="max" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector3" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector3" node="max" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector4" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector4" node="max" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color2FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color2FA" node="max" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color3FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color3FA" node="max" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_color4FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_color4FA" node="max" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector2FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector2FA" node="max" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector3FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector3FA" node="max" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_max_vector4FA" node="max" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_max_vector4FA" node="max" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Node: <normalize>
     Outputs the normalized vector from the incoming vector stream.
   -->
-  <nodedef name="ND_normalize_vector2" node="normalize" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_normalize_vector2" node="normalize" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_normalize_vector3" node="normalize" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_normalize_vector3" node="normalize" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_normalize_vector4" node="normalize" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_normalize_vector4" node="normalize" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <magnitude>
     Outputs the float magnitude (vector length) of the incoming vector stream.
   -->
-  <nodedef name="ND_magnitude_vector2" node="magnitude" nodegroup="math" default="0.0">
+  <nodedef name="ND_magnitude_vector2" node="magnitude" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_magnitude_vector3" node="magnitude" nodegroup="math" default="0.0">
+  <nodedef name="ND_magnitude_vector3" node="magnitude" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_magnitude_vector4" node="magnitude" nodegroup="math" default="0.0">
+  <nodedef name="ND_magnitude_vector4" node="magnitude" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
     Node: <dotproduct>
     Perform a dot product of two 2-4 channel vectors
   -->
-  <nodedef name="ND_dotproduct_vector2" node="dotproduct" nodegroup="math" default="0.0">
+  <nodedef name="ND_dotproduct_vector2" node="dotproduct" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_dotproduct_vector3" node="dotproduct" nodegroup="math" default="0.0">
+  <nodedef name="ND_dotproduct_vector3" node="dotproduct" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_dotproduct_vector4" node="dotproduct" nodegroup="math" default="0.0">
+  <nodedef name="ND_dotproduct_vector4" node="dotproduct" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
     Node: <crossproduct>
     Perform a cross product of two vectors
   -->
-  <nodedef name="ND_crossproduct_vector3" node="crossproduct" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_crossproduct_vector3" node="crossproduct" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
 
   <!--
@@ -2476,146 +2486,146 @@
     Transform a vector coordinate from one named space to another, or by a specified
     matrix.
   -->
-  <nodedef name="ND_transformpoint_vector2M3" node="transformpoint" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformpoint_vector2M3" node="transformpoint" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformpoint_vector3" node="transformpoint" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformpoint_vector3" node="transformpoint" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformpoint_vector3M" node="transformpoint" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformpoint_vector3M" node="transformpoint" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformpoint_vector3M4" node="transformpoint" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformpoint_vector3M4" node="transformpoint" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <transformvector>
     Transform a vector from one named space to another, or by a specified matrix.
   -->
-  <nodedef name="ND_transformvector_vector2M3" node="transformvector" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformvector_vector2M3" node="transformvector" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformvector_vector3" node="transformvector" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformvector_vector3" node="transformvector" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformvector_vector3M" node="transformvector" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformvector_vector3M" node="transformvector" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformvector_vector3M4" node="transformvector" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformvector_vector3M4" node="transformvector" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformvector_vector4M" node="transformvector" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformvector_vector4M" node="transformvector" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4"  defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <transformnormal>
     Transform a normal vector from one named space to another, or by a specified matrix.
   -->
-  <nodedef name="ND_transformnormal_vector3" node="transformnormal" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformnormal_vector3" node="transformnormal" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <parameter name="fromspace" type="string" value=""/>
     <parameter name="tospace" type="string" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformnormal_vector3M" node="transformnormal" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformnormal_vector3M" node="transformnormal" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transformnormal_vector3M4" node="transformnormal" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transformnormal_vector3M4" node="transformnormal" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 1.0"/>
     <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3"  defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <normalmap>
     Transform a normal vector from object or tangent space into "world" space.
   -->
-  <nodedef name="ND_normalmap" node="normalmap" nodegroup="math" default="0.0, 1.0, 0.0">
+  <nodedef name="ND_normalmap" node="normalmap" nodegroup="math">
     <input name="in" type="vector3" value="0.5, 0.5, 1.0"/>
     <parameter name="space" type="string" value="tangent" enum="tangent, object"/>
     <input name="scale" type="float" value="1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
     <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="0.0, 1.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <transpose>
     Output the transpose of the incoming matrix.
   -->
-  <nodedef name="ND_transpose_matrix33" node="transpose" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transpose_matrix33" node="transpose" nodegroup="math">
     <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_transpose_matrix44" node="transpose" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_transpose_matrix44" node="transpose" nodegroup="math">
     <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <determinant>
     Output the determinant of the incoming matrix.
   -->
-  <nodedef name="ND_determinant_matrix33" node="determinant" nodegroup="math" default="1.0">
+  <nodedef name="ND_determinant_matrix33" node="determinant" nodegroup="math">
     <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="1.0"/>
   </nodedef>
-  <nodedef name="ND_determinant_matrix44" node="determinant" nodegroup="math" default="1.0">
+  <nodedef name="ND_determinant_matrix44" node="determinant" nodegroup="math">
     <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="1.0"/>
   </nodedef>
 
   <!--
     Node: <rotate>
     Rotates a vector value about the origin; for vector3 types, rotate about a specified axis
   -->
-  <nodedef name="ND_rotate_vector2" node="rotate" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_rotate_vector2" node="rotate" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="amount" type="float" value="0.0" unittype="angle" unit="degrees"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_rotate_vector3" node="rotate" nodegroup="math" defaultinput="in">
+  <nodedef name="ND_rotate_vector3" node="rotate" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="0.0" unittype="angle" unit="degrees"/>
     <parameter name="axis" type="vector3" value="0.0, 1.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <place2d> Supplemental Node
     Transform incoming UV texture coordinates for 2D texture placement.
   -->
-  <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math" defaultinput="texcoord">
+  <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math">
     <input name="texcoord" type="vector2" value="0.0, 0.0"/>
     <parameter name="pivot" type="vector2" value="0.0,0.0"/>
     <input name="scale" type="vector2" value="1.0,1.0"/>
     <input name="rotate" type="float" value="0.0" unittype="angle" unit="degrees"/>
     <input name="offset" type="vector2" value="0.0,0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="texcoord"/>
   </nodedef>
 
   <!--
@@ -2623,95 +2633,95 @@
     Creates a two-element array from two base types, or appends a base-type value to an array of
     the same type.
   -->
-  <nodedef name="ND_arrayappend_integer_integerarray" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_integer_integerarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="integer" value="0"/>
     <input name="in2" type="integer" value="0"/>
-    <output name="out" type="integerarray"/>
+    <output name="out" type="integerarray" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_integerarray_integerarray" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_integerarray_integerarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="integerarray" value=""/>
     <input name="in2" type="integer" value="0"/>
-    <output name="out" type="integerarray"/>
+    <output name="out" type="integerarray" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_float_floatarray" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_float_floatarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="floatarray"/>
+    <output name="out" type="floatarray" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_floatarray_floatarray" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_floatarray_floatarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="floatarray" value=""/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="floatarray"/>
+    <output name="out" type="floatarray" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color2_color2array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_color2_color2array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2array"/>
+    <output name="out" type="color2array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color2array_color2array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_color2array_color2array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color2array" value=""/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color2array"/>
+    <output name="out" type="color2array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color3_color3array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_color3_color3array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3array"/>
+    <output name="out" type="color3array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color3array_color3array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_color3array_color3array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color3array" value=""/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3array"/>
+    <output name="out" type="color3array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color4_color4array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_color4_color4array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4array"/>
+    <output name="out" type="color4array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_color4array_color4array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_color4array_color4array" node="arrayappend" nodegroup="math">
     <input name="in1" type="color4array" value=""/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4array"/>
+    <output name="out" type="color4array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector2_vector2array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_vector2_vector2array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2array"/>
+    <output name="out" type="vector2array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector2array_vector2array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_vector2array_vector2array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector2array" value=""/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2array"/>
+    <output name="out" type="vector2array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector3_vector3array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_vector3_vector3array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3array"/>
+    <output name="out" type="vector3array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector3array_vector3array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_vector3array_vector3array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector3array" value=""/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3array"/>
+    <output name="out" type="vector3array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector4_vector4array" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_vector4_vector4array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4array"/>
+    <output name="out" type="vector4array" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_vector4array_vector4array" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_vector4array_vector4array" node="arrayappend" nodegroup="math">
     <input name="in1" type="vector4array" value=""/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4array"/>
+    <output name="out" type="vector4array" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_string_stringarray" node="arrayappend" nodegroup="math" default="[]">
+  <nodedef name="ND_arrayappend_string_stringarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="string" value=""/>
     <input name="in2" type="string" value=""/>
-    <output name="out" type="stringarray"/>
+    <output name="out" type="stringarray" default="[]"/>
   </nodedef>
-  <nodedef name="ND_arrayappend_stringarray_stringarray" node="arrayappend" nodegroup="math" defaultinput="in1">
+  <nodedef name="ND_arrayappend_stringarray_stringarray" node="arrayappend" nodegroup="math">
     <input name="in1" type="stringarray" value=""/>
     <input name="in2" type="string" value=""/>
-    <output name="out" type="stringarray"/>
+    <output name="out" type="stringarray" defaultinput="in1"/>
   </nodedef>
 
 
@@ -2723,109 +2733,109 @@
     Node: <remap>
     Remap a value from one range of float/color/vector values to another.
   -->
-  <nodedef name="ND_remap_float" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_float" node="remap" nodegroup="adjustment">
     <input name="in" type="float" value="0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color2" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color2" node="remap" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="inlow" type="color2" value="0.0, 0.0"/>
     <input name="inhigh" type="color2" value="1.0, 1.0"/>
     <input name="outlow" type="color2" value="0.0, 0.0"/>
     <input name="outhigh" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color3" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color3" node="remap" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inhigh" type="color3" value="1.0, 1.0, 1.0"/>
     <input name="outlow" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="outhigh" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color4" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color4" node="remap" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector2" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector2" node="remap" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="inlow" type="vector2" value="0.0, 0.0"/>
     <input name="inhigh" type="vector2" value="1.0, 1.0"/>
     <input name="outlow" type="vector2" value="0.0, 0.0"/>
     <input name="outhigh" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector3" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector3" node="remap" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0"/>
     <input name="outlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector4" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector4" node="remap" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color2FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color2FA" node="remap" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color3FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color3FA" node="remap" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_color4FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_color4FA" node="remap" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector2FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector2FA" node="remap" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector3FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector3FA" node="remap" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_remap_vector4FA" node="remap" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_remap_vector4FA" node="remap" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -2833,83 +2843,83 @@
     Outputs a smooth (hermite-interpolated) remapping of input values from low-high
     to output 0-1.
   -->
-  <nodedef name="ND_smoothstep_float" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_float" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="float" value="0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color2" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color2" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="low" type="color2" value="0.0, 0.0"/>
     <input name="high" type="color2" value="1.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color3" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color3" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="low" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="high" type="color3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color4" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color4" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector2" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector2" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="low" type="vector2" value="0.0, 0.0"/>
     <input name="high" type="vector2" value="1.0, 1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector3" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector3" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="low" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="high" type="vector3" value="1.0, 1.0, 1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector4" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector4" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color2FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color2FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color3FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color3FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_color4FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_color4FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="low" type="float" value="0.0"/>
     <input name="high" type="float" value="1.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -2919,40 +2929,40 @@
     lookup on input knot values and a forward spline through output knot values.
     All channels of the input will be remapped using the same curve.
   -->
-  <nodedef name="ND_curveadjust_float" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_float" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="float" value="0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_color2" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_color2" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_color3" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_color3" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_color4" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_color4" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_vector2" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_vector2" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_vector3" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_vector3" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_curveadjust_vector4" node="curveadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_curveadjust_vector4" node="curveadjust" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="knots" type="vector2array" value=""/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -2960,123 +2970,123 @@
     Output a grayscale image containing the luminance of the incoming RGB color in all color channels;
     the alpha channel is left unchanged if present.
   -->
-  <nodedef name="ND_luminance_color3" node="luminance" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_luminance_color3" node="luminance" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
 	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_luminance_color4" node="luminance" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_luminance_color4" node="luminance" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
 	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Nodes: <rgbtohsv> and <hsvtorgb>
     Convert an incoming color between RGB and HSV space, with H and S ranging from 0-1.
   -->
-  <nodedef name="ND_rgbtohsv_color3" node="rgbtohsv" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_rgbtohsv_color3" node="rgbtohsv" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_rgbtohsv_color4" node="rgbtohsv" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_rgbtohsv_color4" node="rgbtohsv" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_hsvtorgb_color3" node="hsvtorgb" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_hsvtorgb_color3" node="hsvtorgb" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_hsvtorgb_color4" node="hsvtorgb" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_hsvtorgb_color4" node="hsvtorgb" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <contrast> Supplemental Node
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->
-  <nodedef name="ND_contrast_float" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_float" node="contrast" nodegroup="adjustment">
     <input name="in" type="float" value="0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color2" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color2" node="contrast" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="amount" type="color2" value="1.0, 1.0"/>
     <parameter name="pivot" type="color2" value="0.5, 0.5"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color3" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color3" node="contrast" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="color3" value="0.5, 0.5, 0.5"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color4" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color4" node="contrast" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector2" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector2" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="amount" type="vector2" value="1.0, 1.0"/>
     <parameter name="pivot" type="vector2" value="0.5, 0.5"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector3" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector3" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="vector3" value="0.5, 0.5, 0.5"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector4" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector4" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color2FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color2FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color3FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color3FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_color4FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_color4FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector2FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector2FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector3FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector3FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_contrast_vector4FA" node="contrast" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_contrast_vector4FA" node="contrast" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="pivot" type="float" value="0.5"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -3084,7 +3094,7 @@
     Remap a value from one range of float/color/vector values to another, optionally
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
-  <nodedef name="ND_range_float" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_float" node="range" nodegroup="adjustment">
     <input name="in" type="float" value="0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3092,9 +3102,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color2" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color2" node="range" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="inlow" type="color2" value="0.0, 0.0"/>
     <input name="inhigh" type="color2" value="1.0, 1.0"/>
@@ -3102,9 +3112,9 @@
     <input name="outlow" type="color2" value="0.0, 0.0"/>
     <input name="outhigh" type="color2" value="1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color3" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color3" node="range" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inhigh" type="color3" value="1.0, 1.0, 1.0"/>
@@ -3112,9 +3122,9 @@
     <input name="outlow" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="outhigh" type="color3" value="1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color4" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color4" node="range" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
@@ -3122,9 +3132,9 @@
     <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector2" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector2" node="range" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="inlow" type="vector2" value="0.0, 0.0"/>
     <input name="inhigh" type="vector2" value="1.0, 1.0"/>
@@ -3132,9 +3142,9 @@
     <input name="outlow" type="vector2" value="0.0, 0.0"/>
     <input name="outhigh" type="vector2" value="1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector3" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector3" node="range" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0"/>
@@ -3142,9 +3152,9 @@
     <input name="outlow" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector4" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector4" node="range" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
@@ -3152,9 +3162,9 @@
     <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color2FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color2FA" node="range" nodegroup="adjustment">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3162,9 +3172,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color3FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color3FA" node="range" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3172,9 +3182,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_color4FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_color4FA" node="range" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3182,9 +3192,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector2FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector2FA" node="range" nodegroup="adjustment">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3192,9 +3202,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector3FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector3FA" node="range" nodegroup="adjustment">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3202,9 +3212,9 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_range_vector4FA" node="range" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_range_vector4FA" node="range" nodegroup="adjustment">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="inlow" type="float" value="0.0"/>
     <input name="inhigh" type="float" value="1.0"/>
@@ -3212,7 +3222,7 @@
     <input name="outlow" type="float" value="0.0"/>
     <input name="outhigh" type="float" value="1.0"/>
     <parameter name="doclamp" type="boolean" value="false"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -3221,15 +3231,15 @@
     to HSV, adding amount.x to the hue, multiplying the saturation by amount.y,
     multiplying the value by amount.z, then converting back to RGB.
   -->
-  <nodedef name="ND_hsvadjust_color3" node="hsvadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_hsvadjust_color3" node="hsvadjust" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="vector3" value="0.0, 1.0, 1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_hsvadjust_color4" node="hsvadjust" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_hsvadjust_color4" node="hsvadjust" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="vector3" value="0.0, 1.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -3238,21 +3248,21 @@
     color and the grayscale luminance of the input computed using the provided luma
     coefficients; the alpha channel will be unchanged if present.
   -->
-  <nodedef name="ND_saturate_color3" node="saturate" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_saturate_color3" node="saturate" nodegroup="adjustment">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
 	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_saturate_color4" node="saturate" nodegroup="adjustment" defaultinput="in">
+  <nodedef name="ND_saturate_color4" node="saturate" nodegroup="adjustment">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="amount" type="float" value="1.0"/>
     <parameter name="lumacoeffs" type="color3" value="0.272287, 0.6740818, 0.0536895"
 	enum="acescg, rec709, rec2020, rec2100"
 	enumvalues="0.272287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
 
@@ -3264,13 +3274,13 @@
     Node: <premult>
     Multiply the R or RGB channels of the input by the Alpha channel of the input.
   -->
-  <nodedef name="ND_premult_color2" node="premult" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_premult_color2" node="premult" nodegroup="compositing">
     <input name="in" type="color2" value="0.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_premult_color4" node="premult" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_premult_color4" node="premult" nodegroup="compositing">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -3278,71 +3288,71 @@
     Divide the R or RGB channels of the input by the Alpha channel of the input.
     If the Alpha value is zero, it is passed through unchanged.
   -->
-  <nodedef name="ND_unpremult_color2" node="unpremult" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_unpremult_color2" node="unpremult" nodegroup="compositing">
     <input name="in" type="color2" value="0.0, 1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_unpremult_color4" node="unpremult" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_unpremult_color4" node="unpremult" nodegroup="compositing">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <plus>
     Add two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
-  <nodedef name="ND_plus_float" node="plus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_plus_float" node="plus" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_plus_color2" node="plus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_plus_color2" node="plus" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_plus_color3" node="plus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_plus_color3" node="plus" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_plus_color4" node="plus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_plus_color4" node="plus" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
     Node: <minus>
     Subtract two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
-  <nodedef name="ND_minus_float" node="minus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_minus_float" node="minus" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_minus_color2" node="minus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_minus_color2" node="minus" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_minus_color3" node="minus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_minus_color3" node="minus" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_minus_color4" node="minus" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_minus_color4" node="minus" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3350,116 +3360,116 @@
     Absolute-value difference of two 1-4 channel inputs, with optional mixing between
     the bg input and the result.
   -->
-  <nodedef name="ND_difference_float" node="difference" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_difference_float" node="difference" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_difference_color2" node="difference" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_difference_color2" node="difference" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_difference_color3" node="difference" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_difference_color3" node="difference" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_difference_color4" node="difference" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_difference_color4" node="difference" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
     Node: <burn>
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-B)/F
   -->
-  <nodedef name="ND_burn_float" node="burn" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_burn_float" node="burn" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_burn_color2" node="burn" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_burn_color2" node="burn" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_burn_color3" node="burn" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_burn_color3" node="burn" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_burn_color4" node="burn" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_burn_color4" node="burn" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
     Node: <dodge>
     Take two 1-4 channel inputs and apply the same operator to all channels: B/(1-F)
   -->
-  <nodedef name="ND_dodge_float" node="dodge" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_dodge_float" node="dodge" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_dodge_color2" node="dodge" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_dodge_color2" node="dodge" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_dodge_color3" node="dodge" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_dodge_color3" node="dodge" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_dodge_color4" node="dodge" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_dodge_color4" node="dodge" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
     Node: <screen>
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-F)*(1-B)
   -->
-  <nodedef name="ND_screen_float" node="screen" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_screen_float" node="screen" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_screen_color2" node="screen" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_screen_color2" node="screen" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_screen_color3" node="screen" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_screen_color3" node="screen" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_screen_color4" node="screen" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_screen_color4" node="screen" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3468,29 +3478,29 @@
       2FB if F<0.5;
       1-(1-F)(1-B) if F>=0.5
   -->
-  <nodedef name="ND_overlay_float" node="overlay" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_overlay_float" node="overlay" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_overlay_color2" node="overlay" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_overlay_color2" node="overlay" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_overlay_color3" node="overlay" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_overlay_color3" node="overlay" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_overlay_color4" node="overlay" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_overlay_color4" node="overlay" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3501,17 +3511,17 @@
       F+B(1-f)/b  if f+b>1
       alpha: min(f+b,1)
   -->
-  <nodedef name="ND_disjointover_color2" node="disjointover" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_disjointover_color2" node="disjointover" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_disjointover_color4" node="disjointover" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_disjointover_color4" node="disjointover" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3519,17 +3529,17 @@
     Take two color2 or two color4 inputs and use the built-in alpha
     channel(s) to control the compositing of the fg and bg inputs: Fb  (alpha: fb)
   -->
-  <nodedef name="ND_in_color2" node="in" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_in_color2" node="in" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_in_color4" node="in" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_in_color4" node="in" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3537,17 +3547,17 @@
     Take two color2 or two color4 inputs and use the built-in alpha
     channel(s) to control the compositing of the fg and bg inputs: Bf  (alpha: bf)
   -->
-  <nodedef name="ND_mask_color2" node="mask" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mask_color2" node="mask" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mask_color4" node="mask" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mask_color4" node="mask" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3555,17 +3565,17 @@
     Take two color2 or two color4 inputs and use the built-in alpha
     channel(s) to control the compositing of the fg and bg inputs: Ff+B(1-f)  (alpha: f+b(1-f))
   -->
-  <nodedef name="ND_matte_color2" node="matte" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_matte_color2" node="matte" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_matte_color4" node="matte" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_matte_color4" node="matte" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3573,17 +3583,17 @@
     Take two color2 or two color4 inputs and use the built-in alpha
     channel(s) to control the compositing of the fg and bg inputs: F(1-b)  (alpha: f(1-b))
   -->
-  <nodedef name="ND_out_color2" node="out" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_out_color2" node="out" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_out_color4" node="out" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_out_color4" node="out" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3591,17 +3601,17 @@
     Take two color2 or two color4 inputs and use the built-in alpha
     channel(s) to control the compositing of the fg and bg inputs: F+B(1-f)  (alpha: f+b(1-f))
   -->
-  <nodedef name="ND_over_color2" node="over" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_over_color2" node="over" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_over_color4" node="over" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_over_color4" node="over" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
 
   <!--
@@ -3609,25 +3619,25 @@
     Take one 1-4 channel input "in" plus a separate float "mask" input and apply the same
     operator to all channels: in * mask
   -->
-  <nodedef name="ND_inside_float" node="inside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_inside_float" node="inside" nodegroup="compositing">
     <input name="in" type="float" value="0.0"/>
     <input name="mask" type="float" value="1.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_inside_color2" node="inside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_inside_color2" node="inside" nodegroup="compositing">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="mask" type="float" value="1.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_inside_color3" node="inside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_inside_color3" node="inside" nodegroup="compositing">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mask" type="float" value="1.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_inside_color4" node="inside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_inside_color4" node="inside" nodegroup="compositing">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mask" type="float" value="1.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -3635,90 +3645,90 @@
     Take one 1-4 channel input "in" plus a separate float "mask" input and apply the same
     operator to all channels: in * (1-mask)
   -->
-  <nodedef name="ND_outside_float" node="outside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_outside_float" node="outside" nodegroup="compositing">
     <input name="in" type="float" value="0.0"/>
     <input name="mask" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_outside_color2" node="outside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_outside_color2" node="outside" nodegroup="compositing">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <input name="mask" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_outside_color3" node="outside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_outside_color3" node="outside" nodegroup="compositing">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mask" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_outside_color4" node="outside" nodegroup="compositing" defaultinput="in">
+  <nodedef name="ND_outside_color4" node="outside" nodegroup="compositing">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mask" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <mix>
     Mix two inputs according to an input mix amount.
   -->
-  <nodedef name="ND_mix_float" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_float" node="mix" nodegroup="compositing">
     <input name="fg" type="float" value="0.0"/>
     <input name="bg" type="float" value="0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_color2" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_color2" node="mix" nodegroup="compositing">
     <input name="fg" type="color2" value="0.0, 0.0"/>
     <input name="bg" type="color2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_color3" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_color3" node="mix" nodegroup="compositing">
     <input name="fg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_color4" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_color4" node="mix" nodegroup="compositing">
     <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_vector2" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_vector2" node="mix" nodegroup="compositing">
     <input name="fg" type="vector2" value="0.0, 0.0"/>
     <input name="bg" type="vector2" value="0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_vector3" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_vector3" node="mix" nodegroup="compositing">
     <input name="fg" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="bg" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_vector4" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_vector4" node="mix" nodegroup="compositing">
     <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_surfaceshader" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_surfaceshader" node="mix" nodegroup="compositing">
     <input name="fg" type="surfaceshader" value=""/>
     <input name="bg" type="surfaceshader" value=""/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="surfaceshader"/>
+    <output name="out" type="surfaceshader" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_displacementshader" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_displacementshader" node="mix" nodegroup="compositing">
     <input name="fg" type="displacementshader" value=""/>
     <input name="bg" type="displacementshader" value=""/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="displacementshader"/>
+    <output name="out" type="displacementshader" defaultinput="bg"/>
   </nodedef>
-  <nodedef name="ND_mix_volumeshader" node="mix" nodegroup="compositing" defaultinput="bg">
+  <nodedef name="ND_mix_volumeshader" node="mix" nodegroup="compositing">
     <input name="fg" type="volumeshader" value=""/>
     <input name="bg" type="volumeshader" value=""/>
     <input name="mix" type="float" value="0.0"/>
-    <output name="out" type="volumeshader"/>
+    <output name="out" type="volumeshader" defaultinput="bg"/>
   </nodedef>
 
 
@@ -3732,178 +3742,178 @@
     then pass the value of one of two other incoming streams depending on whether the selector
     stream value is greater than the fixed cutoff value.
   -->
-  <nodedef name="ND_compare_float" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_float" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float"  defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_compare_color2" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_color2" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="color2" value="0.0, 0.0"/>
-    <input name="in2" type="color2" value="0.0, 0.0"/>
+    <input name="in2" type="color2" value="0.0, 0.0" defaultinput="in1"/>
     <output name="out" type="color2"/>
   </nodedef>
-  <nodedef name="ND_compare_color3" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_color3" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3"  defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_compare_color4" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_color4" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_compare_vector2" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_vector2" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_compare_vector3" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_vector3" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_compare_vector4" node="compare" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_compare_vector4" node="compare" nodegroup="conditional">
     <input name="intest" type="float" value="0.0"/>
     <parameter name="cutoff" type="float" value="0.0"/>
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
   <!--
     Node: <switch>
     Pass on the value of one of five input streams, according to the value of a selector parameter.
   -->
-  <nodedef name="ND_switch_float" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_float" node="switch" nodegroup="conditional">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <input name="in3" type="float" value="0.0"/>
     <input name="in4" type="float" value="0.0"/>
     <input name="in5" type="float" value="0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color2" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color2" node="switch" nodegroup="conditional">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
     <input name="in3" type="color2" value="0.0, 0.0"/>
     <input name="in4" type="color2" value="0.0, 0.0"/>
     <input name="in5" type="color2" value="0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color3" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color3" node="switch" nodegroup="conditional">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in3" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color4" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color4" node="switch" nodegroup="conditional">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector2" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector2" node="switch" nodegroup="conditional">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
     <input name="in3" type="vector2" value="0.0, 0.0"/>
     <input name="in4" type="vector2" value="0.0, 0.0"/>
     <input name="in5" type="vector2" value="0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector3" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector3" node="switch" nodegroup="conditional">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in3" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector4" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector4" node="switch" nodegroup="conditional">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="which" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_floatI" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_floatI" node="switch" nodegroup="conditional">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <input name="in3" type="float" value="0.0"/>
     <input name="in4" type="float" value="0.0"/>
     <input name="in5" type="float" value="0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color2I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color2I" node="switch" nodegroup="conditional">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
     <input name="in3" type="color2" value="0.0, 0.0"/>
     <input name="in4" type="color2" value="0.0, 0.0"/>
     <input name="in5" type="color2" value="0.0, 0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color3I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color3I" node="switch" nodegroup="conditional">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in3" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color4I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color4I" node="switch" nodegroup="conditional">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector2I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector2I" node="switch" nodegroup="conditional">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
     <input name="in3" type="vector2" value="0.0, 0.0"/>
     <input name="in4" type="vector2" value="0.0, 0.0"/>
     <input name="in5" type="vector2" value="0.0, 0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector3I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector3I" node="switch" nodegroup="conditional">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in3" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in4" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in5" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="integer" value="0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector4I" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector4I" node="switch" nodegroup="conditional">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -3912,47 +3922,47 @@
     <parameter name="which" type="integer" value="0"/>
     <output name="out" type="vector4"/>
   </nodedef>
-  <nodedef name="ND_switch_floatB" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_floatB" node="switch" nodegroup="conditional">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color2B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color2B" node="switch" nodegroup="conditional">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color3B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color3B" node="switch" nodegroup="conditional">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_color4B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_color4B" node="switch" nodegroup="conditional">
     <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector2B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector2B" node="switch" nodegroup="conditional">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector3B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector3B" node="switch" nodegroup="conditional">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in1"/>
   </nodedef>
-  <nodedef name="ND_switch_vector4B" node="switch" nodegroup="conditional" defaultinput="in1">
+  <nodedef name="ND_switch_vector4B" node="switch" nodegroup="conditional">
     <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="which" type="boolean" value="false"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in1"/>
   </nodedef>
 
 
@@ -3967,83 +3977,83 @@
   -->
   <nodedef name="ND_convert_float_color2" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_float_color3" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_float_color4" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_float_vector2" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_float_vector3" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_float_vector4" node="convert" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector2_color2" node="convert" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector2_vector3" node="convert" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector3_color3" node="convert" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector3_vector2" node="convert" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector3_vector4" node="convert" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector4_color4" node="convert" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_vector4_vector3" node="convert" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_color2_vector2" node="convert" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_color3_vector3" node="convert" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_color4_vector4" node="convert" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_color3_color4" node="convert" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_color4_color3" node="convert" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_convert_boolean_float" node="convert" nodegroup="channel">
     <input name="in" type="boolean" value="false"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_convert_integer_float" node="convert" nodegroup="channel">
     <input name="in" type="integer" value="0"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
@@ -4056,248 +4066,248 @@
   <nodedef name="ND_swizzle_float_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_float_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_float_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_float_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_float_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_float_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="float" value="0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: color2 -->
   <nodedef name="ND_swizzle_color2_float" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="r"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color2_color2" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_color2_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color2_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: color3 -->
   <nodedef name="ND_swizzle_color3_float" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="r"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color3_color3" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_color3_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color3_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: color4 -->
   <nodedef name="ND_swizzle_color4_float" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="r"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_color4_color4" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_color4_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rr"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrr"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_color4_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="rrrr"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: vector2 -->
   <nodedef name="ND_swizzle_vector2_float" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="x"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector2_vector2" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_vector2_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector2_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: vector3 -->
   <nodedef name="ND_swizzle_vector3_float" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="x"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector3_vector3" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_vector3_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector3_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <!-- from type: vector4 -->
   <nodedef name="ND_swizzle_vector4_float" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="x"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_color2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_color3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_color4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_vector2" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xx"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
   <nodedef name="ND_swizzle_vector4_vector3" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxx"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_swizzle_vector4_vector4" node="swizzle" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_swizzle_vector4_vector4" node="swizzle" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="channels" type="string" value="xxxx"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
@@ -4305,96 +4315,96 @@
     Combine the channels from two, three or four streams into the same number of channels of a
     single output stream of a specified compatible type.
   -->
-  <nodedef name="ND_combine_color2" node="combine" nodegroup="channel" default="0.0, 0.0">
+  <nodedef name="ND_combine_color2" node="combine" nodegroup="channel">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_vector2" node="combine" nodegroup="channel" default="0.0, 0.0">
+  <nodedef name="ND_combine_vector2" node="combine" nodegroup="channel">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" default="0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_color3" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0">
-    <input name="in1" type="float" value="0.0"/>
-    <input name="in2" type="float" value="0.0"/>
-    <input name="in3" type="float" value="0.0"/>
-    <output name="out" type="color3"/>
-  </nodedef>
-  <nodedef name="ND_combine_vector3" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_color3" node="combine" nodegroup="channel">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <input name="in3" type="float" value="0.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="color3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_color4" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_vector3" node="combine" nodegroup="channel">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <input name="in3" type="float" value="0.0"/>
-    <input name="in4" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_vector4" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_color4" node="combine" nodegroup="channel">
     <input name="in1" type="float" value="0.0"/>
     <input name="in2" type="float" value="0.0"/>
     <input name="in3" type="float" value="0.0"/>
     <input name="in4" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_color4CF" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_vector4" node="combine" nodegroup="channel">
+    <input name="in1" type="float" value="0.0"/>
+    <input name="in2" type="float" value="0.0"/>
+    <input name="in3" type="float" value="0.0"/>
+    <input name="in4" type="float" value="0.0"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
+  </nodedef>
+ <nodedef name="ND_combine_color4CF" node="combine" nodegroup="channel">
     <input name="in1" type="color3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_vector4VF" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_vector4VF" node="combine" nodegroup="channel">
     <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
     <input name="in2" type="float" value="0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_color4CC" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_color4CC" node="combine" nodegroup="channel">
     <input name="in1" type="color2" value="0.0, 0.0"/>
     <input name="in2" type="color2" value="0.0, 0.0"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
-  <nodedef name="ND_combine_vector4VV" node="combine" nodegroup="channel" default="0.0, 0.0, 0.0, 0.0">
+  <nodedef name="ND_combine_vector4VV" node="combine" nodegroup="channel">
     <input name="in1" type="vector2" value="0.0, 0.0"/>
     <input name="in2" type="vector2" value="0.0, 0.0"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0"/>
   </nodedef>
 
   <!--
     Node: <extract> Supplemental Node
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
-  <nodedef name="ND_extract_color2" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_color2" node="extract" nodegroup="channel">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="1"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_extract_color3" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_color3" node="extract" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="2"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_extract_color4" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_color4" node="extract" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="3"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_extract_vector2" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_vector2" node="extract" nodegroup="channel">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="1"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_extract_vector3" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_vector3" node="extract" nodegroup="channel">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="2"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
-  <nodedef name="ND_extract_vector4" node="extract" nodegroup="channel" defaultinput="in">
+  <nodedef name="ND_extract_vector4" node="extract" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="index" type="integer" value="0" uimin="0" uimax="3"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" default="0.0"/>
   </nodedef>
 
   <!--
@@ -4406,11 +4416,22 @@
     <output name="outr" type="float" default="0.0"/>
     <output name="outa" type="float" default="0.0"/>
   </nodedef>
+  <nodedef name="ND_separate_vector2" node="separate" nodegroup="channel">
+    <input name="in" type="vector2" value="0.0, 0.0"/>
+    <output name="outx" type="float" default="0.0"/>
+    <output name="outy" type="float" default="0.0"/>
+  </nodedef>
   <nodedef name="ND_separate_color3" node="separate" nodegroup="channel">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <output name="outr" type="float" default="0.0"/>
     <output name="outg" type="float" default="0.0"/>
     <output name="outb" type="float" default="0.0"/>
+  </nodedef>
+  <nodedef name="ND_separate_vector3" node="separate" nodegroup="channel">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
+    <output name="outx" type="float" default="0.0"/>
+    <output name="outy" type="float" default="0.0"/>
+    <output name="outz" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_color4" node="separate" nodegroup="channel">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -4418,17 +4439,6 @@
     <output name="outg" type="float" default="0.0"/>
     <output name="outb" type="float" default="0.0"/>
     <output name="outa" type="float" default="0.0"/>
-  </nodedef>
-  <nodedef name="ND_separate_vector2" node="separate" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0"/>
-    <output name="outx" type="float" default="0.0"/>
-    <output name="outy" type="float" default="0.0"/>
-  </nodedef>
-  <nodedef name="ND_separate_vector3" node="separate" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <output name="outx" type="float" default="0.0"/>
-    <output name="outy" type="float" default="0.0"/>
-    <output name="outz" type="float" default="0.0"/>
   </nodedef>
   <nodedef name="ND_separate_vector4" node="separate" nodegroup="channel">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
@@ -4447,57 +4457,57 @@
     Node: <blur>
     A gaussian-falloff blur.
   -->
-  <nodedef name="ND_blur_float" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_float" node="blur" nodegroup="convolution2d">
     <input name="in" type="float" value="0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_color2" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_color2" node="blur" nodegroup="convolution2d">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_color3" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_color3" node="blur" nodegroup="convolution2d">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_color4" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_color4" node="blur" nodegroup="convolution2d">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_vector2" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_vector2" node="blur" nodegroup="convolution2d">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_vector3" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_vector3" node="blur" nodegroup="convolution2d">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_blur_vector4" node="blur" nodegroup="convolution2d" defaultinput="in">
+  <nodedef name="ND_blur_vector4" node="blur" nodegroup="convolution2d">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="size" type="float" value="0.0"/>
     <parameter name="filtertype" type="string" value="box" enum="box,gaussian"/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <heighttonormal>
     Convert a scalar height map to a normal map of type vector3.
   -->
-  <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" nodegroup="convolution2d" default="0.0, 1.0, 0.0">
+  <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" nodegroup="convolution2d">
     <input name="in" type="float" value="0.0"/>
     <parameter name="scale" type="float" value="1.0"/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" default="0.0, 1.0, 0.0"/>
   </nodedef>
 
 
@@ -4509,102 +4519,101 @@
     Node: <dot>
     No-op; passes its input to the output unchanged.
   -->
-  <nodedef name="ND_dot_float" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_float" node="dot" nodegroup="organization">
     <input name="in" type="float" value="0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="float"/>
+    <output name="out" type="float" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_color2" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_color2" node="dot" nodegroup="organization">
     <input name="in" type="color2" value="0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="color2"/>
+    <output name="out" type="color2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_color3" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_color3" node="dot" nodegroup="organization">
     <input name="in" type="color3" value="0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="color3"/>
+    <output name="out" type="color3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_color4" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_color4" node="dot" nodegroup="organization">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="color4"/>
+    <output name="out" type="color4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_vector2" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_vector2" node="dot" nodegroup="organization">
     <input name="in" type="vector2" value="0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="vector2"/>
+    <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_vector3" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_vector3" node="dot" nodegroup="organization">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="vector3"/>
+    <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_vector4" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_vector4" node="dot" nodegroup="organization">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="vector4"/>
+    <output name="out" type="vector4" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_boolean" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_boolean" node="dot" nodegroup="organization">
     <input name="in" type="boolean" value="false"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="boolean"/>
+    <output name="out" type="boolean" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_integer" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_integer" node="dot" nodegroup="organization">
     <input name="in" type="integer" value="0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="integer"/>
+    <output name="out" type="integer" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_matrix33" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_matrix33" node="dot" nodegroup="organization">
     <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="matrix33"/>
+    <output name="out" type="matrix33" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_matrix44" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_matrix44" node="dot" nodegroup="organization">
     <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="matrix44"/>
+    <output name="out" type="matrix44" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_string" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_string" node="dot" nodegroup="organization">
     <input name="in" type="string" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="string"/>
+    <output name="out" type="string" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_filename" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_filename" node="dot" nodegroup="organization">
     <input name="in" type="filename" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="filename"/>
+    <output name="out" type="filename" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_surfaceshader" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_surfaceshader" node="dot" nodegroup="organization">
     <input name="in" type="surfaceshader" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="surfaceshader"/>
+    <output name="out" type="surfaceshader" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_displacementshader" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_displacementshader" node="dot" nodegroup="organization">
     <input name="in" type="displacementshader" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="displacementshader"/>
+    <output name="out" type="displacementshader" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_volumeshader" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_volumeshader" node="dot" nodegroup="organization">
     <input name="in" type="volumeshader" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="volumeshader"/>
+    <output name="out" type="volumeshader" defaultinput="in"/>
   </nodedef>
-  <nodedef name="ND_dot_lightshader" node="dot" nodegroup="organization" defaultinput="in">
+  <nodedef name="ND_dot_lightshader" node="dot" nodegroup="organization">
     <input name="in" type="lightshader" value=""/>
     <parameter name="note" type="string" value=""/>
-    <output name="out" type="lightshader"/>
+    <output name="out" type="lightshader" defaultinput="in"/>
   </nodedef>
 
   <!--
     Node: <backdrop>
-    A layout element used to contain, group and document other nodes
+    An outputless layout element used to contain, group and document other nodes
   -->
   <nodedef name="ND_backdrop" node="backdrop" nodegroup="organization">
     <parameter name="note" type="string" value=""/>
     <parameter name="contains" type="stringarray" value=""/>
     <parameter name="width" type="float" value="1.0"/>
     <parameter name="height" type="float" value="1.0"/>
-    <output name="out" type="none"/>
   </nodedef>
 
 </materialx>

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -18,6 +18,7 @@ const string PROCEDURAL_NODE_GROUP = "procedural";
 const string GEOMETRIC_NODE_GROUP = "geometric";
 const string ADJUSTMENT_NODE_GROUP = "adjustment";
 const string CONDITIONAL_NODE_GROUP = "conditional";
+const string ORGANIZATION_NODE_GROUP = "organization";
 
 const string NodeDef::NODE_ATTRIBUTE = "node";
 const string NodeDef::NODE_GROUP_ATTRIBUTE = "nodegroup";
@@ -31,6 +32,30 @@ const string UnitDef::UNITTYPE_ATTRIBUTE = "unittype";
 //
 // NodeDef methods
 //
+
+const string& NodeDef::getType() const
+{
+    // Organizational nodes have no output type
+    if (getNodeGroup() == ORGANIZATION_NODE_GROUP)
+    {
+        return ORGANIZATION_NODE_GROUP;
+    }
+
+    const vector<OutputPtr>& activeOutputs = getActiveOutputs();
+    size_t numActiveOutputs = activeOutputs.size();
+    if (numActiveOutputs > 1)
+    {
+        return MULTI_OUTPUT_TYPE_STRING;
+    }
+    else if (numActiveOutputs == 1)
+    {
+        return activeOutputs[0]->getType();
+    }
+    else
+    {
+        throw Exception("Nodedef: " + getName() + " has no outputs");
+    }
+}
 
 InterfaceElementPtr NodeDef::getImplementation(const string& target, const string& language) const
 {

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -37,12 +37,6 @@ const string& NodeDef::getType() const
 {
     const vector<OutputPtr>& activeOutputs = getActiveOutputs();
 
-    // Some organizational nodes have no output types
-    if (getNodeGroup() == ORGANIZATION_NODE_GROUP && activeOutputs.empty())
-    {
-        return NONE_TYPE_STRING;
-    }
-
     size_t numActiveOutputs = activeOutputs.size();
     if (numActiveOutputs > 1)
     {
@@ -52,10 +46,7 @@ const string& NodeDef::getType() const
     {
         return activeOutputs[0]->getType();
     }
-    else
-    {
-        throw Exception("Nodedef: " + getName() + " has no outputs");
-    }
+    return EMPTY_STRING;
 }
 
 InterfaceElementPtr NodeDef::getImplementation(const string& target, const string& language) const

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -38,7 +38,7 @@ const string& NodeDef::getType() const
     // Organizational nodes have no output type
     if (getNodeGroup() == ORGANIZATION_NODE_GROUP)
     {
-        return ORGANIZATION_NODE_GROUP;
+        return NONE_TYPE_STRING;
     }
 
     const vector<OutputPtr>& activeOutputs = getActiveOutputs();

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -13,12 +13,12 @@ namespace MaterialX
 const string COLOR_SEMANTIC = "color";
 const string SHADER_SEMANTIC = "shader";
 
-const string TEXTURE_NODE_GROUP = "texture";
-const string PROCEDURAL_NODE_GROUP = "procedural";
-const string GEOMETRIC_NODE_GROUP = "geometric";
-const string ADJUSTMENT_NODE_GROUP = "adjustment";
-const string CONDITIONAL_NODE_GROUP = "conditional";
-const string ORGANIZATION_NODE_GROUP = "organization";
+const string NodeDef::TEXTURE_NODE_GROUP = "texture";
+const string NodeDef::PROCEDURAL_NODE_GROUP = "procedural";
+const string NodeDef::GEOMETRIC_NODE_GROUP = "geometric";
+const string NodeDef::ADJUSTMENT_NODE_GROUP = "adjustment";
+const string NodeDef::CONDITIONAL_NODE_GROUP = "conditional";
+const string NodeDef::ORGANIZATION_NODE_GROUP = "organization";
 
 const string NodeDef::NODE_ATTRIBUTE = "node";
 const string NodeDef::NODE_GROUP_ATTRIBUTE = "nodegroup";
@@ -35,13 +35,14 @@ const string UnitDef::UNITTYPE_ATTRIBUTE = "unittype";
 
 const string& NodeDef::getType() const
 {
-    // Organizational nodes have no output type
-    if (getNodeGroup() == ORGANIZATION_NODE_GROUP)
+    const vector<OutputPtr>& activeOutputs = getActiveOutputs();
+
+    // Some organizational nodes have no output types
+    if (getNodeGroup() == ORGANIZATION_NODE_GROUP && activeOutputs.empty())
     {
         return NONE_TYPE_STRING;
     }
 
-    const vector<OutputPtr>& activeOutputs = getActiveOutputs();
     size_t numActiveOutputs = activeOutputs.size();
     if (numActiveOutputs > 1)
     {

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -46,7 +46,10 @@ const string& NodeDef::getType() const
     {
         return activeOutputs[0]->getType();
     }
-    return EMPTY_STRING;
+    else
+    {
+        throw Exception("Nodedef: " + getName() + " has no outputs");
+    }
 }
 
 InterfaceElementPtr NodeDef::getImplementation(const string& target, const string& language) const

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -24,6 +24,7 @@ extern const string PROCEDURAL_NODE_GROUP;
 extern const string GEOMETRIC_NODE_GROUP;
 extern const string ADJUSTMENT_NODE_GROUP;
 extern const string CONDITIONAL_NODE_GROUP;
+extern const string ORGANIZATION_NODE_GROUP;
 
 class NodeDef;
 class Implementation;
@@ -107,23 +108,7 @@ class NodeDef : public InterfaceElement
     }
 
     /// Return the element's output type.
-    const string& getType() const override
-    {
-        const vector<OutputPtr>& activeOutputs = getActiveOutputs();
-        size_t numActiveOutputs = activeOutputs.size();
-        if (numActiveOutputs > 1)
-        {
-            return MULTI_OUTPUT_TYPE_STRING;
-        }
-        else if (numActiveOutputs == 1)
-        {
-            return activeOutputs[0]->getType();
-        }
-        else
-        {
-            throw Exception("Nodedef: " + getName() + " has no outputs");
-        }
-    }
+    const string& getType() const override;
 
     /// @}
     /// @name Node Group

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -19,13 +19,6 @@ namespace MaterialX
 extern const string COLOR_SEMANTIC;
 extern const string SHADER_SEMANTIC;
 
-extern const string TEXTURE_NODE_GROUP;
-extern const string PROCEDURAL_NODE_GROUP;
-extern const string GEOMETRIC_NODE_GROUP;
-extern const string ADJUSTMENT_NODE_GROUP;
-extern const string CONDITIONAL_NODE_GROUP;
-extern const string ORGANIZATION_NODE_GROUP;
-
 class NodeDef;
 class Implementation;
 class TypeDef;
@@ -182,6 +175,13 @@ class NodeDef : public InterfaceElement
     static const string CATEGORY;
     static const string NODE_ATTRIBUTE;
     static const string NODE_GROUP_ATTRIBUTE;
+
+    static const string TEXTURE_NODE_GROUP;
+    static const string PROCEDURAL_NODE_GROUP;
+    static const string GEOMETRIC_NODE_GROUP;
+    static const string ADJUSTMENT_NODE_GROUP;
+    static const string CONDITIONAL_NODE_GROUP;
+    static const string ORGANIZATION_NODE_GROUP;
 };
 
 /// @class Implementation

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -608,7 +608,7 @@ void Document::upgradeVersion()
         if (interfaceElem && interfaceElem->hasType())
         {
             string type = interfaceElem->getAttribute(TypedElement::TYPE_ATTRIBUTE);
-            if (type != MULTI_OUTPUT_TYPE_STRING)
+            if (type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
             {
                 interfaceElem->addOutput("out", type);
             }

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -609,7 +609,7 @@ void Document::upgradeVersion()
         {
             string type = interfaceElem->getAttribute(TypedElement::TYPE_ATTRIBUTE);
             OutputPtr outputPtr;
-            if (!type.empty() && type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
+            if (!type.empty() && type != MULTI_OUTPUT_TYPE_STRING)
             {
                 outputPtr = interfaceElem->addOutput("out", type);
             }

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -608,17 +608,19 @@ void Document::upgradeVersion()
         if (interfaceElem && interfaceElem->hasType())
         {
             string type = interfaceElem->getAttribute(TypedElement::TYPE_ATTRIBUTE);
+            OutputPtr outputPtr;
             if (type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
             {
-                OutputPtr newOutput = interfaceElem->addOutput("out", type);
-                const string& defaultInput = interfaceElem->getAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
-                if (!defaultInput.empty())
-                {
-                    newOutput->setAttribute(Output::DEFAULT_INPUT_ATTRIBUTE, defaultInput);
-                    interfaceElem->removeAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
-                }
-                interfaceElem->removeAttribute(TypedElement::TYPE_ATTRIBUTE);
+                outputPtr = interfaceElem->addOutput("out", type);
             }
+            interfaceElem->removeAttribute(TypedElement::TYPE_ATTRIBUTE);
+
+            const string& defaultInput = interfaceElem->getAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
+            if (outputPtr && !defaultInput.empty())
+            {
+                outputPtr->setAttribute(Output::DEFAULT_INPUT_ATTRIBUTE, defaultInput);
+            }
+            interfaceElem->removeAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
         }
     }
 

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -610,9 +610,15 @@ void Document::upgradeVersion()
             string type = interfaceElem->getAttribute(TypedElement::TYPE_ATTRIBUTE);
             if (type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
             {
-                interfaceElem->addOutput("out", type);
+                OutputPtr newOutput = interfaceElem->addOutput("out", type);
+                const string& defaultInput = interfaceElem->getAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
+                if (!defaultInput.empty())
+                {
+                    newOutput->setAttribute(Output::DEFAULT_INPUT_ATTRIBUTE, defaultInput);
+                    interfaceElem->removeAttribute(Output::DEFAULT_INPUT_ATTRIBUTE);
+                }
+                interfaceElem->removeAttribute(TypedElement::TYPE_ATTRIBUTE);
             }
-            interfaceElem->removeAttribute(TypedElement::TYPE_ATTRIBUTE);
         }
     }
 

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -609,7 +609,7 @@ void Document::upgradeVersion()
         {
             string type = interfaceElem->getAttribute(TypedElement::TYPE_ATTRIBUTE);
             OutputPtr outputPtr;
-            if (type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
+            if (!type.empty() && type != MULTI_OUTPUT_TYPE_STRING && type != NONE_TYPE_STRING)
             {
                 outputPtr = interfaceElem->addOutput("out", type);
             }

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -28,6 +28,7 @@ const string PortElement::OUTPUT_ATTRIBUTE = "output";
 const string PortElement::CHANNELS_ATTRIBUTE = "channels";
 const string InterfaceElement::NODE_DEF_ATTRIBUTE = "nodedef";
 const string Input::DEFAULT_GEOM_PROP_ATTRIBUTE = "defaultgeomprop";
+const string Output::DEFAULT_INPUT_ATTRIBUTE = "defaultinput";
 
 // Map from type strings to swizzle pattern character sets.
 const std::unordered_map<string, CharSet> PortElement::CHANNELS_CHARACTER_SET =

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -321,6 +321,7 @@ class Output : public PortElement
 
   public:
     static const string CATEGORY;
+    static const string DEFAULT_INPUT_ATTRIBUTE;
 };
 
 /// @class InterfaceElement

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -391,7 +391,7 @@ string GraphElement::asStringDot() const
             dot += "    \"" + nameMap[node->getName()] + "\" ";
             NodeDefPtr nodeDef = node->getNodeDef();
             const string& nodeGroup = nodeDef ? nodeDef->getNodeGroup() : EMPTY_STRING;
-            if (nodeGroup == CONDITIONAL_NODE_GROUP)
+            if (nodeGroup == NodeDef::CONDITIONAL_NODE_GROUP)
             {
                 dot += "[shape=diamond];\n";
             }

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -75,12 +75,12 @@ void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, c
     }
 }
 
-void loadLibrary(const FilePath& file, DocumentPtr doc)
+void loadLibrary(const FilePath& file, DocumentPtr doc, const FileSearchPath* searchPath)
 {
     DocumentPtr libDoc = createDocument();
     XmlReadOptions readOptions;
     readOptions.skipConflictingElements = true;
-    readFromXmlFile(libDoc, file, FileSearchPath(), &readOptions);
+    readFromXmlFile(libDoc, file, searchPath ? *searchPath : FileSearchPath(), &readOptions);
     CopyOptions copyOptions;
     copyOptions.skipConflictingElements = true;
     doc->importLibrary(libDoc, &copyOptions);
@@ -102,7 +102,7 @@ StringVec loadLibraries(const StringVec& libraryNames,
                 if (!excludeFiles || !excludeFiles->count(filename))
                 {
                     const FilePath& file = path / filename;
-                    loadLibrary(file, doc);
+                    loadLibrary(file, doc, &searchPath);
                     loadedLibraries.push_back(file.asString());
                 }
             }

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -34,7 +34,7 @@ void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, c
                    StringVec& errors);
 
 /// Load a given MaterialX library into a document
-void loadLibrary(const FilePath& file, DocumentPtr doc);
+void loadLibrary(const FilePath& file, DocumentPtr doc, const FileSearchPath* searchPath = nullptr);
 
 /// Load all MaterialX files with given library names in given search paths.
 /// Note that all library files will have a URI set on them.

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -91,8 +91,8 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
         const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
         for (const mx::NodeDefPtr& nodedef : nodedefs)
         {
-            // Some nodes have no type, such as some organizational nodes 
-            if (nodedef->getType() == mx::NONE_TYPE_STRING)
+            // Skip typeless nodes
+            if (nodedef->getType().empty())
             {
                 continue;
             }
@@ -180,8 +180,8 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
     for (const mx::NodeDefPtr& nodedef : nodedefs)
     {
-        // Some nodes have no type, such as some organizational nodes 
-        if (nodedef->getType() == mx::NONE_TYPE_STRING)
+        // Skip typeless nodes
+        if (nodedef->getType().empty())
         {
             continue;
         }

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -63,14 +63,15 @@ TEST_CASE("GenReference: genglsl reference implementation file", "[genreference]
     const std::string IMPLEMENTATION_PREFIX = "IM_";
     const std::string IMPLEMENTATION_STRING = "impl";
 
-    const mx::StringVec GEN_LANGUAGE = { "genglsl", "genosl" };
-    const mx::StringVec LANGUAGE = { "glsl", "osl" };
+    const mx::StringVec genlanguage = { "genglsl", "genosl" };
+    const mx::StringVec language = { "glsl", "osl" };
+    const std::vector<bool> outputFunction = { false, true };
 
-    for (size_t i = 0; i < GEN_LANGUAGE.size(); i++)
+    for (size_t i = 0; i < genlanguage.size(); i++)
     {
-
         mx::FilePath librariesPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-        mx::FilePath outputPathRel = LIBRARY + "/" + "reference/" + GEN_LANGUAGE[i];
+        mx::FilePath outputPathRel = LIBRARY + "/" + "reference/" + genlanguage[i];
+        mx::FilePath implPath = LIBRARY + "/" + genlanguage[i];
 
         mx::FilePath outputPath = librariesPath / outputPathRel;
 
@@ -80,7 +81,7 @@ TEST_CASE("GenReference: genglsl reference implementation file", "[genreference]
 
         // Create an implementation per nodedef
         //
-        const std::string logFilename = GEN_LANGUAGE[i] + "_impl_file_test.txt";
+        const std::string logFilename = genlanguage[i] + "_impl_file_test.txt";
         const mx::FilePath logPath(logFilename);
         std::ofstream logFile;
         logFile.open(logPath);
@@ -95,15 +96,18 @@ TEST_CASE("GenReference: genglsl reference implementation file", "[genreference]
                 nodeName = nodeName.substr(3);
             }
 
-            const std::string filename = nodeName + "." + LANGUAGE[i];
+            const std::string filename = nodeName + "." + language[i];
             try
             {
                 mx::ImplementationPtr impl = implDoc->addImplementation(
-                    IMPLEMENTATION_PREFIX + nodeName + "_" + LANGUAGE[i]);
+                    IMPLEMENTATION_PREFIX + nodeName + "_" + language[i]);
                 impl->setNodeDef(nodedef);
-                impl->setFile((outputPathRel / filename).asString(mx::FilePath::FormatPosix));
-                impl->setFunction("mx_" + nodeName);
-                impl->setLanguage(GEN_LANGUAGE[i]);
+                impl->setFile((implPath / filename).asString(mx::FilePath::FormatPosix));
+                if (outputFunction[i])
+                {
+                    impl->setFunction("mx_" + nodeName);
+                }
+                impl->setLanguage(genlanguage[i]);
             }
             catch (mx::ExceptionShaderGenError& e)
             {
@@ -113,7 +117,7 @@ TEST_CASE("GenReference: genglsl reference implementation file", "[genreference]
         }
 
         // Save implementations to disk
-        const std::string implFileName = LIBRARY + "_" + LANGUAGE[i] + "_" + IMPLEMENTATION_STRING + ".mtlx";
+        const std::string implFileName = LIBRARY + "_" + language[i] + "_" + IMPLEMENTATION_STRING + ".mtlx";
         std::cout << "write OSL impl file to: " << (outputPath / implFileName).asString() << std::endl;
         mx::writeToXmlFile(implDoc, outputPath / implFileName);
 

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -89,8 +89,8 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
         const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
         for (const mx::NodeDefPtr& nodedef : nodedefs)
         {
-            // Organizational nodes have no implementations
-            if (nodedef->getNodeGroup() == mx::ORGANIZATION_NODE_GROUP)
+            // Some nodes have no type, such as some organizational nodes 
+            if (nodedef->getType() == mx::NONE_TYPE_STRING)
             {
                 continue;
             }
@@ -163,8 +163,8 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
     for (const mx::NodeDefPtr& nodedef : nodedefs)
     {
-        // Organizational nodes have no implementations
-        if (nodedef->getNodeGroup() == mx::ORGANIZATION_NODE_GROUP)
+        // Some nodes have no type, such as some organizational nodes 
+        if (nodedef->getType() == mx::NONE_TYPE_STRING)
         {
             continue;
         }

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -118,7 +118,7 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
             {
                 if (!logFile.is_open())
                 {
-                    logFile.open();
+                    logFile.open(logPath);
                 }
                 logFile << "Cannot create implementation reference for node: '" << nodeName << " : ";
                 logFile << e.what() << std::endl;
@@ -126,7 +126,7 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
         }
 
         // Save implementations to disk
-        const std::string implFileName = LIBRARY + "_" + language[i] + "_" + IMPLEMENTATION_STRING + ".mtlx";
+        const std::string implFileName = LIBRARY + "_" + language[i] + "_" + IMPLEMENTATION_STRING + ".refmtlx";
         mx::writeToXmlFile(implDoc, outputPath / implFileName);
 
         if (logFile.is_open())

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -94,6 +94,16 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
             {
                 continue;
             }
+            bool hasOutputs = !nodedef->getActiveOutputs().empty();
+            CHECK(hasOutputs);
+            if (!hasOutputs)
+            {
+                if (!logFile.is_open())
+                {
+                    logFile.open(logPath);
+                }
+                logFile << "Cannot create implementation reference for nodedef which has not outputs: '" << nodedef->getName() << std::endl;
+            }
 
             std::string nodeName = nodedef->getName();
             if (nodeName.size() > 3 && nodeName.substr(0, 3) == DEFINITION_PREFIX)

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -91,11 +91,6 @@ TEST_CASE("GenReference: Reference implementation file test", "[genreference]")
         const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
         for (const mx::NodeDefPtr& nodedef : nodedefs)
         {
-            // Skip typeless nodes
-            if (nodedef->getType().empty())
-            {
-                continue;
-            }
             bool hasOutputs = !nodedef->getActiveOutputs().empty();
             CHECK(hasOutputs);
             if (!hasOutputs)
@@ -180,12 +175,6 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     const std::vector<mx::NodeDefPtr> nodedefs = stdlibDoc->getNodeDefs();
     for (const mx::NodeDefPtr& nodedef : nodedefs)
     {
-        // Skip typeless nodes
-        if (nodedef->getType().empty())
-        {
-            continue;
-        }
-
         std::string nodeName = nodedef->getName();
         if (nodeName.size() > 3 && nodeName.substr(0, 3) == "ND_")
         {
@@ -243,7 +232,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
         stdlibDoc->removeChild(node->getName());
     }
 
-    mx::writeToXmlFile(implDoc, outputPath / "stdlib_osl_impl.mtlx");
+    mx::writeToXmlFile(implDoc, outputPath / "stdlib_osl_impl.refmtlx");
 
     logFile.close();
 }

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -67,7 +67,7 @@ TEST_CASE("Node", "[node]")
 
     // Create a custom nodedef.
     mx::NodeDefPtr customNodeDef = doc->addNodeDef("ND_turbulence3d", "float", "turbulence3d");
-    customNodeDef->setNodeGroup(mx::PROCEDURAL_NODE_GROUP);
+    customNodeDef->setNodeGroup(mx::NodeDef::PROCEDURAL_NODE_GROUP);
     customNodeDef->setParameterValue("octaves", 3);
     customNodeDef->setParameterValue("lacunarity", 2.0f);
     customNodeDef->setParameterValue("gain", 0.5f);
@@ -75,7 +75,7 @@ TEST_CASE("Node", "[node]")
     // Reference the custom nodedef.
     mx::NodePtr custom = doc->addNodeInstance(customNodeDef);
     REQUIRE(custom->getNodeDefString() == customNodeDef->getName());
-    REQUIRE(custom->getNodeDef()->getNodeGroup() == mx::PROCEDURAL_NODE_GROUP);
+    REQUIRE(custom->getNodeDef()->getNodeGroup() == mx::NodeDef::PROCEDURAL_NODE_GROUP);
     REQUIRE(custom->getParameterValue("octaves")->isA<int>());
     REQUIRE(custom->getParameterValue("octaves")->asA<int>() == 3);
     custom->setParameterValue("octaves", 5);

--- a/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
@@ -28,7 +28,13 @@ void bindPyDefinition(py::module& mod)
         .def("getInstantiatingShaderRefs", &mx::NodeDef::getInstantiatingShaderRefs)
         .def("isVersionCompatible", &mx::NodeDef::isVersionCompatible)
         .def_readonly_static("CATEGORY", &mx::NodeDef::CATEGORY)
-        .def_readonly_static("NODE_ATTRIBUTE", &mx::NodeDef::NODE_ATTRIBUTE);
+        .def_readonly_static("NODE_ATTRIBUTE", &mx::NodeDef::NODE_ATTRIBUTE)
+        .def_readonly_static("TEXTURE_NODE_GROUP", &mx::NodeDef::TEXTURE_NODE_GROUP)
+        .def_readonly_static("PROCEDURAL_NODE_GROUP", &mx::NodeDef::PROCEDURAL_NODE_GROUP)
+        .def_readonly_static("GEOMETRIC_NODE_GROUP", &mx::NodeDef::GEOMETRIC_NODE_GROUP)
+        .def_readonly_static("ADJUSTMENT_NODE_GROUP", &mx::NodeDef::ADJUSTMENT_NODE_GROUP)
+        .def_readonly_static("CONDITIONAL_NODE_GROUP", &mx::NodeDef::CONDITIONAL_NODE_GROUP)
+        .def_readonly_static("ORGANIZATION_NODE_GROUP", &mx::NodeDef::ORGANIZATION_NODE_GROUP);
 
     py::class_<mx::Implementation, mx::ImplementationPtr, mx::InterfaceElement>(mod, "Implementation")
         .def("setFile", &mx::Implementation::setFile)

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -38,7 +38,8 @@ void bindPyInterface(py::module& mod)
 
     py::class_<mx::Output, mx::OutputPtr, mx::PortElement>(mod, "Output")
         .def("hasUpstreamCycle", &mx::Output::hasUpstreamCycle)
-        .def_readonly_static("CATEGORY", &mx::Output::CATEGORY);
+        .def_readonly_static("CATEGORY", &mx::Output::CATEGORY)
+        .def_readonly_static("DEFAULT_INPUT_ATTRIBUTE", &mx::Output::DEFAULT_INPUT_ATTRIBUTE);
 
     py::class_<mx::InterfaceElement, mx::InterfaceElementPtr, mx::TypedElement>(mod, "InterfaceElement")
         .def("setNodeDefString", &mx::InterfaceElement::setNodeDefString)


### PR DESCRIPTION
Update #639, #385
Part I updates: Preliminary fixes for explicit outputs.
- Update of stddef for explicit outputs.
- Add in handing for non-typed nodedefs (e.g. "backdrop")
- Add in logic for handling "defaultinput" properly.
Part II prep: Nodedef remapping.
- Add in implementation generation test, which sanity check against updates in Part I.
