### PR TITLE
Add in version option, materialnode upgrade + associated traversal logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ deploy
 # Ignore local editor settings
 .vscode/*
 
-build_public_rel/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ deploy
 # Ignore local editor settings
 .vscode/*
 
+build_public_rel/

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -462,7 +462,7 @@ class TestMaterialX(unittest.TestCase):
         for filename in _exampleFilenames:
             doc = mx.createDocument()
             mx.readFromXmlFile(doc, filename, _searchPath)
-            self.assertTrue(doc.validate()[0])
+            self.assertTrue(doc.validate()[0], filename + ' is not valid.')
 
             # Copy the document.
             copiedDoc = doc.copy()

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -96,7 +96,7 @@
       <parameter name="desiredMajorVersion" type="integer" value="1" />
 
       <!-- Desired minor version to upgrade to if possible -->
-      <parameter name="desiredMinorVersion" type="integer" value="38" />
+      <parameter name="desiredMinorVersion" type="integer" value="37" />
 
    </nodedef>
 </materialx>

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -92,5 +92,11 @@
       <!-- External testing: extra comma separated list of test root paths -->
       <parameter name="externalTestPaths" type="string" value="" />
 
+      <!-- Desired major version to upgrade to if possible -->
+      <parameter name="desiredMajorVersion" type="integer" value="1" />
+
+      <!-- Desired minor version to upgrade to if possible -->
+      <parameter name="desiredMinorVersion" type="integer" value="38" />
+
    </nodedef>
 </materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -292,7 +292,7 @@ bool Document::validate(string* message) const
     return GraphElement::validate(message) && res;
 }
 
-void Document::upgradeVersion()
+void Document::upgradeVersion(int desiredMajorVersion, int desiredMinorVersion)
 {
     std::pair<int, int> versions = getVersionIntegers();
     int majorVersion = versions.first;
@@ -300,6 +300,12 @@ void Document::upgradeVersion()
     if (majorVersion == MATERIALX_MAJOR_VERSION &&
         minorVersion == MATERIALX_MINOR_VERSION)
     {
+        return;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
         return;
     }
 
@@ -318,6 +324,12 @@ void Document::upgradeVersion()
             }
         }
         minorVersion = 23;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
 
     // Upgrade from v1.23 to v1.24
@@ -341,6 +353,12 @@ void Document::upgradeVersion()
         }
         minorVersion = 24;
     }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
+    }
 
     // Upgrade from v1.24 to v1.25
     if (majorVersion == 1 && minorVersion == 24)
@@ -354,6 +372,12 @@ void Document::upgradeVersion()
             }
         }
         minorVersion = 25;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
 
     // Upgrade from v1.25 to v1.26
@@ -371,6 +395,12 @@ void Document::upgradeVersion()
             }
         }
         minorVersion = 26;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
 
     // Upgrade from v1.26 to v1.34
@@ -507,6 +537,12 @@ void Document::upgradeVersion()
 
         minorVersion = 34;
     }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
+    }
 
     // Upgrade from v1.34 to v1.35
     if (majorVersion == 1 && minorVersion == 34)
@@ -531,6 +567,12 @@ void Document::upgradeVersion()
             }
         }
         minorVersion = 35;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
 
     // Upgrade from v1.35 to v1.36
@@ -603,6 +645,12 @@ void Document::upgradeVersion()
             }
         }
         minorVersion = 36;
+    }
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
 
     // Upgrade path for 1.37 
@@ -782,12 +830,170 @@ void Document::upgradeVersion()
 
         minorVersion = 37;
     }
-
-    if (majorVersion == MATERIALX_MAJOR_VERSION &&
-        minorVersion == MATERIALX_MINOR_VERSION)
+    if (majorVersion == desiredMajorVersion &&
+        minorVersion == desiredMinorVersion)
     {
-        setVersionString(DOCUMENT_VERSION_STRING);
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+        return;
     }
+
+    if (majorVersion == 1 && minorVersion == 37)
+    {
+        // Convert material Elements to Nodes
+        convertMaterialsToNode(true);
+        minorVersion = 38;
+    }
+
+    if (majorVersion >= MATERIALX_MAJOR_VERSION &&
+        minorVersion >= MATERIALX_MINOR_VERSION)
+    {
+        setVersionString(makeVersionString(majorVersion, minorVersion));
+    }
+}
+
+bool Document::convertMaterialsToNode(bool replaceNodes)
+{
+    bool modified = false;
+
+    vector<MaterialPtr> materials = getMaterials();
+    if (!materials.empty())
+    {
+        for (auto m : materials)
+        {
+            // See if a node of this name has already been created.
+            // Should not occur otherwise there are duplicate existing
+            // Material elements.
+            string materialName = m->getName();
+            if (getNode(materialName))
+            {
+                continue;
+            }
+
+            // Create a temporary name for the material element 
+            // so the new node can reuse the existing name.
+            if (replaceNodes)
+            {
+                string validName = createValidChildName(materialName + "1");
+                m->setName(validName);
+            }
+            else
+            {
+                materialName = createValidChildName(materialName);
+            }
+
+            // Create a new material node
+            NodePtr materialNode = nullptr;
+
+            ShaderRefPtr sr;
+            // Only include the shader refs explicitly specified on the material instance
+            vector<ShaderRefPtr> srs = m->getShaderRefs();
+            for (size_t i = 0; i < srs.size(); i++)
+            {
+                sr = srs[i];
+
+                // See if shader has been created already.
+                // Should be unlikely to occur as the shaderref is a uniquely named
+                // child of a uniquely named material element, but the two combined
+                // may have been used for another node instance which not shader node.
+                string shaderNodeName = m->getName() + "_" + sr->getName();
+                NodePtr existingShaderNode = getNode(shaderNodeName);
+                if (existingShaderNode)
+                {
+                    const string& existingType = existingShaderNode->getType();
+                    if (existingType == VOLUME_SHADER_TYPE_STRING ||
+                        existingType == SURFACE_SHADER_TYPE_STRING ||
+                        existingType == DISPLACEMENT_SHADER_TYPE_STRING)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        shaderNodeName = createValidChildName(shaderNodeName);
+                    }
+                }
+
+                modified = true;
+
+                // Find the shader type if defined
+                string shaderNodeType = SURFACE_SHADER_TYPE_STRING;
+                NodeDefPtr nodeDef = sr->getNodeDef();
+                if (nodeDef)
+                {
+                    shaderNodeType = nodeDef->getType();
+                }
+
+                // Add in a new shader node
+                const string shaderNodeCategory = sr->getNodeString();
+                NodePtr shaderNode = addNode(shaderNodeCategory, shaderNodeName, shaderNodeType);
+                shaderNode->setSourceUri(sr->getSourceUri());
+
+                for (auto valueElement : sr->getChildrenOfType<ValueElement>())
+                {
+                    ElementPtr portChild = nullptr;
+
+                    // Copy over bindinputs as inputs, and bindparams as params
+                    if (valueElement->isA<BindInput>())
+                    {
+                        portChild = shaderNode->addInput(valueElement->getName(), valueElement->getType());
+                    }
+                    else if (valueElement->isA<BindParam>())
+                    {
+                        portChild = shaderNode->addParameter(valueElement->getName(), valueElement->getType());
+                    }
+                    if (portChild)
+                    {
+                        // Copy over attributes.
+                        // Note: We preserve inputs which have nodegraph connections,
+                        // as well as top level output connections.
+                        portChild->copyContentFrom(valueElement);
+                    }
+                }
+
+                // Copy over any bindtokens as tokens
+                for (auto bt : sr->getBindTokens())
+                {
+                    TokenPtr token = shaderNode->addToken(bt->getName());
+                    token->copyContentFrom(bt);
+                }
+
+                // Create a new material node if not already created and
+                // add a reference from the material node to the new shader node
+                if (!materialNode)
+                {
+                    // Set the type of material based on current assumption that
+                    // surfaceshaders + displacementshaders result in a surfacematerial
+                    // while a volumeshader means a volumematerial needs to be created.
+                    string materialNodeCategory =
+                        (shaderNodeType != VOLUME_SHADER_TYPE_STRING) ? SURFACE_MATERIAL_NODE_STRING
+                        : VOLUME_MATERIAL_NODE_STRING;
+                    materialNode = addNode(materialNodeCategory, materialName, MATERIAL_TYPE_STRING);
+                    materialNode->setSourceUri(m->getSourceUri());
+                    // Note: Inheritance does not get transfered to the node.
+                    //materialNode->setInheritString(m->getInheritString()); 
+                }
+                // Create input to replace each shaderref. Use shaderref name as unique
+                // input name.
+                InputPtr shaderInput = materialNode->addInput(shaderNodeType, shaderNodeType);
+                shaderInput->setNodeName(shaderNode->getName());
+                // Make sure to copy over any target and version information from the shaderref.
+                if (!sr->getTarget().empty())
+                {
+                    shaderInput->setTarget(sr->getTarget());
+                }
+                if (!sr->getVersionString().empty())
+                {
+                    shaderInput->setVersionString(sr->getVersionString());
+                }
+            }
+
+            // Remove existing material element
+            if (replaceNodes)
+            {
+                removeChild(m->getName());
+            }
+        }
+    }
+    return modified;
 }
 
 void Document::onAddElement(ElementPtr, ElementPtr)

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -297,11 +297,6 @@ void Document::upgradeVersion(int desiredMajorVersion, int desiredMinorVersion)
     std::pair<int, int> versions = getVersionIntegers();
     int majorVersion = versions.first;
     int minorVersion = versions.second;
-    if (majorVersion == MATERIALX_MAJOR_VERSION &&
-        minorVersion == MATERIALX_MINOR_VERSION)
-    {
-        return;
-    }
     if (majorVersion == desiredMajorVersion &&
         minorVersion == desiredMinorVersion)
     {

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -574,7 +574,7 @@ class Document : public GraphElement
     void upgradeVersion(int desiredMajorVersion, int desiredMinorVersion);
 
     // Convert Material Elements to Material Nodes
-    bool convertMaterialsToNode(bool replaceNodes);
+    bool convertMaterialsToNodes(bool replaceNodes);
 
     /// @}
     /// @name Color Management System

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -137,6 +137,22 @@ class Document : public GraphElement
     }
 
     /// @}
+    /// @name Material Node Utilities
+    /// @{
+
+    /// Return the Material node, if any, with the given name.
+    NodePtr getMaterialNode(const string& name) const
+    {
+        return getNode(name);
+    }
+
+    /// Return a vector of all Material nodes in the document.
+    vector<NodePtr> getMaterialNodes() const
+    {
+        return getNodesOfType(MATERIAL_TYPE_STRING);
+    }
+
+    /// @}
     /// @name GeomInfo Elements
     /// @{
 
@@ -555,7 +571,10 @@ class Document : public GraphElement
 
     /// Upgrade the content of this document from earlier supported versions to
     /// the library version.  Documents from future versions are left unmodified.
-    void upgradeVersion();
+    void upgradeVersion(int desiredMajorVersion, int desiredMinorVersion);
+
+    // Convert Material Elements to Material Nodes
+    bool convertMaterialsToNode(bool replaceNodes);
 
     /// @}
     /// @name Color Management System

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -67,6 +67,10 @@ class Parameter : public ValueElement
     }
     virtual ~Parameter() { }
 
+  protected:
+    using NodePtr = shared_ptr<Node>;
+
+  public:
     /// @name Traversal
     /// @{
 
@@ -80,6 +84,12 @@ class Parameter : public ValueElement
     {
         return 1;
     }
+
+    /// Return the output, if any, to which this element is connected.
+    OutputPtr getConnectedOutput() const;
+
+    /// Return the node, if any, to which this element is connected.
+    NodePtr getConnectedNode() const;
 
     /// @}
 

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -134,6 +134,21 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
         // port. If no explicit output is specified this will
         // return an empty string which is handled below.
         outputName = &port->getOutputString();
+
+        // Handle case where it's a input to a top level output
+        InputPtr connectedInput = connectingElement->asA<Input>();
+        OutputPtr output = OutputPtr();
+        if (connectedInput)
+        {
+            output = connectedInput->getConnectedOutput();
+        }
+        if (output)
+        {
+            if (output->getParent() == output->getDocument())
+            {
+                outputName = &output->getOutputString();
+            }
+        }
     }
     else
     {

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -135,7 +135,7 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
         // return an empty string which is handled below.
         outputName = &port->getOutputString();
 
-        // Handle case where it's a input to a top level output
+        // Handle case where it's an input to a top level output
         InputPtr connectedInput = connectingElement->asA<Input>();
         OutputPtr output = OutputPtr();
         if (connectedInput)

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -43,6 +43,11 @@ std::tuple<int, int, int> getVersionIntegers()
     return LIBRARY_VERSION_TUPLE;
 }
 
+string makeVersionString(int majorVersion, int minorVersion)
+{
+    return std::to_string(majorVersion) + "." + std::to_string(minorVersion);
+}
+
 string createValidName(string name, char replaceChar)
 {
     std::replace_if(name.begin(), name.end(), invalidNameChar, replaceChar);

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -28,6 +28,9 @@ string getVersionString();
 /// as an integer tuple.
 std::tuple<int, int, int> getVersionIntegers();
 
+/// Make a version string from integers. 
+string makeVersionString(int majorVersion, int minorVersion);
+
 /// Create a valid MaterialX name from the given string.
 string createValidName(string name, char replaceChar = '_');
 

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -238,7 +238,17 @@ void documentFromXml(DocumentPtr doc,
         elementFromXml(xmlRoot, doc, readOptions);
     }
 
-    doc->upgradeVersion();
+    if (readOptions)
+    {
+        doc->upgradeVersion(readOptions->desiredMajorVersion, readOptions->desiredMinorVersion);
+    }
+    else
+    {
+        std::tuple<int, int, int> versionIntegers = getVersionIntegers();
+        int majorVersion = std::get<0>(versionIntegers);
+        int minorVersion = std::get<1>(versionIntegers);
+        doc->upgradeVersion(majorVersion, minorVersion);
+    }
 }
 
 } // anonymous namespace
@@ -250,6 +260,9 @@ void documentFromXml(DocumentPtr doc,
 XmlReadOptions::XmlReadOptions() :
     readXIncludeFunction(readFromXmlFile)
 {
+    std::tuple<int, int, int> versionIntegers = getVersionIntegers();
+    desiredMajorVersion = std::get<0>(versionIntegers);
+    desiredMinorVersion = std::get<1>(versionIntegers);
 }
 
 //

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -41,6 +41,12 @@ class XmlReadOptions : public CopyOptions
     /// The vector of parent XIncludes at the scope of the current document.
     /// Defaults to an empty vector.
     StringVec parentXIncludes;
+
+    /// Desired major version on read. By default the this is the same as the library version
+    int desiredMajorVersion;
+
+    /// Desired minor version on read. By default the this is the same as the library version
+    int desiredMinorVersion;
 };
 
 /// @class XmlWriteOptions

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -42,10 +42,10 @@ class XmlReadOptions : public CopyOptions
     /// Defaults to an empty vector.
     StringVec parentXIncludes;
 
-    /// Desired major version on read. By default the this is the same as the library version
+    /// Desired major version on read. By default this is the same as the library version
     int desiredMajorVersion;
 
-    /// Desired minor version on read. By default the this is the same as the library version
+    /// Desired minor version on read. By default this is the same as the library version
     int desiredMinorVersion;
 };
 

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <unordered_set>
 
 namespace MaterialX
 {
@@ -47,7 +46,7 @@ bool readFile(const string& filename, string& contents)
 
 void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, const StringSet& skipFiles,
                    const StringSet& includeFiles, vector<DocumentPtr>& documents, StringVec& documentsPaths,
-                   StringVec& errors)
+                   const XmlReadOptions& readOptions, StringVec& errors)
 {
     for (const FilePath& dir : rootPath.getSubDirectories())
     {
@@ -62,7 +61,7 @@ void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, c
                 {
                     FileSearchPath readSearchPath(searchPath);
                     readSearchPath.append(dir);
-                    readFromXmlFile(doc, filePath, readSearchPath);
+                    readFromXmlFile(doc, filePath, readSearchPath, &readOptions);
                     documents.push_back(doc);
                     documentsPaths.push_back(filePath.asString());
                 }

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -16,6 +16,9 @@
 #include <MaterialXCore/Interface.h>
 
 #include <MaterialXFormat/File.h>
+#include <MaterialXFormat/XmlIo.h>
+
+#include <unordered_set>
 
 namespace MaterialX
 {
@@ -31,7 +34,7 @@ bool readFile(const string& filename, string& content);
 /// Scans for all documents under a root path and returns documents which can be loaded
 void loadDocuments(const FilePath& rootPath, const FileSearchPath& searchPath, const StringSet& skipFiles,
                    const StringSet& includeFiles, vector<DocumentPtr>& documents, StringVec& documentsPaths,
-                   StringVec& errors);
+                   const XmlReadOptions& readOptions, StringVec& errors);
 
 /// Load a given MaterialX library into a document
 void loadLibrary(const FilePath& file, DocumentPtr doc, const FileSearchPath* searchPath = nullptr);

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -134,6 +134,12 @@ class TestSuiteOptions
 
     // Additional testPaths paths
     mx::FileSearchPath externalTestPaths;
+
+    // Desired major version to test
+    int desiredMajorVersion;
+
+    // Desired minor version to test
+    int desiredMinorVersion;
 };
 
 // Utility class to handle testing of shader generators.

--- a/source/MaterialXTest/Observer.cpp
+++ b/source/MaterialXTest/Observer.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Observer", "[observer]")
             REQUIRE(_beginUpdateCount == 4);
             REQUIRE(_endUpdateCount == 4);
             REQUIRE(_addElementCount == 12);
-            REQUIRE(_setAttributeCount == 16);
+            REQUIRE(_setAttributeCount == 17);
             REQUIRE(_removeElementCount == 4);
             REQUIRE(_removeAttributeCount == 0);
             REQUIRE(_copyContentCount == 0);

--- a/source/MaterialXTest/RenderUtil.cpp
+++ b/source/MaterialXTest/RenderUtil.cpp
@@ -93,25 +93,6 @@ void ShaderRenderTester::loadDependentLibraries(GenShaderUtil::TestSuiteOptions 
 
 bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx::FilePath optionsFilePath)
 {
-    // Test has been turned off so just do nothing.
-    // Check for an option file
-    GenShaderUtil::TestSuiteOptions options;
-    if (!options.readOptions(optionsFilePath))
-    {
-        std::cout << "Can't find options file. Skip test." << std::endl;
-        return false;
-    }
-    if (!runTest(options))
-    {
-        std::cout << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
-        return false;
-    }
-
-    // Profiling times
-    RenderUtil::RenderProfileTimes profileTimes;
-    // Global setup timer
-    RenderUtil::AdditiveScopedTimer totalTime(profileTimes.totalTime, "Global total time");
-
 #ifdef LOG_TO_FILE
     std::ofstream logfile(_languageTargetString + "_render_log.txt");
     std::ostream& log(logfile);
@@ -126,6 +107,25 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     std::ostream& docValidLog(std::cout);
     std::ostream& profilingLog(std::cout);
 #endif
+
+    // Test has been turned off so just do nothing.
+    // Check for an option file
+    GenShaderUtil::TestSuiteOptions options;
+    if (!options.readOptions(optionsFilePath))
+    {
+        log << "Can't find options file. Skip test." << std::endl;
+        return false;
+    }
+    if (!runTest(options))
+    {
+        log << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
+        return false;
+    }
+
+    // Profiling times
+    RenderUtil::RenderProfileTimes profileTimes;
+    // Global setup timer
+    RenderUtil::AdditiveScopedTimer totalTime(profileTimes.totalTime, "Global total time");
 
     // Add files to override the files in the test suite to be tested.
     mx::StringSet testfileOverride;
@@ -242,7 +242,10 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             {
                 mx::FileSearchPath readSearchPath(searchPath);
                 readSearchPath.append(dir);
-                mx::readFromXmlFile(doc, filename, readSearchPath);
+                mx::XmlReadOptions readOptions;
+                readOptions.desiredMajorVersion = options.desiredMajorVersion;
+                readOptions.desiredMinorVersion = options.desiredMinorVersion;
+                mx::readFromXmlFile(doc, filename, readSearchPath, &readOptions);
             }
             catch (mx::Exception& e)
             {

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -13,241 +13,251 @@ namespace mx = MaterialX;
 
 TEST_CASE("Load content", "[xmlio]")
 {
-    mx::FilePath libraryPath("libraries/stdlib");
-    mx::FilePath examplesPath("resources/Materials/Examples/Syntax");
-    mx::FileSearchPath searchPath = libraryPath.asString() +
-                                    mx::PATH_LIST_SEPARATOR +
-                                    examplesPath.asString();
-
-    // Read the standard library.
-    std::vector<mx::DocumentPtr> libs;
-    for (const mx::FilePath& filename : libraryPath.getFilesInDirectory(mx::MTLX_EXTENSION))
-    {
-        mx::DocumentPtr lib = mx::createDocument();
-        mx::readFromXmlFile(lib, filename, searchPath);
-        libs.push_back(lib);
-    }
-
-    // Read and validate each example document.
-    for (const mx::FilePath& filename : examplesPath.getFilesInDirectory(mx::MTLX_EXTENSION))
-    {
-        mx::DocumentPtr doc = mx::createDocument();
-        mx::readFromXmlFile(doc, filename, searchPath);
-        for (mx::DocumentPtr lib : libs)
-        {
-            doc->importLibrary(lib);
-        }
-        std::string message;
-        bool docValid = doc->validate(&message);
-        if (!docValid)
-        {
-            WARN("[" + filename.asString() + "] " + message);
-        }
-        REQUIRE(docValid);
-
-        // Traverse the document tree
-        int valueElementCount = 0;
-        for (mx::ElementPtr elem : doc->traverseTree())
-        {
-            if (elem->isA<mx::ValueElement>())
-            {
-                valueElementCount++;
-            }
-        }
-        REQUIRE(valueElementCount > 0);
-
-        // Traverse the dataflow graph from each shader parameter and input
-        // to its source nodes.
-        for (mx::MaterialPtr material : doc->getMaterials())
-        {
-            REQUIRE(material->getPrimaryShaderNodeDef());
-            int edgeCount = 0;
-            for (mx::ParameterPtr param : material->getPrimaryShaderParameters())
-            {
-                REQUIRE(param->getBoundValue(material));
-                for (mx::Edge edge : param->traverseGraph(material))
-                {
-                    edgeCount++;
-                }
-            }
-            for (mx::InputPtr input : material->getPrimaryShaderInputs())
-            {
-                REQUIRE((input->getBoundValue(material) || input->getUpstreamElement(material)));
-                for (mx::Edge edge : input->traverseGraph(material))
-                {
-                    edgeCount++;
-                }
-            }
-            REQUIRE(edgeCount > 0);
-        }
-
-        // Serialize to XML.
-        mx::XmlWriteOptions writeOptions;
-        writeOptions.writeXIncludeEnable = false;
-        std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
-
-        // Verify that the serialized document is identical.
-        mx::DocumentPtr writtenDoc = mx::createDocument();
-        mx::XmlReadOptions serialReadOptions;
-        serialReadOptions.skipConflictingElements = true;
-        mx::readFromXmlString(writtenDoc, xmlString, &serialReadOptions);
-        REQUIRE(*writtenDoc == *doc);
-
-        // Flatten subgraph references.
-        for (mx::NodeGraphPtr nodeGraph : doc->getNodeGraphs())
-        {
-            if (nodeGraph->getActiveSourceUri() != doc->getSourceUri())
-            {
-                continue;
-            }
-            nodeGraph->flattenSubgraphs();
-            REQUIRE(nodeGraph->validate());
-        }
-
-        // Verify that all referenced types and nodes are declared.
-        bool referencesValid = true;
-        for (mx::ElementPtr elem : doc->traverseTree())
-        {
-            if (elem->getActiveSourceUri() != doc->getSourceUri())
-            {
-                continue;
-            }
-
-            mx::TypedElementPtr typedElem = elem->asA<mx::TypedElement>();
-            if (typedElem && typedElem->hasType() && !typedElem->isMultiOutputType())
-            {
-                if (!typedElem->getTypeDef())
-                {
-                    WARN("[" + typedElem->getActiveSourceUri() + "] TypedElement " + typedElem->getName() + " has no matching TypeDef");
-                    referencesValid = false;
-                }
-            }
-            mx::NodePtr node = elem->asA<mx::Node>();
-            if (node)
-            {
-                if (!node->getNodeDefString().empty() && !node->getNodeDef())
-                {
-                    WARN("[" + node->getActiveSourceUri() + "] Node " + node->getName() + " has no matching NodeDef for " + node->getNodeDefString());
-                    referencesValid = false;
-                }
-            }
-        }
-        REQUIRE(referencesValid);
-    }
-
-    // Read the same document twice and verify that duplicate elements
-    // are skipped.
-    mx::DocumentPtr doc = mx::createDocument();
-    std::string filename = "PostShaderComposite.mtlx";
-    mx::readFromXmlFile(doc, filename, searchPath);
     mx::XmlReadOptions readOptions;
     readOptions.skipConflictingElements = true;
-    mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
-    REQUIRE(doc->validate());
-
-    // Import libraries twice and verify that duplicate elements are
-    // skipped.
-    mx::DocumentPtr libDoc = doc->copy();
-    mx::CopyOptions copyOptions;
-    copyOptions.skipConflictingElements = true;
-    for (mx::DocumentPtr lib : libs)
+    std::vector<int> versions = { 37, 38 };
+    for (int version : versions)
     {
-        libDoc->importLibrary(lib, &copyOptions);
-        libDoc->importLibrary(lib, &copyOptions);
-    }
-    REQUIRE(libDoc->validate());
+        readOptions.desiredMinorVersion = version;
 
-    // Read document with conflicting elements.
-    mx::DocumentPtr conflictDoc = doc->copy();
-    for (mx::ElementPtr elem : conflictDoc->traverseTree())
-    {
-        if (elem->isA<mx::Node>("image"))
+        mx::FilePath libraryPath("libraries/stdlib");
+        mx::FilePath examplesPath("resources/Materials/Examples/Syntax");
+        mx::FileSearchPath searchPath = libraryPath.asString() +
+            mx::PATH_LIST_SEPARATOR +
+            examplesPath.asString();
+
+        // Read the standard library.
+        std::vector<mx::DocumentPtr> libs;
+        for (const mx::FilePath& filename : libraryPath.getFilesInDirectory(mx::MTLX_EXTENSION))
         {
-            elem->setFilePrefix("differentFolder/");
+            mx::DocumentPtr lib = mx::createDocument();
+            mx::readFromXmlFile(lib, filename, searchPath, &readOptions);
+            libs.push_back(lib);
         }
-    }
-    REQUIRE_THROWS_AS(mx::readFromXmlFile(conflictDoc, filename, searchPath), mx::Exception&);
-    mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions);
-    REQUIRE(conflictDoc->validate());
 
-    // Read document without XIncludes.
-    mx::DocumentPtr flatDoc = mx::createDocument();
-    readOptions = mx::XmlReadOptions();
-    readOptions.readXIncludeFunction = nullptr;
-    mx::readFromXmlFile(flatDoc, filename, searchPath, &readOptions);
-    REQUIRE(*flatDoc != *doc);
-
-    // Read document using environment search path.
-    mx::setEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR, searchPath.asString());
-    mx::DocumentPtr envDoc = mx::createDocument();
-    mx::readFromXmlFile(envDoc, filename);
-    REQUIRE(*envDoc == *doc);
-    mx::removeEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR);
-    REQUIRE_THROWS_AS(mx::readFromXmlFile(envDoc, filename), mx::ExceptionFileMissing&);
-
-    // Serialize to XML with a custom predicate that skips images.
-    auto skipImages = [](mx::ConstElementPtr elem)
-    {
-        return !elem->isA<mx::Node>("image");
-    };
-    mx::XmlWriteOptions writeOptions;
-    writeOptions.writeXIncludeEnable = false;
-    writeOptions.elementPredicate = skipImages;
-    std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
-        
-    // Reconstruct and verify that the document contains no images.
-    mx::DocumentPtr writtenDoc = mx::createDocument();
-    mx::readFromXmlString(writtenDoc, xmlString);
-    REQUIRE(*writtenDoc != *doc);
-    unsigned imageElementCount = 0;
-    for (mx::ElementPtr elem : writtenDoc->traverseTree())
-    {
-        if (elem->isA<mx::Node>("image"))
+        // Read and validate each example document.
+        for (const mx::FilePath& filename : examplesPath.getFilesInDirectory(mx::MTLX_EXTENSION))
         {
-            imageElementCount++;
-        }
-    }
-    REQUIRE(imageElementCount == 0);
-
-    // Serialize to XML with a custom predicate to remove xincludes.
-    auto skipLibIncludes = [libs](mx::ConstElementPtr elem)
-    {
-        if (elem->hasSourceUri())
-        {
-            for (auto lib : libs)
+            mx::DocumentPtr doc = mx::createDocument();
+            mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+            for (mx::DocumentPtr lib : libs)
             {
-                if (lib->getSourceUri() == elem->getSourceUri())
+                doc->importLibrary(lib);
+            }
+            std::string message;
+            bool docValid = doc->validate(&message);
+            if (!docValid)
+            {
+                WARN("[" + filename.asString() + "] " + message);
+            }
+            REQUIRE(docValid);
+
+            // Traverse the document tree
+            int valueElementCount = 0;
+            for (mx::ElementPtr elem : doc->traverseTree())
+            {
+                if (elem->isA<mx::ValueElement>())
                 {
-                    return false;
+                    valueElementCount++;
                 }
             }
+            REQUIRE(valueElementCount > 0);
+
+            // Traverse the dataflow graph from each shader parameter and input
+            // to its source nodes.
+            for (mx::MaterialPtr material : doc->getMaterials())
+            {
+                REQUIRE(material->getPrimaryShaderNodeDef());
+                int edgeCount = 0;
+                for (mx::ParameterPtr param : material->getPrimaryShaderParameters())
+                {
+                    REQUIRE(param->getBoundValue(material));
+                    for (mx::Edge edge : param->traverseGraph(material))
+                    {
+                        edgeCount++;
+                    }
+                }
+                for (mx::InputPtr input : material->getPrimaryShaderInputs())
+                {
+                    REQUIRE((input->getBoundValue(material) || input->getUpstreamElement(material)));
+                    for (mx::Edge edge : input->traverseGraph(material))
+                    {
+                        edgeCount++;
+                    }
+                }
+                REQUIRE(edgeCount > 0);
+            }
+
+            // Serialize to XML.
+            mx::XmlWriteOptions writeOptions;
+            writeOptions.writeXIncludeEnable = false;
+            std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
+
+            // Verify that the serialized document is identical.
+            mx::DocumentPtr writtenDoc = mx::createDocument();
+            mx::readFromXmlString(writtenDoc, xmlString, &readOptions);
+            REQUIRE(*writtenDoc == *doc);
+
+            // Flatten subgraph references.
+            for (mx::NodeGraphPtr nodeGraph : doc->getNodeGraphs())
+            {
+                if (nodeGraph->getActiveSourceUri() != doc->getSourceUri())
+                {
+                    continue;
+                }
+                nodeGraph->flattenSubgraphs();
+                REQUIRE(nodeGraph->validate());
+            }
+
+            // Verify that all referenced types and nodes are declared.
+            bool referencesValid = true;
+            for (mx::ElementPtr elem : doc->traverseTree())
+            {
+                if (elem->getActiveSourceUri() != doc->getSourceUri())
+                {
+                    continue;
+                }
+
+                mx::TypedElementPtr typedElem = elem->asA<mx::TypedElement>();
+                if (typedElem && typedElem->hasType() && !typedElem->isMultiOutputType())
+                {
+                    if (!typedElem->getTypeDef())
+                    {
+                        WARN("[" + typedElem->getActiveSourceUri() + "] TypedElement " + typedElem->getName() + " has no matching TypeDef");
+                        referencesValid = false;
+                    }
+                }
+                mx::NodePtr node = elem->asA<mx::Node>();
+                if (node)
+                {
+                    if (!node->getNodeDefString().empty() && !node->getNodeDef())
+                    {
+                        WARN("[" + node->getActiveSourceUri() + "] Node " + node->getName() + " has no matching NodeDef for " + node->getNodeDefString());
+                        referencesValid = false;
+                    }
+                }
+            }
+            REQUIRE(referencesValid);
         }
-        return true;
-    };
-    writeOptions.writeXIncludeEnable = true;
-    writeOptions.elementPredicate = skipLibIncludes;
-    xmlString = mx::writeToXmlString(writtenDoc, &writeOptions);
-    // Verify that the document contains no xincludes.
-    writtenDoc = mx::createDocument();
-    mx::readFromXmlString(writtenDoc, xmlString);
-    bool hasSourceUri = false;
-    for (mx::ElementPtr elem : writtenDoc->traverseTree())
-    {
-        if (elem->hasSourceUri())
+
+        // Read the same document twice and verify that duplicate elements
+        // are skipped.
+        mx::DocumentPtr doc = mx::createDocument();
+        std::string filename = "PostShaderComposite.mtlx";
+        mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+        mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+        REQUIRE(doc->validate());
+
+        // Import libraries twice and verify that duplicate elements are
+        // skipped.
+        mx::DocumentPtr libDoc = doc->copy();
+        mx::CopyOptions copyOptions;
+        copyOptions.skipConflictingElements = true;
+        for (mx::DocumentPtr lib : libs)
         {
-            hasSourceUri = true;
-            break;
+            libDoc->importLibrary(lib, &copyOptions);
+            libDoc->importLibrary(lib, &copyOptions);
         }
+        REQUIRE(libDoc->validate());
+
+        // Read document with conflicting elements.
+        mx::DocumentPtr conflictDoc = doc->copy();
+        for (mx::ElementPtr elem : conflictDoc->traverseTree())
+        {
+            if (elem->isA<mx::Node>("image"))
+            {
+                elem->setFilePrefix("differentFolder/");
+            }
+        }
+        readOptions.skipConflictingElements = false;
+        //REQUIRE_THROWS_AS(mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions), mx::Exception&);
+        readOptions.skipConflictingElements = true;
+        mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions);
+        REQUIRE(conflictDoc->validate());
+
+        // Reread in clean document
+        doc = mx::createDocument();
+        mx::readFromXmlFile(doc, filename, searchPath, &readOptions);
+
+        // Read document without XIncludes.
+        mx::DocumentPtr flatDoc = mx::createDocument();
+        readOptions.readXIncludeFunction = nullptr;
+        mx::readFromXmlFile(flatDoc, filename, searchPath, &readOptions);
+        readOptions.readXIncludeFunction = mx::readFromXmlFile;
+        REQUIRE(*flatDoc != *doc);
+
+        // Read document using environment search path.
+        mx::setEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR, searchPath.asString());
+        mx::DocumentPtr envDoc = mx::createDocument();
+        mx::readFromXmlFile(envDoc, filename, mx::FileSearchPath(), &readOptions);
+        REQUIRE(*doc == *envDoc);
+        mx::removeEnviron(mx::MATERIALX_SEARCH_PATH_ENV_VAR);
+        REQUIRE_THROWS_AS(mx::readFromXmlFile(envDoc, filename, mx::FileSearchPath(), &readOptions), mx::ExceptionFileMissing&);
+
+        // Serialize to XML with a custom predicate that skips images.
+        auto skipImages = [](mx::ConstElementPtr elem)
+        {
+            return !elem->isA<mx::Node>("image");
+        };
+        mx::XmlWriteOptions writeOptions;
+        writeOptions.writeXIncludeEnable = false;
+        writeOptions.elementPredicate = skipImages;
+        std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
+
+        // Reconstruct and verify that the document contains no images.
+        mx::DocumentPtr writtenDoc = mx::createDocument();
+        mx::readFromXmlString(writtenDoc, xmlString, &readOptions);
+        REQUIRE(*writtenDoc != *doc);
+        unsigned imageElementCount = 0;
+        for (mx::ElementPtr elem : writtenDoc->traverseTree())
+        {
+            if (elem->isA<mx::Node>("image"))
+            {
+                imageElementCount++;
+            }
+        }
+        REQUIRE(imageElementCount == 0);
+
+        // Serialize to XML with a custom predicate to remove xincludes.
+        auto skipLibIncludes = [libs](mx::ConstElementPtr elem)
+        {
+            if (elem->hasSourceUri())
+            {
+                for (auto lib : libs)
+                {
+                    if (lib->getSourceUri() == elem->getSourceUri())
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
+        writeOptions.writeXIncludeEnable = true;
+        writeOptions.elementPredicate = skipLibIncludes;
+        xmlString = mx::writeToXmlString(writtenDoc, &writeOptions);
+        // Verify that the document contains no xincludes.
+        writtenDoc = mx::createDocument();
+        mx::readFromXmlString(writtenDoc, xmlString, &readOptions);
+        bool hasSourceUri = false;
+        for (mx::ElementPtr elem : writtenDoc->traverseTree())
+        {
+            if (elem->hasSourceUri())
+            {
+                hasSourceUri = true;
+                break;
+            }
+        }
+        REQUIRE(!hasSourceUri);
+
+        // Read a non-existent document.
+        mx::DocumentPtr nonExistentDoc = mx::createDocument();
+        REQUIRE_THROWS_AS(mx::readFromXmlFile(nonExistentDoc, "NonExistent.mtlx", mx::FileSearchPath(), &readOptions), mx::ExceptionFileMissing&);
+
+        // Read in include file without specifying search to the parent document
+        mx::DocumentPtr parentDoc = mx::createDocument();
+        mx::readFromXmlFile(parentDoc,
+            "resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx", searchPath);
+        REQUIRE(nullptr != parentDoc->getNodeDef("ND_TestMetal"));
     }
-    REQUIRE(!hasSourceUri);
-
-    // Read a non-existent document.
-    mx::DocumentPtr nonExistentDoc = mx::createDocument();
-    REQUIRE_THROWS_AS(mx::readFromXmlFile(nonExistentDoc, "NonExistent.mtlx"), mx::ExceptionFileMissing&);
-
-    // Read in include file without specifying search to the parent document
-    mx::DocumentPtr parentDoc = mx::createDocument();
-    mx::readFromXmlFile(parentDoc,
-        "resources/Materials/TestSuite/libraries/metal/brass_wire_mesh.mtlx", searchPath);
-    REQUIRE(nullptr != parentDoc->getNodeDef("ND_TestMetal"));
 }

--- a/source/MaterialXTest/XmlIo.cpp
+++ b/source/MaterialXTest/XmlIo.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Load content", "[xmlio]")
             }
         }
         readOptions.skipConflictingElements = false;
-        //REQUIRE_THROWS_AS(mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions), mx::Exception&);
+        REQUIRE_THROWS_AS(mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions), mx::Exception&);
         readOptions.skipConflictingElements = true;
         mx::readFromXmlFile(conflictDoc, filename, searchPath, &readOptions);
         REQUIRE(conflictDoc->validate());

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -49,7 +49,8 @@ bool Material::generateEnvironmentShader(mx::GenContext& context,
     mx::DocumentPtr doc = mx::createDocument();
     doc->importLibrary(stdLib);
     mx::DocumentPtr envDoc = mx::createDocument();
-    mx::readFromXmlFile(envDoc, filename);
+    mx::XmlReadOptions options;
+    mx::readFromXmlFile(envDoc, filename, mx::FileSearchPath(), &options);
     doc->importLibrary(envDoc);
 
     mx::NodeGraphPtr envGraph = doc->getNodeGraph("environmentDraw");

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -233,7 +233,8 @@ Viewer::Viewer(const std::string& materialFilename,
     _lightHandler = mx::LightHandler::create();
     _lightFilename = "resources/Materials/TestSuite/Utilities/Lights/default_viewer_lights.mtlx";
     _lightDoc = mx::createDocument();
-    mx::readFromXmlFile(_lightDoc, _lightFilename, _searchPath);
+    mx::XmlReadOptions options;
+    mx::readFromXmlFile(_lightDoc, _lightFilename, _searchPath, &options);
 
     // Initialize user interfaces.
     createLoadMeshInterface(_window, "Load Mesh");


### PR DESCRIPTION
Update #616 
- Add in upgrade code from material element to material node.
- Update traversal logic to handle equivalent traversal on inputs as for bindinputs.
- Allow version to be chosen for file read to allow for 1.38 (materialnode) to be converted as desired.
- Options file can be set to 1.38 for shadergen but backend recognition logic to come.
Note that xmllio test runs against both 1.37.2 and 1.38 (w/o and w/ a materialnode)

