### PR TITLE
Fix up to add dependent includes to reference osl area

### DIFF
--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -31,7 +31,11 @@ endif()
 
 add_custom_command(TARGET MaterialXTest POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
-	${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)
+	${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_CURRENT_BINARY_DIR}/libraries)     
+install(DIRECTORY DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libraries/stdlib/reference/osl)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/stdlib/osl/"
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libraries/stdlib/reference/osl 
+    FILES_MATCHING PATTERN "*.h")
 add_custom_command(TARGET MaterialXTest POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 	${CMAKE_CURRENT_SOURCE_DIR}/../../resources ${CMAKE_CURRENT_BINARY_DIR}/resources)

--- a/source/MaterialXTest/GenReference.cpp
+++ b/source/MaterialXTest/GenReference.cpp
@@ -168,9 +168,14 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     context.registerSourceCodeSearchPath(librariesPath);
     context.getOptions().fileTextureVerticalFlip = true;
 
-    mx::OslRendererPtr oslRenderer = mx::OslRenderer::create();
-    oslRenderer->setOslCompilerExecutable(MATERIALX_OSLC_EXECUTABLE);
-    oslRenderer->setOslIncludePath(MATERIALX_OSL_INCLUDE_PATH);
+    bool runCompileTest = !std::string(MATERIALX_OSLC_EXECUTABLE).empty();
+    mx::OslRendererPtr oslRenderer = nullptr;
+    if (runCompileTest)
+    {
+        oslRenderer = mx::OslRenderer::create();
+        oslRenderer->setOslCompilerExecutable(MATERIALX_OSLC_EXECUTABLE);
+        oslRenderer->setOslIncludePath(MATERIALX_OSL_INCLUDE_PATH);
+    }
 
     const mx::FilePath logPath("genosl_reference_generate_test.txt");
     std::ofstream logFile;
@@ -200,7 +205,10 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             file << shader->getSourceCode();
             file.close();
 
-            oslRenderer->compileOSL(filepath);
+            if (oslRenderer)
+            {
+                oslRenderer->compileOSL(filepath);
+            }
 
             mx::ImplementationPtr impl = implDoc->addImplementation(node->getName());
             impl->setAttribute("node", nodedef->getNodeString());


### PR DESCRIPTION
Fix #713.
Install osl include files into local reference directory so that generated files can use local include
references.
