### PR TITLE
Enumeration, texture resource usage for MDL script

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2545,7 +2545,7 @@
     <input name="scale" type="float" value="1.0"/>
     <input name="normal" type="vector3" defaultgeomprop="Nworld"/>
     <input name="tangent" type="vector3" defaultgeomprop="Tworld"/>
-    <output name="out" type="vector3" defaultinput="0.0, 1.0, 0.0"/>
+    <output name="out" type="vector3" default="0.0, 1.0, 0.0"/>
   </nodedef>
 
   <!--

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -88,7 +88,6 @@ def _writeValueAssignment(file, outputValue, outputType, writeEmptyValues):
     elif outputType in assignMap:
         outputType = assignMap[outputType]
         writeEmptyValues = True
-        print(outputType + '\n');
 
     if len(outputValue) or writeEmptyValues:
         file.write(' = ')
@@ -194,7 +193,7 @@ def main():
     SPACE = ' '
     QUOTE = '"'
     FUNCTION_PREFIX = 'mx_'
-    FUNCTION_PARAMETER_PREFIX = ''#'mxp_'
+    FUNCTION_PARAMETER_PREFIX = 'mxp_'
 
     # Create an implementation per nodedef
     #

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -277,7 +277,9 @@ def main():
                 if outputValue == '[]':
                     outputvalue = ''
                 if not outputValue:
-                    outputValue =  FUNCTION_PARAMETER_PREFIX + elem.getAttribute('defaultinput')
+                    outputValue = elem.getAttribute('defaultinput')
+                    if outputValue:
+                        outputValue = FUNCTION_PARAMETER_PREFIX + outputValue
                     routeInputToOutput = True
                 outputType = elem.getType()
                 outputType = _mapType(outputType, typeMap, functionName)

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -277,7 +277,7 @@ def main():
                 if outputValue == '[]':
                     outputvalue = ''
                 if not outputValue:
-                    outputValue = elem.getAttribute('defaultinput')
+                    outputValue =  FUNCTION_PARAMETER_PREFIX + elem.getAttribute('defaultinput')
                     routeInputToOutput = True
                 outputType = elem.getType()
                 outputType = _mapType(outputType, typeMap, functionName)


### PR DESCRIPTION
- Add in enumeration mapping
- Use swizzle for 2d texcoord lookup
- Add in texture resource usage vs string, but skip for actual filename constant nodedef (stays a string)
- use 'mxp_' prefix for parameters names to avoid keyword name clashes
- fix up defaultinput, defaultvalue support
- fix up when return type is 'material' type or 'multioutput' type 

Fix to stdlib.mtlx as 'normalmap' 'defaultinput' should be a 'default' attribute (since it's value, not routing an input)

Output validated using 'mdlc' with '-W "183=off"' to turn off unused parameter as warning.