### PR TITLE
Add addPort() interfaces for RtNodeGraph and RtNodeDef

### DIFF
--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -39,6 +39,11 @@ const RtToken& RtNodeDef::getNodeName() const
     return data()->asA<PvtNodeDef>()->getNodeName();
 }
 
+void RtNodeDef::addPort(const RtToken& name, const RtToken& type, uint32_t flags)
+{
+    RtPortDef::createNew(getObject(), name, type, flags);
+}
+
 void RtNodeDef::removePort(RtObject portdef)
 {
     if (!portdef.hasApi(RtApiType::PORTDEF))

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -33,7 +33,10 @@ public:
     /// Return the node name.
     const RtToken& getNodeName() const;
 
-    /// Remove an port definition.
+    /// Add a port to the definition
+    void addPort(const RtToken& name, const RtToken& type, uint32_t flags = 0);
+
+    /// Remove a port from the definition.
     void removePort(RtObject portdef);
 
     /// Return the port count.

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -47,6 +47,11 @@ void RtNodeGraph::removeNode(const RtObject& node)
     return data()->asA<PvtNodeGraph>()->removeNode(n->getName());
 }
 
+void RtNodeGraph::addPort(const RtToken& name, const RtToken& type, uint32_t flags)
+{
+    RtPortDef::createNew(getObject(), name, type, flags);
+}
+
 void RtNodeGraph::removePort(const RtObject& portdef)
 {
     if (!portdef.hasApi(RtApiType::PORTDEF))

--- a/source/MaterialXRuntime/RtNodeGraph.h
+++ b/source/MaterialXRuntime/RtNodeGraph.h
@@ -37,6 +37,9 @@ public:
     /// Remove a node from the graph.
     void removeNode(const RtObject& node);
 
+    /// Add a port to the graph.
+    void addPort(const RtToken& name, const RtToken& type, uint32_t flags = 0);
+
     /// Remove a port from the graph.
     void removePort(const RtObject& portdef);
 

--- a/source/MaterialXRuntime/RtPortDef.h
+++ b/source/MaterialXRuntime/RtPortDef.h
@@ -42,7 +42,7 @@ public:
     RtPortDef(const RtObject& obj);
 
     /// Create a new portdef and add it to a parent if specified.
-    /// The parent must be a nodedefs or a nodegraph.
+    /// The parent must be a nodedef or a nodegraph.
     static RtObject createNew(RtObject parent, const RtToken& name, const RtToken& type, uint32_t flags = 0);
 
     /// Return the type for this API.

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -259,10 +259,10 @@ TEST_CASE("Runtime: Nodes", "[runtime]")
     REQUIRE(addDef.numAttributes() == 1);
 
     // Add ports to the nodedef
-    mx::RtPortDef::createNew(addDefObj, "in1", "float");
-    mx::RtPortDef::createNew(addDefObj, "in2", "float");
-    mx::RtPortDef::createNew(addDefObj, "in3", "float");
-    mx::RtPortDef::createNew(addDefObj, "out", "float", mx::RtPortFlag::OUTPUT);
+    addDef.addPort("in1", "float");
+    addDef.addPort("in2", "float");
+    addDef.addPort("in3", "float");
+    addDef.addPort("out", "float", mx::RtPortFlag::OUTPUT);
     REQUIRE(addDef.numPorts() == 4);
 
     // Delete a port
@@ -455,9 +455,9 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(!stage.findElementByPath(pathStr));
 
     // Add interface port definitions to the graph.
-    mx::RtPortDef::createNew(graphObj1, "a", "float");
-    mx::RtPortDef::createNew(graphObj1, "b", "float");
-    mx::RtPortDef::createNew(graphObj1, "out", "float", mx::RtPortFlag::OUTPUT);
+    graph1.addPort("a", "float");
+    graph1.addPort("b", "float");
+    graph1.addPort("out", "float", mx::RtPortFlag::OUTPUT);
     REQUIRE(graph1.numPorts() == 3);
     REQUIRE(graph1.findInputSocket("a").isValid());
     REQUIRE(graph1.findInputSocket("b").isValid());
@@ -467,7 +467,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(graph1.getOutputSocket(0).isInput());
 
     // Test deleting a port.
-    mx::RtPortDef::createNew(graphObj1, "c", "float");
+    graph1.addPort("c", "float");
     REQUIRE(graph1.numPorts() == 4);
     REQUIRE(graph1.findInputSocket("c").isValid());
     mx::RtObject cPort = mx::RtNodeDef(graph1.getNodeDef()).findPort("c");


### PR DESCRIPTION
Update #638 
Add addPort() interfaces to RtNodeGraph and RtNodeDef to simplify addition and have an interaces cooresponding to the removePort() method on each class.