### PR TITLE
Fix vanilla osl test #705

### DIFF
--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -44,7 +44,7 @@ void GenContext::addNodeImplementation(const string& name, ShaderNodeImplPtr imp
     _nodeImpls[name] = impl;
 }
 
-ShaderNodeImplPtr GenContext::findNodeImplementation(const string& name)
+ShaderNodeImplPtr GenContext::findNodeImplementation(const string& name) const
 {
     auto it = _nodeImpls.find(name);
     return it != _nodeImpls.end() ? it->second : nullptr;

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -126,7 +126,7 @@ class GenContext
 
     /// Find and return a cached shader node implementation,
     /// or return nullptr if no implementation is found.
-    ShaderNodeImplPtr findNodeImplementation(const string& name);
+    ShaderNodeImplPtr findNodeImplementation(const string& name) const;
 
     /// Clear all cached shader node implementation.
     void clearNodeImplementations();

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -122,6 +122,7 @@ static void generateOslCode()
     const mx::FilePath logPath("genosl_vanilla_generate_test.txt");
 
     OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
+    tester.addSkipLibraryFiles();
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");

--- a/source/MaterialXTest/GenOsl.h
+++ b/source/MaterialXTest/GenOsl.h
@@ -39,6 +39,11 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
         ParentClass::addSkipNodeDefs();
     }
 
+    // Arnold specific files are ignored in vanilla osl target
+    void addSkipLibraryFiles() override
+    {
+        _skipLibraryFiles.insert( "pbrlib_genosl_arnold_impl.mtlx" );
+    }
     // Ignore light shaders in the document for OSL
     void findLights(mx::DocumentPtr /*doc*/, std::vector<mx::NodePtr>& lights) override
     {

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -464,7 +464,8 @@ void ShaderGeneratorTester::setupDependentLibraries()
 
     // Load the standard libraries.
     const mx::StringVec libraries = { "stdlib", "pbrlib", "lights" };
-    loadLibraries(libraries, _libSearchPath, _dependLib);
+
+    loadLibraries(libraries, _libSearchPath, _dependLib, &_skipLibraryFiles);
 
     // Load shader definitions used in the test suite.
     loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/bxdf/standard_surface.mtlx"), _dependLib);
@@ -480,6 +481,10 @@ void ShaderGeneratorTester::addSkipFiles()
 }
 
 void ShaderGeneratorTester::addSkipNodeDefs()
+{
+}
+
+void ShaderGeneratorTester::addSkipLibraryFiles()
 {
 }
 

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -296,8 +296,8 @@ void testUniqueNames(mx::GenContext& context, const std::string& stage)
 }
 
 
-void ShaderGeneratorTester::checkImplementationUsage(mx::StringSet& usedImpls,
-                                                     mx::GenContext& context,
+void ShaderGeneratorTester::checkImplementationUsage(const mx::StringSet& usedImpls,
+                                                     const mx::GenContext& context,
                                                      std::ostream& stream)
 {
     // Get list of implementations a given langauge.

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -199,13 +199,13 @@ class ShaderGeneratorTester
     void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);
 
   protected:
-    // Check to see that all implemenations have been tested for a given
+    // Check to see that all implementations have been tested for a given
     // language.
-    void checkImplementationUsage(mx::StringSet& usedImpls,
-                                    mx::GenContext& context,
+    void checkImplementationUsage(const mx::StringSet& usedImpls,
+                                    const mx::GenContext& context,
                                     std::ostream& stream);
 
-    // Get implemenation "whitelist" for those implementations that have
+    // Get implementation "whitelist" for those implementations that have
     // been skipped for checking
     virtual void getImplementationWhiteList(mx::StringSet& whiteList) = 0;
 

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -172,6 +172,9 @@ class ShaderGeneratorTester
     // Add nodedefs to not examine
     virtual void addSkipNodeDefs();
 
+    // Add files to be skipped while loading libraries
+    virtual void addSkipLibraryFiles();
+
     // Add color management
     virtual void addColorManagement();
 
@@ -225,6 +228,7 @@ class ShaderGeneratorTester
     const mx::FilePath _logFilePath;
 
     mx::StringSet _skipFiles;
+    mx::StringSet _skipLibraryFiles;
     std::vector<mx::DocumentPtr> _documents;
     mx::StringVec _documentPaths;
     std::ofstream _logFile;


### PR DESCRIPTION
While running the "GenShader: OSL Shader Generation", "[genosl]" test, it is failing.
See issue #705 for more info.

This fix is adding a new method to be able to exclude specific files located in the libraries paths.