### PR TITLE
1.37 Update : Migrate backdrop to no longer be a node.

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4868,17 +4868,4 @@
     <output name="out" type="lightshader" defaultinput="in"/>
   </nodedef>
 
-  <!--
-    Node: <backdrop>
-    A layout element used to contain, group and document other nodes.
-    Output type is marked as "none" to indicate there is no output.
-  -->
-  <nodedef name="ND_backdrop" node="backdrop" nodegroup="organization">
-    <parameter name="note" type="string" value=""/>
-    <parameter name="contains" type="stringarray" value=""/>
-    <parameter name="width" type="float" value="1.0"/>
-    <parameter name="height" type="float" value="1.0"/>
-    <output name="out" type="none"/>
-  </nodedef>
-
 </materialx>

--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -61,7 +61,7 @@ def main(args=None):
         if len(glslFiles) != len(oslFiles):
             print ("Number of glsl files " + str(len(glslFiles)) + " does not match number of osl files " +  str(len(oslFiles)) + " in dir: " + subdir)
             print ("GLSL list: " + str(glslFiles))
-	        print ("OSL files: " + str(oslFiles))
+            print ("OSL files: " + str(oslFiles))
             continue
         elif len(glslFiles) > 0 and len(oslFiles) > 0:
             fh.write("<h2>" + subdir + ":</h2><br>\n")

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -658,6 +658,8 @@ void Document::upgradeVersion()
             }
         }
         removeNodeDef(ND_BACKDROP);
+
+        minorVersion = 37;
     }
 
     if (majorVersion == MATERIALX_MAJOR_VERSION &&

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -353,6 +353,34 @@ class Document : public GraphElement
     vector<NodeDefPtr> getMatchingNodeDefs(const string& nodeName) const;
 
     /// @}
+    /// @name Backdrop Elements
+    /// @{
+
+    /// Add a Backdrop to the document.
+    BackdropPtr addBackdrop(const string& name = EMPTY_STRING)
+    {
+        return addChild<Backdrop>(name);
+    }
+
+    /// Return the Backdrop, if any, with the given name.
+    BackdropPtr getBackdrop(const string& name) const
+    {
+        return getChildOfType<Backdrop>(name);
+    }
+
+    /// Return a vector of all Backdrop elements in the document.
+    vector<BackdropPtr> getBackdrops() const
+    {
+        return getChildrenOfType<Backdrop>();
+    }
+
+    /// Remove the Backdrop, if any, with the given name.
+    void removeBackdrop(const string& name)
+    {
+        removeChildOfType<Backdrop>(name);
+    }
+
+    /// @}
     /// @name PropertySet Elements
     /// @{
 

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -785,6 +785,7 @@ const string T::CATEGORY(category);                     \
 ElementRegistry<T> registry##T;                         \
 INSTANTIATE_SUBCLASS(T)
 
+INSTANTIATE_CONCRETE_SUBCLASS(Backdrop, "backdrop")
 INSTANTIATE_CONCRETE_SUBCLASS(BindParam, "bindparam")
 INSTANTIATE_CONCRETE_SUBCLASS(BindInput, "bindinput")
 INSTANTIATE_CONCRETE_SUBCLASS(BindToken, "bindtoken")

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -495,4 +495,84 @@ ConstNodeDefPtr NodeGraph::getDeclaration(const string&) const
     return getNodeDef();
 }
 
+
+// 
+// Backdrop Methods
+// 
+const string Backdrop::NOTE_ATTRIBUTE = "note";
+const string Backdrop::CONTAINS_ATTRIBUTE = "contains";
+const string Backdrop::WIDTH_ATTRIBUTE = "width";
+const string Backdrop::HEIGHT_ATTRIBUTE = "height";
+
+string Backdrop::getNote() const
+{
+    ValuePtr value = getParameterValue(NOTE_ATTRIBUTE);
+    return value ? value->asA<string>() : EMPTY_STRING;
+}
+
+void Backdrop::setNote(const string& note)
+{
+    ParameterPtr param = getParameter(NOTE_ATTRIBUTE);
+    if (!param)
+    {
+        param = addParameter(NOTE_ATTRIBUTE);
+    }
+    param->setValue(note);
+}
+
+/// Returns a comma-separated list of node names that the
+/// backdrop "contains".  By default a backdrop contains no nodes.
+string Backdrop::getContains() const
+{
+    ValuePtr value = getParameterValue(CONTAINS_ATTRIBUTE);
+    return value ? value->asA<string>() : EMPTY_STRING;
+}
+
+/// Set the list of nodes that the backdrop "contains".
+void Backdrop::setContains(const string& contains)
+{
+    ParameterPtr param = getParameter(CONTAINS_ATTRIBUTE);
+    if (!param)
+    {
+        param = addParameter(CONTAINS_ATTRIBUTE);
+    }
+    param->setValue(contains);
+}
+
+/// Get the width of the backdrop when drawn in a UI.
+float Backdrop::getWidth() const
+{
+    ValuePtr value = getParameterValue(WIDTH_ATTRIBUTE);
+    return value ? value->asA<float>() : 1.0f;
+}
+
+/// Set the width of the backdrop when drawn in a UI.
+void Backdrop::setWidth(float width)
+{
+    ParameterPtr param = getParameter(WIDTH_ATTRIBUTE);
+    if (!param)
+    {
+        param = addParameter(WIDTH_ATTRIBUTE);
+    }
+    param->setValue(width);
+}
+
+/// Get the width of the backdrop when drawn in a UI.
+float Backdrop::getHeight() const
+{
+    ValuePtr value = getParameterValue(HEIGHT_ATTRIBUTE);
+    return value ? value->asA<float>() : 1.0f;
+}
+
+/// Set the height of the backdrop when drawn in a UI.
+void Backdrop::setHeight(float height)
+{
+    ParameterPtr param = getParameter(HEIGHT_ATTRIBUTE);
+    if (!param)
+    {
+        param = addParameter(HEIGHT_ATTRIBUTE);
+    }
+    param->setValue(height);
+}
+
 } // namespace MaterialX

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -290,75 +290,47 @@ class NodeGraph : public GraphElement
 
 /// @class Backdrop
 /// A layout element used to contain, group and document other nodes.
-class Backdrop : public Element
+class Backdrop : public InterfaceElement
 {
   public:
     Backdrop(ElementPtr parent, const string& name) :
-        Element(parent, CATEGORY, name),
-        _width(1.0),
-        _height(1.0)
+        InterfaceElement(parent, CATEGORY, name)
     {
     }
     virtual ~Backdrop() { }
 
     /// Return the text note associated with the backdrop. By default 
     /// no text is associated.
-    const string& getNote() const
-    {
-        return _note;
-    }
+    string getNote() const;
 
     /// Set the text note associated with the backdrop.
-    void setNote(const string& note)
-    {
-        _note = note;
-    }
+    void setNote(const string& note);
 
     /// Returns a comma-separated list of node names that the
     /// backdrop "contains".  By default a backdrop contains no nodes.
-    const string& getContains() const
-    {
-        return _contains;
-    }
+    string getContains() const;
 
     /// Set the list of nodes that the backdrop "contains".
-    void setContains(const string& contains)
-    {
-        _contains = contains;
-    }
+    void setContains(const string& contains);
 
     /// Get the width of the backdrop when drawn in a UI.
-    float getWidth() const
-    {
-        return _width;
-    }
+    float getWidth() const;
 
     /// Set the width of the backdrop when drawn in a UI.
-    void setWidth(float width)
-    {
-        _width = width;
-    }
+    void setWidth(float width);
 
     /// Get the width of the backdrop when drawn in a UI.
-    float getHeight() const
-    {
-        return _height;
-    }
+    float getHeight() const;
 
     /// Set the height of the backdrop when drawn in a UI.
-    void setHeight(float height)
-    {
-        _height = height;
-    }
+    void setHeight(float height);
 
   public:
     static const string CATEGORY;
-
-  private:
-    string _note;
-    string _contains;
-    float _width;
-    float _height;
+    static const string NOTE_ATTRIBUTE;
+    static const string CONTAINS_ATTRIBUTE;
+    static const string WIDTH_ATTRIBUTE;
+    static const string HEIGHT_ATTRIBUTE;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -19,6 +19,7 @@ namespace MaterialX
 class Node;
 class GraphElement;
 class NodeGraph;
+class Backdrop;
 
 /// A shared pointer to a Node
 using NodePtr = shared_ptr<Node>;
@@ -34,6 +35,11 @@ using ConstGraphElementPtr = shared_ptr<const GraphElement>;
 using NodeGraphPtr = shared_ptr<NodeGraph>;
 /// A shared pointer to a const NodeGraph
 using ConstNodeGraphPtr = shared_ptr<const NodeGraph>;
+
+/// A shared pointer to a Backdrop
+using BackdropPtr = shared_ptr<Backdrop>;
+/// A shared pointer to a const Backdrop
+using ConstBackdropPtr = shared_ptr<const Backdrop>;
 
 /// @class Node
 /// A node element within a NodeGraph or Document.
@@ -280,6 +286,79 @@ class NodeGraph : public GraphElement
 
   public:
     static const string CATEGORY;
+};
+
+/// @class Backdrop
+/// A layout element used to contain, group and document other nodes.
+class Backdrop : public Element
+{
+  public:
+    Backdrop(ElementPtr parent, const string& name) :
+        Element(parent, CATEGORY, name),
+        _width(1.0),
+        _height(1.0)
+    {
+    }
+    virtual ~Backdrop() { }
+
+    /// Return the text note associated with the backdrop. By default 
+    /// no text is associated.
+    const string& getNote() const
+    {
+        return _note;
+    }
+
+    /// Set the text note associated with the backdrop.
+    void setNote(const string& note)
+    {
+        _note = note;
+    }
+
+    /// Returns a comma-separated list of node names that the
+    /// backdrop "contains".  By default a backdrop contains no nodes.
+    const string& getContains() const
+    {
+        return _contains;
+    }
+
+    /// Set the list of nodes that the backdrop "contains".
+    void setContains(const string& contains)
+    {
+        _contains = contains;
+    }
+
+    /// Get the width of the backdrop when drawn in a UI.
+    float getWidth() const
+    {
+        return _width;
+    }
+
+    /// Set the width of the backdrop when drawn in a UI.
+    void setWidth(float width)
+    {
+        _width = width;
+    }
+
+    /// Get the width of the backdrop when drawn in a UI.
+    float getHeight() const
+    {
+        return _height;
+    }
+
+    /// Set the height of the backdrop when drawn in a UI.
+    void setHeight(float height)
+    {
+        _height = height;
+    }
+
+  public:
+    static const string CATEGORY;
+
+  private:
+    string _note;
+    string _contains;
+    float _width;
+    float _height;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -319,7 +319,7 @@ class Backdrop : public InterfaceElement
     /// Set the width of the backdrop when drawn in a UI.
     void setWidth(float width);
 
-    /// Get the width of the backdrop when drawn in a UI.
+    /// Get the height of the backdrop when drawn in a UI.
     float getHeight() const;
 
     /// Set the height of the backdrop when drawn in a UI.

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -534,10 +534,8 @@ TEST_CASE("Organization", "[nodegraph]")
     mx::readFromXmlFile(doc, "custom1_nodedef.mtlx");
     backdrop = doc->getBackdrop("custom1_backdrop");
     CHECK(backdrop != nullptr);
-    const std::string contains = backdrop->getContains();
-    CHECK(contains == "custom1");
+    CHECK(backdrop->getContains() == "custom1");
     CHECK(backdrop->getWidth() == 20.0f);
     CHECK(backdrop->getHeight() == 30.0f);
-    const std::string note = backdrop->getNote();
     CHECK(backdrop->getNote() == "My note.");
 }

--- a/source/MaterialXTest/Node.cpp
+++ b/source/MaterialXTest/Node.cpp
@@ -473,7 +473,8 @@ TEST_CASE("Organization", "[nodegraph]")
     // Create a document.
     mx::DocumentPtr doc = mx::createDocument();
 
-    // Create a node graph with the following structure:
+    // 1. Create a node graph with the following structure to be used as a 
+    // nodedef implementation
     //
     //   [constant1] [constant2]      [image2]
     //           \   /          \    /
@@ -523,19 +524,69 @@ TEST_CASE("Organization", "[nodegraph]")
 
     doc->addNode("custom1", "custom1_node");
 
-    // Add some backdrops
+    // Add backdrop for the node which is implemented as a graph
     mx::BackdropPtr backdrop = doc->addBackdrop("custom1_backdrop");
     backdrop->setContains("custom1");
     backdrop->setWidth(20.0f);
     backdrop->setHeight(30.0f);
-    backdrop->setNote("My note.");
+    backdrop->setNote("Backdrop for custom1.");
 
+    // 2. Additional graph to test backdrops
+    //   [image3] [image4]      
+    //         \   /
+    //         [add4]
+    //            |
+    //         [output]
+    //
+    mx::NodeGraphPtr nodeGraph2 = doc->addNodeGraph("custom2_nodegraph");
+    mx::NodePtr image3 = nodeGraph2->addNode("image", "image3");
+    mx::NodePtr image4 = nodeGraph2->addNode("image", "image4");
+    mx::NodePtr add4 = nodeGraph2->addNode("add", "add4");
+    add4->setConnectedNode("in1", image3);
+    add4->setConnectedNode("in2", image4);
+    mx::OutputPtr output2 = nodeGraph2->addOutput("output");
+    output2->setConnectedNode(add4);
+
+    // Add backdrops for nodes / node graphs
+    mx::BackdropPtr backdrop2 = doc->addBackdrop("custom2_backdrop_nodes");
+    backdrop2->setContains("add4,image3");
+    backdrop2->setWidth(10.0f);
+    backdrop2->setHeight(15.0f);
+    backdrop2->setNote("Backdrop for add and image3");
+    mx::BackdropPtr backdrop3 = doc->addBackdrop("custom2_backdrop_nodegraph");
+    backdrop3->setContains("custom2_nodegraph,custom1");
+    backdrop3->setWidth(45.0f);
+    backdrop3->setHeight(50.0f);
+    backdrop3->setNote("Backdrop for: custom2_nodegraph, and custom1.");
+
+    doc->validate();
+
+    // Test write / read of backdrop information
     mx::writeToXmlFile(doc, "custom1_nodedef.mtlx");
     mx::readFromXmlFile(doc, "custom1_nodedef.mtlx");
+
+    // Test backdrop values and removal
     backdrop = doc->getBackdrop("custom1_backdrop");
     CHECK(backdrop != nullptr);
     CHECK(backdrop->getContains() == "custom1");
     CHECK(backdrop->getWidth() == 20.0f);
     CHECK(backdrop->getHeight() == 30.0f);
-    CHECK(backdrop->getNote() == "My note.");
+    CHECK(backdrop->getNote() == "Backdrop for custom1.");
+
+    backdrop = doc->getBackdrop("custom2_backdrop_nodes");
+    CHECK(backdrop->getContains() == "add4,image3");
+    CHECK(backdrop->getWidth() == 10.0f);
+    CHECK(backdrop->getHeight() == 15.0f);
+    CHECK(backdrop->getNote() == "Backdrop for add and image3");
+
+    backdrop = doc->getBackdrop("custom2_backdrop_nodegraph");
+    CHECK(backdrop->getContains() == "custom2_nodegraph,custom1");
+    CHECK(backdrop->getWidth() == 45.0f);
+    CHECK(backdrop->getHeight() == 50.0f);
+    CHECK(backdrop->getNote() == "Backdrop for: custom2_nodegraph, and custom1.");
+
+    doc->removeBackdrop("custom1_backdrop");
+    doc->removeBackdrop("custom2_backdrop_nodes");
+    doc->removeBackdrop("custom2_backdrop_nodegraph");
+    CHECK(doc->getBackdrops().size() == 0);
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -43,4 +43,19 @@ void bindPyNode(py::module& mod)
         .def("setNodeDef", &mx::NodeGraph::setNodeDef)
         .def("getNodeDef", &mx::NodeGraph::getNodeDef)
         .def_readonly_static("CATEGORY", &mx::NodeGraph::CATEGORY);
+
+    py::class_<mx::Backdrop, mx::BackdropPtr, mx::InterfaceElement>(mod, "Backdrop")
+        .def("getNote", &mx::Backdrop::getNote)
+        .def("setNote", &mx::Backdrop::setNote)
+        .def("getContains", &mx::Backdrop::getContains)
+        .def("setContains", &mx::Backdrop::setContains)
+        .def("getWidth", &mx::Backdrop::getWidth)
+        .def("setWidth", &mx::Backdrop::setWidth)
+        .def("getHeight", &mx::Backdrop::getHeight)
+        .def("setHeight", &mx::Backdrop::setHeight)
+        .def_readonly_static("CATEGORY", &mx::Backdrop::CATEGORY)
+        .def_readonly_static("NOTE_ATTRIBUTE", &mx::Backdrop::NOTE_ATTRIBUTE)
+        .def_readonly_static("CONTAINS_ATTRIBUTE", &mx::Backdrop::CONTAINS_ATTRIBUTE)
+        .def_readonly_static("WIDTH_ATTRIBUTE", &mx::Backdrop::WIDTH_ATTRIBUTE)
+        .def_readonly_static("HEIGHT_ATTRIBUTE", &mx::Backdrop::HEIGHT_ATTRIBUTE);
 }


### PR DESCRIPTION
Update #682 
- `Backdrop` is now an explicit element. We derive from InterfaceElement to be able to use existing class support such as input/parameters. Which also is used for file I/O.
- Add in upgrade path + unit test.

