### PR TITLE
Adsk contrib/surface shader to material in runtime

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -590,6 +590,32 @@ namespace
         }
 
         writeAttributes(node, destNode);
+
+        // If we've got a surface shader at the top-level produce an equivalent material element from it
+        if (type == SURFACE_SHADER_TYPE_STRING && dest->isA<Document>()) {
+            DocumentPtr doc = dest->asA<Document>();
+            MaterialPtr material =
+                doc->addMaterial(destNode->getName() + "_Material");
+            ShaderRefPtr shaderRef = material->addShaderRef(
+                "sref", nodedef->getNodeName().str());
+            for (InputPtr input : destNode->getActiveInputs()) {
+                BindInputPtr bindInput =
+                    shaderRef->addBindInput(input->getName(), input->getType());
+                if (input->hasNodeName()) {
+                    if (input->hasOutputString()) {
+                        bindInput->setNodeGraphString(input->getNodeName());
+                        bindInput->setOutputString(input->getOutputString());
+                    }
+                } else {
+                    bindInput->setValueString(input->getValueString());
+                }
+            }
+            for (ParameterPtr param : destNode->getActiveParameters()) {
+                BindParamPtr bindParam =
+                    shaderRef->addBindParam(param->getName(), param->getType());
+                bindParam->setValueString(param->getValueString());
+            }
+        }
     }
 
     void writeNodeGraph(const PvtNodeGraph* nodegraph, DocumentPtr dest)

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -592,9 +592,9 @@ namespace
         writeAttributes(node, destNode);
 
         // If we've got a surface shader at the top-level produce an equivalent material element from it
-        if (type == SURFACE_SHADER_TYPE_STRING && dest->isA<Document>())
+        if (type == SURFACE_SHADER_TYPE_STRING && dest->template isA<Document>())
         {
-            DocumentPtr doc = dest->asA<Document>();
+            DocumentPtr doc = dest->template asA<Document>();
             MaterialPtr material =
                 doc->addMaterial(destNode->getName() + "_Material");
             ShaderRefPtr shaderRef = material->addShaderRef(

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -631,7 +631,7 @@ namespace
             MaterialAssignPtr materialAssign = look->addMaterialAssign();
             materialAssign->setMaterial(material->getName());
             CollectionPtr collection = doc->addCollection();
-            collection->setIncludeGeom("*");
+            collection->setIncludeGeom("/*");
             materialAssign->setCollection(collection);
         }
     }
@@ -730,8 +730,7 @@ namespace
                     PvtNode* node = elem->asA<PvtNode>();
                     NodePtr mxNode = writeNode(node, doc);
                     const PvtNodeDef* nodedef = node->getNodeDef()->asA<PvtNodeDef>();
-                    if (writeOptions && writeOptions->materialWriteOp != RtWriteOptions::MaterialWriteOp::NONE &&
-                        writeOptions->materialWriteOp & RtWriteOptions::MaterialWriteOp::WRITE &&
+                    if (writeOptions && writeOptions->materialWriteOp & RtWriteOptions::MaterialWriteOp::WRITE &&
                         nodedef->numOutputs() == 1 && nodedef->getPort(0)->getType() == RtType::SURFACESHADER)
                     {
                         writeMaterialElements(node, mxNode, nodedef->getNodeName().str(), doc, writeOptions);

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -593,31 +593,31 @@ namespace
 
         // If we've got a surface shader at the top-level produce an equivalent material element from it
         if (type == SURFACE_SHADER_TYPE_STRING && dest->isA<Document>())
-	{
+        {
             DocumentPtr doc = dest->asA<Document>();
             MaterialPtr material =
                 doc->addMaterial(destNode->getName() + "_Material");
             ShaderRefPtr shaderRef = material->addShaderRef(
                 "sref", nodedef->getNodeName().str());
             for (InputPtr input : destNode->getActiveInputs())
-	    {
+            {
                 BindInputPtr bindInput =
                     shaderRef->addBindInput(input->getName(), input->getType());
                 if (input->hasNodeName())
-		{
+                {
                     if (input->hasOutputString())
-		    {
+                    {
                         bindInput->setNodeGraphString(input->getNodeName());
                         bindInput->setOutputString(input->getOutputString());
                     }
                 }
 		else
-		{
+                {
                     bindInput->setValueString(input->getValueString());
                 }
             }
             for (ParameterPtr param : destNode->getActiveParameters())
-	    {
+            {
                 BindParamPtr bindParam =
                     shaderRef->addBindParam(param->getName(), param->getType());
                 bindParam->setValueString(param->getValueString());

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -592,25 +592,32 @@ namespace
         writeAttributes(node, destNode);
 
         // If we've got a surface shader at the top-level produce an equivalent material element from it
-        if (type == SURFACE_SHADER_TYPE_STRING && dest->isA<Document>()) {
+        if (type == SURFACE_SHADER_TYPE_STRING && dest->isA<Document>())
+	{
             DocumentPtr doc = dest->asA<Document>();
             MaterialPtr material =
                 doc->addMaterial(destNode->getName() + "_Material");
             ShaderRefPtr shaderRef = material->addShaderRef(
                 "sref", nodedef->getNodeName().str());
-            for (InputPtr input : destNode->getActiveInputs()) {
+            for (InputPtr input : destNode->getActiveInputs())
+	    {
                 BindInputPtr bindInput =
                     shaderRef->addBindInput(input->getName(), input->getType());
-                if (input->hasNodeName()) {
-                    if (input->hasOutputString()) {
+                if (input->hasNodeName())
+		{
+                    if (input->hasOutputString())
+		    {
                         bindInput->setNodeGraphString(input->getNodeName());
                         bindInput->setOutputString(input->getOutputString());
                     }
-                } else {
+                }
+		else
+		{
                     bindInput->setValueString(input->getValueString());
                 }
             }
-            for (ParameterPtr param : destNode->getActiveParameters()) {
+            for (ParameterPtr param : destNode->getActiveParameters())
+	    {
                 BindParamPtr bindParam =
                     shaderRef->addBindParam(param->getName(), param->getType());
                 bindParam->setValueString(param->getValueString());

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -611,7 +611,7 @@ namespace
                         bindInput->setOutputString(input->getOutputString());
                     }
                 }
-		else
+                else
                 {
                     bindInput->setValueString(input->getValueString());
                 }

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -53,7 +53,8 @@ class RtWriteOptions
   public:
      RtWriteOptions() :
           writeIncludes(true),
-          writeFilter(nullptr)
+          writeFilter(nullptr),
+          materialElementType(NONE)
     {
     }
     ~RtWriteOptions() { }
@@ -65,6 +66,37 @@ class RtWriteOptions
     /// Filter function type used for filtering objects during write.
     /// If the filter returns false the object will not be written.
     WriteFilter writeFilter;
+
+    /// Enum that specifies how to generate material elements.
+    ///
+    /// NONE: don't generate material elements
+    ///
+    /// WRITE: generate material elements from surface shaders
+    ///
+    /// DELETE: delete source surface shaders (must be used with
+    /// WRITE)
+    ///
+    /// LOOK: generate a look for the material element (must be
+    /// used with WRITE)
+    ///
+    /// WRITE_DELETE: generate material elements from surface
+    /// shaders and delete the surface shaders
+    ///
+    /// WRITE_LOOKS: generate material elements for surface shaders
+    /// and write out looks
+    ///
+    /// WRITE_LOOKS_DELETE: generate material elements from
+    /// surface shaders, delete the surface shaders and write out
+    /// looks
+    enum MaterialElementType{ NONE               = 0,
+                              WRITE              = 1 << 0,
+                              DELETE             = 1 << 1,
+                              LOOK               = 1 << 2,
+                              WRITE_DELETE       = WRITE | DELETE,
+                              WRITE_LOOKS        = WRITE | LOOK,
+                              WRITE_LOOKS_DELETE = WRITE | LOOK | DELETE };
+
+    MaterialElementType materialElementType;
 };
 
 /// API for read and write of data from MaterialXCore documents

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -54,7 +54,7 @@ class RtWriteOptions
      RtWriteOptions() :
           writeIncludes(true),
           writeFilter(nullptr),
-          materialElementType(NONE)
+          materialWriteOp(NONE)
     {
     }
     ~RtWriteOptions() { }
@@ -88,15 +88,17 @@ class RtWriteOptions
     /// WRITE_LOOKS_DELETE: generate material elements from
     /// surface shaders, delete the surface shaders and write out
     /// looks
-    enum MaterialElementType{ NONE               = 0,
-                              WRITE              = 1 << 0,
-                              DELETE             = 1 << 1,
-                              LOOK               = 1 << 2,
-                              WRITE_DELETE       = WRITE | DELETE,
-                              WRITE_LOOKS        = WRITE | LOOK,
-                              WRITE_LOOKS_DELETE = WRITE | LOOK | DELETE };
+    ///
+    /// TODO: Look into removing this once Material nodes are supported
+    enum MaterialWriteOp{ NONE               = 0,
+                          WRITE              = 1 << 0,
+                          DELETE             = 1 << 1,
+                          LOOK               = 1 << 2,
+                          WRITE_DELETE       = WRITE | DELETE,
+                          WRITE_LOOKS        = WRITE | LOOK,
+                          WRITE_LOOKS_DELETE = WRITE | LOOK | DELETE };
 
-    MaterialElementType materialElementType;
+    MaterialWriteOp materialWriteOp;
 };
 
 /// API for read and write of data from MaterialXCore documents


### PR DESCRIPTION
This code creates a material element per surfaceshader node that is equivalent when saving a stage.