### PR TITLE
Update to shading and rendering for material node support

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -91,12 +91,12 @@
 
       <!-- External testing: extra comma separated list of test root paths -->
       <parameter name="externalTestPaths" type="string" value="" />
-
+      
       <!-- Desired major version to upgrade to if possible -->
       <parameter name="desiredMajorVersion" type="integer" value="1" />
 
       <!-- Desired minor version to upgrade to if possible -->
-      <parameter name="desiredMinorVersion" type="integer" value="37" />
+      <parameter name="desiredMinorVersion" type="integer" value="38" />
 
    </nodedef>
 </materialx>

--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -97,6 +97,11 @@ MaterialPtr MaterialAssign::getReferencedMaterial() const
     return resolveRootNameReference<Material>(getMaterial());   
 }
 
+NodePtr MaterialAssign::getReferencedMaterialNode() const
+{
+    return resolveRootNameReference<Node>(getMaterial());
+}
+
 vector<VariantAssignPtr> MaterialAssign::getActiveVariantAssigns() const
 {
     vector<VariantAssignPtr> activeAssigns;

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -336,6 +336,9 @@ class MaterialAssign : public GeomElement
     /// Return the Material, if any, referenced by the MaterialAssign.
     MaterialPtr getReferencedMaterial() const;
 
+    /// Return the Material node, if any, referenced by the MaterialAssign.
+    NodePtr getReferencedMaterialNode() const;
+
     /// @}
     /// @name VariantAssign Elements
     /// @{

--- a/source/MaterialXGenOgsXml/OgsFragment.cpp
+++ b/source/MaterialXGenOgsXml/OgsFragment.cpp
@@ -34,6 +34,20 @@ class GlslGeneratorWrapperBase
         {
             _isSurface = true;
         }
+        else if (element->isA<mx::Node>())
+        {
+            mx::NodePtr outputNode = element->asA<mx::Node>();
+            if (outputNode->getType() == mx::MATERIAL_TYPE_STRING)
+            {
+                std::vector<mx::NodePtr> shaderNodes = 
+                    mx::getShaderNodes(outputNode, mx::SURFACE_SHADER_TYPE_STRING);
+                if (!shaderNodes.empty())
+                {
+                    _element = shaderNodes[0];
+                    _isSurface = true;
+                }
+            }
+        }
         else if (!element->asA<mx::Output>())
         {
             throw mx::Exception("Invalid element to create fragment for " + element->getName());

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -69,14 +69,105 @@ void ShaderGraph::addOutputSockets(const InterfaceElement& elem)
     }
 }
 
+void ShaderGraph::createConnectedNodes(ElementPtr downstreamElement,
+                                        ElementPtr upstreamElement,
+                                        ElementPtr connectingElement,
+                                        GenContext& context,
+                                        ShaderNode* rootNode)
+{
+    // Create the node if it doesn't exists
+    NodePtr upstreamNode = upstreamElement->asA<Node>();
+    if (!upstreamNode)
+    {
+        throw ExceptionShaderGenError("Upstream element to connect is not a node '" 
+            + upstreamElement->getName() + "'");
+    }
+    const string& newNodeName = upstreamNode->getName();
+    ShaderNode* newNode = getNode(newNodeName);
+    if (!newNode)
+    {
+        newNode = createNode(*upstreamNode, context);
+    }
+
+    //
+    // Make connections
+    //
+
+    // Find the output to connect to.
+    if (!connectingElement && downstreamElement->isA<Output>())
+    {
+        // Edge case for having an output downstream but no connecting
+        // element (input) reported upstream. In this case we set the
+        // output itself as connecting element, which handles finding
+        // the nodedef output in case of a multioutput node upstream.
+        connectingElement = downstreamElement->asA<Output>();
+    }
+    OutputPtr nodeDefOutput = connectingElement ? upstreamNode->getNodeDefOutput(connectingElement) : nullptr;
+    ShaderOutput* output = nodeDefOutput ? newNode->getOutput(nodeDefOutput->getName()) : newNode->getOutput();
+    if (!output)
+    {
+        throw ExceptionShaderGenError("Could not find an output named '" + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) +
+            "' on upstream node '" + upstreamNode->getName() + "'");
+    }
+
+    // First check if this was a bind input connection
+    // In this case we must have a root node as well
+    if (rootNode && connectingElement && connectingElement->isA<BindInput>())
+    {
+        // Connect to the corresponding input on the root node
+        ShaderInput* input = rootNode->getInput(connectingElement->getName());
+        if (input)
+        {
+            input->breakConnection();
+            input->makeConnection(output);
+        }
+    }
+    else
+    {
+        // Check if it was a node downstream
+        NodePtr downstreamNode = downstreamElement->asA<Node>();
+        if (downstreamNode)
+        {
+            // We have a node downstream
+            ShaderNode* downstream = getNode(downstreamNode->getName());
+            if (downstream && connectingElement)
+            {
+                ShaderInput* input = downstream->getInput(connectingElement->getName());
+                if (!input)
+                {
+                    throw ExceptionShaderGenError("Could not find an input named '" + connectingElement->getName() +
+                        "' on downstream node '" + downstream->getName() + "'");
+                }
+                input->makeConnection(output);
+            }
+            else
+            {
+                throw ExceptionShaderGenError("Could not find downstream node ' " + downstreamNode->getName() + "'");
+            }
+        }
+        else
+        {
+            // Not a node, then it must be an output
+            ShaderGraphOutputSocket* outputSocket = getOutputSocket(downstreamElement->getName());
+            if (outputSocket)
+            {
+                outputSocket->makeConnection(output);
+            }
+        }
+    }
+}
+
 void ShaderGraph::addUpstreamDependencies(const Element& root, ConstMaterialPtr material, GenContext& context)
 {
     // Keep track of our root node in the graph.
     // This is needed when the graph is a shader graph and we need
     // to make connections for BindInputs during traversal below.
     ShaderNode* rootNode = getNode(root.getName());
-
     std::set<ElementPtr> processedOutputs;
+    std::vector<ElementPtr> downstreamElements;
+    std::vector<ElementPtr> upstreamElements;
+    std::vector<ElementPtr> connectingElements;
+
     for (Edge edge : root.traverseGraph(material))
     {
         ElementPtr upstreamElement = edge.getUpstreamElement();
@@ -109,78 +200,22 @@ void ShaderGraph::addUpstreamDependencies(const Element& root, ConstMaterialPtr 
             }
         }
 
-        // Create the node if it doesn't exists
-        NodePtr upstreamNode = upstreamElement->asA<Node>();
-        const string& newNodeName = upstreamNode->getName();
-        ShaderNode* newNode = getNode(newNodeName);
-        if (!newNode)
-        {
-            newNode = createNode(*upstreamNode, context);
-        }
+        downstreamElements.push_back(downstreamElement);
+        upstreamElements.push_back(upstreamElement);
+        connectingElements.push_back(edge.getConnectingElement());
+    }
 
-        //
-        // Make connections
-        //
+    for (size_t i = 0; i < downstreamElements.size(); i++)
+    {
+        ElementPtr downstreamElement = downstreamElements[i];
+        ElementPtr upstreamElement = upstreamElements[i];
+        ElementPtr connectingElement = connectingElements[i];
 
-        // Find the output to connect to.
-        ElementPtr connectingElement = edge.getConnectingElement();
-        if (!connectingElement && downstreamElement->isA<Output>())
-        {
-            // Edge case for having an output downstream but no connecting
-            // element (input) reported upstream. In this case we set the
-            // output itself as connecting element, which handles finding
-            // the nodedef output in case of a multioutput node upstream.
-            connectingElement = downstreamElement->asA<Output>();
-        }
-        OutputPtr nodeDefOutput = connectingElement ? upstreamNode->getNodeDefOutput(connectingElement) : nullptr;
-        ShaderOutput* output = nodeDefOutput ? newNode->getOutput(nodeDefOutput->getName()) : newNode->getOutput();
-        if (!output)
-        {
-            throw ExceptionShaderGenError("Could not find an output named '" + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) +
-                "' on upstream node '" + upstreamNode->getName() + "'");
-        }
-
-        // First check if this was a bind input connection
-        // In this case we must have a root node as well
-        if (rootNode && connectingElement && connectingElement->isA<BindInput>())
-        {
-            // Connect to the corresponding input on the root node
-            ShaderInput* input = rootNode->getInput(connectingElement->getName());
-            if (input)
-            {
-                input->breakConnection();
-                input->makeConnection(output);
-            }
-        }
-        else
-        {
-            // Check if it was a node downstream
-            NodePtr downstreamNode = downstreamElement->asA<Node>();
-            if (downstreamNode)
-            {
-                // We have a node downstream
-                ShaderNode* downstream = getNode(downstreamNode->getName());
-                if (downstream && connectingElement)
-                {
-                    ShaderInput* input = downstream->getInput(connectingElement->getName());
-                    if (!input)
-                    {
-                        throw ExceptionShaderGenError("Could not find an input named '" + connectingElement->getName() +
-                            "' on downstream node '" + downstream->getName() + "'");
-                    }
-                    input->makeConnection(output);
-                }
-            }
-            else
-            {
-                // Not a node, then it must be an output
-                ShaderGraphOutputSocket* outputSocket = getOutputSocket(downstreamElement->getName());
-                if (outputSocket)
-                {
-                    outputSocket->makeConnection(output);
-                }
-            }
-        }
+        createConnectedNodes(downstreamElement,
+            upstreamElement,
+            connectingElement,
+            context,
+            rootNode);
     }
 }
 
@@ -423,6 +458,187 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const NodeGraph& n
     return graph;
 }
 
+ShaderGraphPtr ShaderGraph::createSurfaceShader(
+    const string& name,
+    const ShaderGraph* parent,
+    NodePtr node,
+    GenContext& context,
+    ElementPtr& root,
+    MaterialPtr& material)
+{
+    NodeDefPtr nodeDef = node->getNodeDef();
+    if (!nodeDef)
+    {
+        throw ExceptionShaderGenError("Could not find a nodedef for shadernode '" + node->getName() + "'");
+    }
+
+    ShaderGraphPtr graph = std::make_shared<ShaderGraph>(parent, name, node->getDocument(), context.getReservedWords());
+
+    // Create input sockets
+    graph->addInputSockets(*nodeDef, context);
+
+    // Create output sockets
+    graph->addOutputSockets(*nodeDef);
+
+    // Create this shader node in the graph.
+    const string& newNodeName = node->getName();
+    ShaderNodePtr newNode = ShaderNode::create(graph.get(), newNodeName, *nodeDef, context);
+    graph->addNode(newNode);
+
+    // Connect it to the graph output
+    ShaderGraphOutputSocket* outputSocket = graph->getOutputSocket();
+    outputSocket->makeConnection(newNode->getOutput());
+    outputSocket->setPath(node->getNamePath());
+
+    string targetColorSpace;
+    ColorManagementSystemPtr colorManagementSystem = context.getShaderGenerator().getColorManagementSystem();
+    if (colorManagementSystem)
+    {
+        targetColorSpace = context.getOptions().targetColorSpaceOverride.empty() ?
+            node->getDocument()->getColorSpace() : context.getOptions().targetColorSpaceOverride;
+    }
+
+    // Set node parameter values onto graph input sockets
+    for (ParameterPtr elem : nodeDef->getActiveParameters())
+    {
+        ShaderGraphInputSocket* inputSocket = graph->getInputSocket(elem->getName());
+        ShaderInput* input = newNode->getInput(elem->getName());
+        if (!inputSocket || !input)
+        {
+            throw ExceptionShaderGenError("Shader parameter '" + elem->getName() + "' doesn't match an existing input on graph '" + graph->getName() + "'");
+        }
+
+        ParameterPtr nodeParam = node->getParameter(elem->getName());
+        if (nodeParam)
+        {
+            // Copy value from binding
+            ValuePtr nodeParamValue = nodeParam->getResolvedValue();
+            if (nodeParamValue)
+            {
+                inputSocket->setValue(nodeParamValue);
+
+                graph->populateInputColorTransformMap(colorManagementSystem, newNode, nodeParam, targetColorSpace);
+                graph->populateUnitTransformMap(true, context.getShaderGenerator().getUnitSystem(), input,
+                    nodeParam, context.getOptions().targetDistanceUnit);
+            }
+            inputSocket->setPath(nodeParam->getNamePath());
+            input->setPath(inputSocket->getPath());
+            const string& nodeParamUnit = nodeParam->getUnit();
+            if (!nodeParamUnit.empty())
+            {
+                inputSocket->setUnit(nodeParamUnit);
+                input->setUnit(nodeParamUnit);
+            }
+        }
+
+        // Connect graph input socket to the node input
+        inputSocket->makeConnection(input);
+    }
+
+    // Set node input values onto grah input sockets
+    for (const InputPtr& nodeDefInput : nodeDef->getActiveInputs())
+    {
+        ShaderGraphInputSocket* inputSocket = graph->getInputSocket(nodeDefInput->getName());
+        ShaderInput* input = newNode->getInput(nodeDefInput->getName());
+        if (!inputSocket || !input)
+        {
+            throw ExceptionShaderGenError("Shader input '" + nodeDefInput->getName() + "' doesn't match an existing input on graph '" + graph->getName() + "'");
+        }
+
+        InputPtr nodeInput = node->getInput(nodeDefInput->getName());
+        if (nodeInput)
+        {
+            // Copy value from binding
+            ValuePtr nodeInputValue = nodeInput->getResolvedValue();
+            if (nodeInputValue)
+            {
+                inputSocket->setValue(nodeInputValue);
+                graph->populateInputColorTransformMap(colorManagementSystem, newNode, nodeInput, targetColorSpace);
+                graph->populateUnitTransformMap(true, context.getShaderGenerator().getUnitSystem(), input,
+                    nodeInput, context.getOptions().targetDistanceUnit);
+            }
+            inputSocket->setPath(nodeInput->getNamePath());
+            input->setPath(inputSocket->getPath());
+            const string& nodeInputUnit = nodeInput->getUnit();
+            if (!nodeInputUnit.empty())
+            {
+                inputSocket->setUnit(nodeInputUnit);
+                input->setUnit(nodeInputUnit);
+            }
+        }
+
+        GeomPropDefPtr geomprop = nodeDefInput->getDefaultGeomProp();
+        if (geomprop)
+        {
+            inputSocket->setGeomProp(geomprop->getName());
+            input->setGeomProp(geomprop->getName());
+        }
+
+        // If no explicit connection, connect to geometric node if a geomprop is used
+        // or otherwise to the graph interface.
+        const string& connection = nodeInput ? nodeInput->getOutputString() : EMPTY_STRING;
+        if (connection.empty())
+        {
+            if (geomprop)
+            {
+                graph->addDefaultGeomNode(input, *geomprop, context);
+            }
+            else
+            {
+                inputSocket->makeConnection(input);
+            }
+        }
+    }
+
+    // Add shader node paths and unit value
+    const string& nodePath = node->getNamePath();
+    for (const ValueElementPtr& nodeInput : nodeDef->getActiveInputs())
+    {
+        const string& inputName = nodeInput->getName();
+        const string path = nodePath + NAME_PATH_SEPARATOR + inputName;
+        const string& unit = nodeInput->getUnit();
+        ShaderInput* input = newNode->getInput(inputName);
+        if (input && input->getPath().empty())
+        {
+            input->setPath(path);
+        }
+        if (input && input->getUnit().empty() && !unit.empty())
+        {
+            input->setUnit(unit);
+        }
+        ShaderGraphInputSocket* inputSocket = graph->getInputSocket(inputName);
+        if (inputSocket && inputSocket->getPath().empty())
+        {
+            inputSocket->setPath(path);
+        }
+        if (inputSocket && inputSocket->getUnit().empty() && !unit.empty())
+        {
+            inputSocket->setUnit(unit);
+        }
+    }
+    for (const ParameterPtr& nodeParameter : nodeDef->getActiveParameters())
+    {
+        const string& paramName = nodeParameter->getName();
+        const string path = nodePath + NAME_PATH_SEPARATOR + paramName;
+        ShaderInput* input = newNode->getInput(paramName);
+        if (input && input->getPath().empty())
+        {
+            input->setPath(path);
+        }
+        ShaderGraphInputSocket* inputSocket = graph->getInputSocket(paramName);
+        if (inputSocket && inputSocket->getPath().empty())
+        {
+            inputSocket->setPath(path);
+        }
+    }
+
+    // Start traversal from this shader node
+    root = node;    
+    material = nullptr; // node->getParent()->asA<Material>(); -- send over material node instead?
+    
+    return graph;
+}
+
 ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name, ElementPtr element, GenContext& context)
 {
     ShaderGraphPtr graph;
@@ -481,10 +697,10 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
         // Start traversal from this output
         root = output;
     }
-    else if (element->isA<Node>())
-    {
-        NodePtr node = element->asA<Node>();
 
+    NodePtr node = element->asA<Node>();
+    if (node && (node->getType() != "surfaceshader"))
+    {
         NodeDefPtr nodeDef = node->getNodeDef();
         if (!nodeDef)
         {
@@ -561,10 +777,15 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
         // No traversal of upstream dependencies
         root = nullptr;
     }
-    else if (element->isA<ShaderRef>())
+    else if (node && (node->getType() == "surfaceshader"))
     {
-        ShaderRefPtr shaderRef = element->asA<ShaderRef>();
+        graph = createSurfaceShader(name, parent, node, context, 
+                                    root, material);
+    }
 
+    ShaderRefPtr shaderRef = element->asA<ShaderRef>();
+    if (shaderRef)
+    {
         NodeDefPtr nodeDef = shaderRef->getNodeDef();
         if (!nodeDef)
         {
@@ -646,7 +867,6 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
             }
 
             BindInputPtr bindInput = shaderRef->getBindInput(nodeDefInput->getName());
-
             if (bindInput)
             {
                 // Copy value from binding

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -115,11 +115,16 @@ class ShaderGraph : public ShaderNode
         ElementPtr& root,
         MaterialPtr& material);
 
-    void createConnectedNodes(ElementPtr downstreamElement,
-        ElementPtr upstreamElement,
-        ElementPtr connectingElement,
-        GenContext& context,
-        ShaderNode* rootNode = nullptr);
+    /// Create node connections corresponding to the connection between a pair of elements.
+    /// @param downstreamElement Element representing the node to connect to.
+    /// @param upstreamElement Element representing  the node to connect from
+    /// @param connectionElement If non-null, specifies the element on on the downstream node to connect to.
+    /// @param rootNode Root node for downstream element. Only required for handing ShaderRef elements.
+    void createConnectedNodes(const ElementPtr& downstreamElement,
+                              const ElementPtr& upstreamElement,
+                              ElementPtr connectingElement,
+                              GenContext& context,
+                              ShaderNode* rootNode = nullptr);
 
     /// Add a node to the graph
     void addNode(ShaderNodePtr node);

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -107,6 +107,20 @@ class ShaderGraph : public ShaderNode
     IdentifierMap& getIdentifierMap() { return _identifiers; }
 
   protected:
+    static ShaderGraphPtr createSurfaceShader(
+        const string& name,
+        const ShaderGraph* parent,
+        NodePtr node,
+        GenContext& context,
+        ElementPtr& root,
+        MaterialPtr& material);
+
+    void createConnectedNodes(ElementPtr downstreamElement,
+        ElementPtr upstreamElement,
+        ElementPtr connectingElement,
+        GenContext& context,
+        ShaderNode* rootNode = nullptr);
+
     /// Add a node to the graph
     void addNode(ShaderNodePtr node);
 

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -47,6 +47,8 @@ class ShaderPort : public std::enable_shared_from_this<ShaderPort>
 
     ShaderPort(ShaderNode* node, const TypeDesc* type, const string& name, ValuePtr value = nullptr);
 
+    virtual ~ShaderPort() = default;
+
     /// Return a shared pointer instance of this object.
     ShaderPortPtr getSelf()
     {
@@ -149,6 +151,8 @@ class ShaderInput : public ShaderPort
   public:
     ShaderInput(ShaderNode* node, const TypeDesc* type, const string& name);
 
+    virtual ~ShaderInput() = default;
+
     /// Return a connection to an upstream node output,
     /// or nullptr if not connected.
     ShaderOutput* getConnection() { return _connection; }
@@ -181,6 +185,8 @@ class ShaderOutput : public ShaderPort
 {
   public:
     ShaderOutput(ShaderNode* node, const TypeDesc* type, const string& name);
+
+    virtual ~ShaderOutput() = default;
 
     /// Return a set of connections to downstream node inputs,
     /// empty if not connected.

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -47,8 +47,6 @@ class ShaderPort : public std::enable_shared_from_this<ShaderPort>
 
     ShaderPort(ShaderNode* node, const TypeDesc* type, const string& name, ValuePtr value = nullptr);
 
-    virtual ~ShaderPort() = default;
-
     /// Return a shared pointer instance of this object.
     ShaderPortPtr getSelf()
     {
@@ -151,8 +149,6 @@ class ShaderInput : public ShaderPort
   public:
     ShaderInput(ShaderNode* node, const TypeDesc* type, const string& name);
 
-    virtual ~ShaderInput() = default;
-
     /// Return a connection to an upstream node output,
     /// or nullptr if not connected.
     ShaderOutput* getConnection() { return _connection; }
@@ -185,8 +181,6 @@ class ShaderOutput : public ShaderPort
 {
   public:
     ShaderOutput(ShaderNode* node, const TypeDesc* type, const string& name);
-
-    virtual ~ShaderOutput() = default;
 
     /// Return a set of connections to downstream node inputs,
     /// empty if not connected.

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -721,10 +721,10 @@ vector<NodePtr> getShaderNodes(const NodePtr materialNode, const string& shaderT
 }
 
 void getShaderConnections(ConstNodePtr shaderNode,
-    std::vector<InputPtr>& inputs,
-    std::vector<ParameterPtr>& parameters,
-    std::vector<OutputPtr>& inputSources,
-    std::vector<OutputPtr>& parameterSources)
+                          std::vector<InputPtr>& inputs,
+                          std::vector<ParameterPtr>& parameters,
+                          std::vector<OutputPtr>& inputSources,
+                          std::vector<OutputPtr>& parameterSources)
 {
     if (shaderNode->getType() != SURFACE_SHADER_TYPE_STRING &&
         shaderNode->getType() != DISPLACEMENT_SHADER_TYPE_STRING &&
@@ -732,8 +732,6 @@ void getShaderConnections(ConstNodePtr shaderNode,
     {
         return;
     }
-
-    ConstDocumentPtr doc = shaderNode->getDocument();
 
     for (ParameterPtr parameter : shaderNode->getParameters())
     {

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -363,7 +363,7 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
         NodeDefPtr nodeDef = shaderNode->getNodeDef();
         if (!nodeDef)
         {
-            throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + shaderNode->getName() + "' in material " + shaderNode->getName());
+            throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + shaderNode->getNamePath());
         }
 
         const string& nodetype = nodeDef->getNodeString();

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -82,20 +82,13 @@ bool elementRequiresShading(ConstTypedElementPtr element);
 /// Return a vector of all Shader nodes for a Material node.
 /// @param materialNode Node to example
 /// @param shaderType Type of shader to return. If an empty string is specified then
-///        all shader node types are returned.
-vector<NodePtr> getShaderNodes(const NodePtr materialNode, const string& shaderType = SURFACE_SHADER_TYPE_STRING);
-
-/// Get shader connections for a given shader node
-/// @param shaderNode Node to examine
-/// @param inputs List of inputs on the shader node
-/// @param parameters List of parameters on the shader node
-/// @param inputSources List of outputs connected to inputs
-/// @param parameterSources List of outputs connected to parameters
-void getShaderConnections(ConstNodePtr shaderNode,
-                          std::vector<InputPtr>& inputs,
-                          std::vector<ParameterPtr>& parameters,
-                          std::vector<OutputPtr>& inputSources,
-                          std::vector<OutputPtr>& parameterSources);
+///        all shader node types are returned. The default argument value is an empetyr
+///        string which inidates to include shaders which match any type.
+/// @param target Target attribute of shader to return. The default argument value is an empty string
+///        which indicates to include shaders which match any target.
+vector<NodePtr> getShaderNodes(const NodePtr materialNode, 
+                               const string& shaderType = EMPTY_STRING,
+                               const string& target = EMPTY_STRING);
 
 /// Return a vector of all MaterialAssign elements that bind this material node
 /// to the given geometry string

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -80,6 +80,9 @@ bool requiresImplementation(ConstNodeDefPtr nodeDef);
 bool elementRequiresShading(ConstTypedElementPtr element);
 
 /// Return a vector of all Shader nodes for a Material node.
+/// @param materialNode Node to example
+/// @param shaderType Type of shader to return. If an empty string is specified then
+///        all shader node types are returned.
 vector<NodePtr> getShaderNodes(const NodePtr materialNode, const string& shaderType = SURFACE_SHADER_TYPE_STRING);
 
 /// Get shader connections for a given shader node
@@ -96,7 +99,7 @@ void getShaderConnections(ConstNodePtr shaderNode,
 
 /// Return a vector of all MaterialAssign elements that bind this material node
 /// to the given geometry string
-/// @param materialNode node to examine
+/// @param materialNode Node to examine
 /// @param geom The geometry for which material bindings should be returned.
 ///    By default, this argument is the universal geometry string "/", and
 ///    all material bindings are returned.

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -79,6 +79,52 @@ bool requiresImplementation(ConstNodeDefPtr nodeDef);
 /// Determine if a given element requires shading / lighting for rendering
 bool elementRequiresShading(ConstTypedElementPtr element);
 
+/// Return a vector of all Shader nodes for a Material node.
+vector<NodePtr> getShaderNodes(const NodePtr materialNode, const string& shaderType = SURFACE_SHADER_TYPE_STRING);
+
+/// Get shader connections for a given shader node
+/// @param shaderNode Node to examine
+/// @param inputs List of inputs on the shader node
+/// @param parameters List of parameters on the shader node
+/// @param inputSources List of outputs connected to inputs
+/// @param parameterSources List of outputs connected to parameters
+void getShaderConnections(ConstNodePtr shaderNode,
+                          std::vector<InputPtr>& inputs,
+                          std::vector<ParameterPtr>& parameters,
+                          std::vector<OutputPtr>& inputSources,
+                          std::vector<OutputPtr>& parameterSources);
+
+/// Return a vector of all MaterialAssign elements that bind this material node
+/// to the given geometry string
+/// @param materialNode node to examine
+/// @param geom The geometry for which material bindings should be returned.
+///    By default, this argument is the universal geometry string "/", and
+///    all material bindings are returned.
+/// @return Vector of MaterialAssign elements
+vector<MaterialAssignPtr> getGeometryBindings(NodePtr materialNode, const string& geom);
+
+/// Find any material node elements which are renderable (have input shaders)
+/// @param doc Document to examine
+/// @param elements List of renderable elements (returned)
+/// @param includeRefencedGraphs Whether to check for outputs on referenced graphs
+/// @param graphOutputs List of outputs examined. Graph outputs are added if they do
+///     not already exist
+void findRenderableMaterialNodes(ConstDocumentPtr doc, 
+                                 vector<TypedElementPtr>& elements, 
+                                 bool includeReferencedGraphs,
+                                 std::unordered_set<OutputPtr> &processedOutputs);
+
+/// Find any shaderrefs elements which are renderable
+/// @param doc Document to examine
+/// @param elements List of renderable elements (returned)
+/// @param includeRefencedGraphs Whether to check for outputs on referenced graphs
+/// @param graphOutputs List of outputs examined. Graph outputs are added if they do
+///     not already exist
+void findRenderableShaderRefs(ConstDocumentPtr doc,
+                              vector<TypedElementPtr>& elements, 
+                              bool includeReferencedGraphs,
+                              std::unordered_set<OutputPtr> &processedOutputs);
+
 /// Find any elements which may be renderable from within a document.
 /// This includes all outputs on node graphs and shader references which are not
 /// part of any included library. Light shaders are not considered to be renderable.

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -44,11 +44,17 @@ class TextureBaker : public GlslRenderer
     /// Bake textures for all graph inputs of the given shader reference.
     void bakeShaderInputs(ShaderRefPtr shaderRef, GenContext& context, const FilePath& outputFolder);
 
+    /// Bake textures for all graph inputs of the given shader node.
+    void bakeShaderInputs(NodePtr shader, GenContext& context, const FilePath& outputFolder);
+
     /// Bake a texture for the given graph output.
     void bakeGraphOutput(OutputPtr output, GenContext& context, const FilePath& outputFolder);
 
-    /// Write out the baked material document.
+    /// Write out the baked material document based on a shader reference
     void writeBakedDocument(ShaderRefPtr shaderRef, const FilePath& filename);
+
+    /// Write out the baked material document based on a shader node
+    void writeBakedDocument(NodePtr shader, const FilePath& filename);
 
   protected:
     TextureBaker(unsigned int res);

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -677,7 +677,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
             mx::XmlWriteOptions writeOptions;
             writeOptions.writeXIncludeEnable = true;
             writeOptions.elementPredicate = skipXincludes;
-            mx::writeToXmlFile(doc, doc->getSourceUri() + "_modified.mtlxxx", &writeOptions);
+            mx::writeToXmlFile(doc, doc->getSourceUri() + "_modified.mtlxx", &writeOptions);
         }
 
         // Find and register lights

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -596,8 +596,17 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     mx::StringVec errorLog;
     mx::FileSearchPath searchPath(_libSearchPath);
     mx::XmlReadOptions readOptions;
-    readOptions.desiredMajorVersion = options.desiredMajorVersion;
-    readOptions.desiredMinorVersion = options.desiredMinorVersion;
+    bool fileUpgraded = false;
+    if (options.desiredMajorVersion > readOptions.desiredMajorVersion)
+    {
+        fileUpgraded = true;
+        readOptions.desiredMajorVersion = options.desiredMajorVersion;
+    }
+    if (options.desiredMinorVersion > readOptions.desiredMinorVersion)
+    {
+        fileUpgraded = true;
+        readOptions.desiredMinorVersion = options.desiredMinorVersion;
+    }
     for (const auto& testRoot : _testRootPaths)
     {
         mx::loadDocuments(testRoot, searchPath, _skipFiles, overrideFiles, _documents, _documentPaths, 
@@ -650,6 +659,27 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
             continue;
         }
 
+        if (fileUpgraded && 
+            (!doc->getNodes(mx::SURFACE_MATERIAL_NODE_STRING).empty() ||
+             !doc->getNodes(mx::VOLUME_MATERIAL_NODE_STRING).empty()))
+        {
+            _logFile << "Updated version document written to: " << doc->getSourceUri() + "modified.mtlxx" << std::endl;
+
+            mx::StringSet xincludeFiles = doc->getReferencedSourceUris();
+            auto skipXincludes = [xincludeFiles](mx::ConstElementPtr elem)
+            {
+                if (elem->hasSourceUri())
+                {
+                    return (xincludeFiles.count(elem->getSourceUri()) == 0);
+                }
+                return true;
+            };
+            mx::XmlWriteOptions writeOptions;
+            writeOptions.writeXIncludeEnable = true;
+            writeOptions.elementPredicate = skipXincludes;
+            mx::writeToXmlFile(doc, doc->getSourceUri() + "_modified.mtlxxx", &writeOptions);
+        }
+
         // Find and register lights
         findLights(doc, _lights);
         registerLights(doc, _lights, context);
@@ -687,16 +717,34 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
         int codeGenerationFailures = 0;
         for (const auto& element : elements)
         {
-            mx::OutputPtr output = element->asA<mx::Output>();
-            mx::ShaderRefPtr shaderRef = element->asA<mx::ShaderRef>();
+            mx::TypedElementPtr targetElement = element;
+            mx::OutputPtr output = targetElement->asA<mx::Output>();
+            mx::ShaderRefPtr shaderRef = targetElement->asA<mx::ShaderRef>();
+            mx::NodePtr outputNode = targetElement->asA<mx::Node>();
             mx::NodeDefPtr nodeDef = nullptr;
             if (output)
             {
-                nodeDef = output->getConnectedNode()->getNodeDef();
+                outputNode = output->getConnectedNode();
+                // Handle connected upstream material nodes later on.
+                if (outputNode->getType() != mx::MATERIAL_TYPE_STRING)
+                {
+                    nodeDef = outputNode->getNodeDef();
+                }
             }
             else if (shaderRef)
             {
                 nodeDef = shaderRef->getNodeDef();
+            }
+
+            // Handle material node checking. For now only check first surface shader if any
+            if (outputNode && outputNode->getType() == mx::MATERIAL_TYPE_STRING)
+            {
+                std::vector<mx::NodePtr> shaderNodes = getShaderNodes(outputNode, mx::SURFACE_SHADER_TYPE_STRING);
+                if (!shaderNodes.empty())
+                {
+                    nodeDef = shaderNodes[0]->getNodeDef();
+                    targetElement = shaderNodes[0];
+                }
             }
 
             // Allow to skip nodedefs to test if specified
@@ -707,7 +755,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                 continue;
             }
 
-            const std::string namePath(element->getNamePath());
+            const std::string namePath(targetElement->getNamePath());
             if (nodeDef)
             {
                 mx::string elementName = mx::replaceSubstrings(namePath, pathMap);
@@ -726,7 +774,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
 
                     _logFile << "------------ Run validation with element: " << namePath << "------------" << std::endl;
                     mx::StringVec sourceCode;
-                    bool generatedCode = generateCode(context, elementName, element, _logFile, _testStages, sourceCode);
+                    bool generatedCode = generateCode(context, elementName, targetElement, _logFile, _testStages, sourceCode);
                     if (!generatedCode)
                     {
                         _logFile << ">> Failed to generate code for nodedef: " << nodeDefName << std::endl;
@@ -853,7 +901,6 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     try {
         mx::XmlReadOptions readOptions;
         MaterialX::readFromXmlFile(doc, optionFile, mx::FileSearchPath(), &readOptions);
-        //logFile << "Read file: " << doc->getSourceUri() << std::endl;
 
         MaterialX::NodeDefPtr optionDefs = doc->getNodeDef(RENDER_TEST_OPTIONS_STRING);
         if (optionDefs)

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -70,6 +70,19 @@ class Material
         _elem = val;
     }
 
+    /// Return the material element associated with this material
+    mx::TypedElementPtr getMaterial() const
+    {
+        return _material;
+    }
+
+    /// Set the material element associated with this material
+    void setMaterial(mx::TypedElementPtr val)
+    {
+        _material = val;
+    }
+
+
     /// Get any associated udim identifier
     const std::string& getUdim()
     {
@@ -193,6 +206,7 @@ class Material
 
     mx::DocumentPtr _doc;
     mx::TypedElementPtr _elem;
+    mx::TypedElementPtr _material;
 
     std::string _udim;
     bool _hasTransparency;

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -71,13 +71,13 @@ class Material
     }
 
     /// Return the material element associated with this material
-    mx::TypedElementPtr getMaterial() const
+    mx::TypedElementPtr getMaterialElement() const
     {
         return _material;
     }
 
     /// Set the material element associated with this material
-    void setMaterial(mx::TypedElementPtr val)
+    void setMaterialElement(mx::TypedElementPtr val)
     {
         _material = val;
     }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -154,8 +154,8 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
     }
     for (mx::NodePtr materialNode : doc->getMaterialNodes())
     {
-        ;
-        for (mx::NodePtr shader : getShaderNodes(materialNode, mx::SURFACE_SHADER_TYPE_STRING))
+        // Passing empty string to getShaderNodes() means to get all shader node types
+        for (mx::NodePtr shader : getShaderNodes(materialNode, mx::EMPTY_STRING))
         {
             mx::NodeDefPtr nodeDef = shader->getNodeDef();
             if (nodeDef && !nodeDef->getImplementation())

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -154,8 +154,7 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
     }
     for (mx::NodePtr materialNode : doc->getMaterialNodes())
     {
-        // Passing empty string to getShaderNodes() means to get all shader node types
-        for (mx::NodePtr shader : getShaderNodes(materialNode, mx::EMPTY_STRING))
+        for (mx::NodePtr shader : getShaderNodes(materialNode))
         {
             mx::NodeDefPtr nodeDef = shader->getNodeDef();
             if (nodeDef && !nodeDef->getImplementation())

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -152,6 +152,25 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
             }
         }
     }
+    for (mx::NodePtr materialNode : doc->getMaterialNodes())
+    {
+        ;
+        for (mx::NodePtr shader : getShaderNodes(materialNode, mx::SURFACE_SHADER_TYPE_STRING))
+        {
+            mx::NodeDefPtr nodeDef = shader->getNodeDef();
+            if (nodeDef && !nodeDef->getImplementation())
+            {
+                std::vector<mx::NodeDefPtr> altNodeDefs = doc->getMatchingNodeDefs(nodeDef->getNodeString());
+                for (mx::NodeDefPtr altNodeDef : altNodeDefs)
+                {
+                    if (altNodeDef->getImplementation())
+                    {
+                        shader->setNodeDefString(altNodeDef->getName());
+                    }
+                }
+            }
+        }
+    }
 }
 
 } // anonymous namespace
@@ -536,9 +555,9 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
                 filename = mx::FilePath(filename.asString() + "." + mx::MTLX_EXTENSION);
             }
 
-            mx::ShaderRefPtr shaderRef = material->getElement()->asA<mx::ShaderRef>();
-            if (_bakeTextures && shaderRef)
+            if (_bakeTextures && material->getMaterial())
             {
+
                 mx::FileSearchPath searchPath = _searchPath;
                 if (material->getDocument())
                 {
@@ -557,8 +576,19 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
 
                 mx::TextureBakerPtr baker = mx::TextureBaker::create();
                 baker->setImageHandler(imageHandler);
-                baker->bakeShaderInputs(shaderRef, _genContext, filename.getParentPath());
-                baker->writeBakedDocument(shaderRef, filename);
+
+                mx::ShaderRefPtr shaderRef = material->getElement()->asA<mx::ShaderRef>();
+                if (shaderRef)
+                {
+                    baker->bakeShaderInputs(shaderRef, _genContext, filename.getParentPath());
+                    baker->writeBakedDocument(shaderRef, filename);
+                }
+                mx::NodePtr shader = material->getElement()->asA<mx::Node>();
+                if (shader)
+                {
+                    baker->bakeShaderInputs(shader, _genContext, filename.getParentPath());
+                    baker->writeBakedDocument(shader, filename);
+                }
             }
             else
             {
@@ -781,11 +811,9 @@ void Viewer::updateMaterialSelections()
     std::vector<std::string> items;
     for (const auto& material : _materials)
     {
-        mx::ElementPtr displayElem = material->getElement();
-        if (displayElem->isA<mx::ShaderRef>())
-        {
-            displayElem = displayElem->getParent();
-        }
+        mx::ElementPtr displayElem = material->getMaterial();
+        if (!displayElem)
+            displayElem = material->getElement();
         std::string displayName = displayElem->getNamePath();
         if (!material->getUdim().empty())
         {
@@ -823,6 +851,8 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
 {
     // Set up read options.
     mx::XmlReadOptions readOptions;
+    readOptions.desiredMajorVersion = 1;
+    readOptions.desiredMinorVersion = 38;
     readOptions.skipConflictingElements = true;
     readOptions.readXIncludeFunction = [](mx::DocumentPtr doc, const mx::FilePath& filename,
                                           const mx::FileSearchPath& searchPath, const mx::XmlReadOptions* options)
@@ -883,10 +913,28 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         // Find new renderable elements.
         mx::StringVec renderablePaths;
         std::vector<mx::TypedElementPtr> elems;
+        std::vector<mx::TypedElementPtr> materials;
         mx::findRenderableElements(doc, elems);
         for (mx::TypedElementPtr elem : elems)
         {
-            renderablePaths.push_back(elem->getNamePath());
+            mx::TypedElementPtr renderableElem = elem;
+            mx::NodePtr node = elem->asA<mx::Node>();
+            if (node && node->getType() == mx::MATERIAL_TYPE_STRING)
+            {
+                std::vector<mx::NodePtr> shaderNodes = getShaderNodes(node, mx::SURFACE_SHADER_TYPE_STRING);
+                if (!shaderNodes.empty())
+                {
+                    renderableElem = shaderNodes[0];
+                }
+                materials.push_back(node);
+            }
+            else
+            {
+                mx::ShaderRefPtr shaderRef = elem->asA<mx::ShaderRef>();
+                mx::TypedElementPtr materialRef = (shaderRef ? shaderRef->getParent()->asA<mx::TypedElement>() : nullptr);
+                materials.push_back(materialRef);
+            }
+            renderablePaths.push_back(renderableElem->getNamePath());
         }
 
         // Check for any udim set.
@@ -894,8 +942,9 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
 
         // Create new materials.
         mx::TypedElementPtr udimElement;
-        for (const auto& renderablePath : renderablePaths)
+        for (size_t i=0; i<renderablePaths.size(); i++)
         {
+            const auto& renderablePath = renderablePaths[i];
             mx::ElementPtr elem = doc->getDescendant(renderablePath);
             mx::TypedElementPtr typedElem = elem ? elem->asA<mx::TypedElement>() : nullptr;
             if (!typedElem)
@@ -909,6 +958,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                     MaterialPtr mat = Material::create();
                     mat->setDocument(doc);
                     mat->setElement(typedElem);
+                    mat->setMaterial(materials[i]);
                     mat->setUdim(udim);
                     newMaterials.push_back(mat);
                     
@@ -920,6 +970,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 MaterialPtr mat = Material::create();
                 mat->setDocument(doc);
                 mat->setElement(typedElem);
+                mat->setMaterial(materials[i]);
                 newMaterials.push_back(mat);
             }
         }
@@ -977,6 +1028,21 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                         if (!materialRef->getGeometryBindings(partGeomName).empty())
                         {
                             assignMaterial(part, mat);
+                        }
+                    }
+                }
+                else
+                {
+                    mx::NodePtr materialNode = mat->getMaterial()->asA<mx::Node>();
+                    if (materialNode)
+                    {
+                        for (mx::MeshPartitionPtr part : _geometryList)
+                        {
+                            std::string partGeomName = part->getIdentifier();
+                            if (!getGeometryBindings(materialNode, partGeomName).empty())
+                            {
+                                assignMaterial(part, mat);
+                            }
                         }
                     }
                 }
@@ -1121,6 +1187,34 @@ void Viewer::saveDotFiles()
                     std::string dot = nodeGraph->asStringDot();
                     std::string baseName = _searchPath[0] / nodeDef->getName();
                     writeTextFile(dot, baseName + ".dot");
+                }
+            }
+            else
+            {
+                mx::NodePtr shaderNode = elem->asA<mx::Node>();
+                if (shaderNode && material->getMaterial())
+                {
+                    for (mx::InputPtr input : shaderNode->getInputs())
+                    {
+                        mx::OutputPtr output = input->getConnectedOutput();
+                        mx::ConstNodeGraphPtr nodeGraph = output ? output->getAncestorOfType<mx::NodeGraph>() : nullptr;
+                        if (nodeGraph)
+                        {
+                            std::string dot = nodeGraph->asStringDot();
+                            std::string baseName = _searchPath[0] / nodeGraph->getName();
+                            writeTextFile(dot, baseName + ".dot");
+                        }
+                    }
+
+                    mx::NodeDefPtr nodeDef = shaderNode->getNodeDef();
+                    mx::InterfaceElementPtr implement = nodeDef ? nodeDef->getImplementation() : nullptr;
+                    mx::NodeGraphPtr nodeGraph = implement ? implement->asA<mx::NodeGraph>() : nullptr;
+                    if (nodeGraph)
+                    {
+                        std::string dot = nodeGraph->asStringDot();
+                        std::string baseName = _searchPath[0] / nodeDef->getName();
+                        writeTextFile(dot, baseName + ".dot");
+                    }
                 }
             }
         }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -554,7 +554,7 @@ void Viewer::createSaveMaterialsInterface(Widget* parent, const std::string& lab
                 filename = mx::FilePath(filename.asString() + "." + mx::MTLX_EXTENSION);
             }
 
-            if (_bakeTextures && material->getMaterial())
+            if (_bakeTextures && material->getMaterialElement())
             {
 
                 mx::FileSearchPath searchPath = _searchPath;
@@ -810,7 +810,7 @@ void Viewer::updateMaterialSelections()
     std::vector<std::string> items;
     for (const auto& material : _materials)
     {
-        mx::ElementPtr displayElem = material->getMaterial();
+        mx::ElementPtr displayElem = material->getMaterialElement();
         if (!displayElem)
             displayElem = material->getElement();
         std::string displayName = displayElem->getNamePath();
@@ -957,7 +957,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                     MaterialPtr mat = Material::create();
                     mat->setDocument(doc);
                     mat->setElement(typedElem);
-                    mat->setMaterial(materials[i]);
+                    mat->setMaterialElement(materials[i]);
                     mat->setUdim(udim);
                     newMaterials.push_back(mat);
                     
@@ -969,7 +969,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 MaterialPtr mat = Material::create();
                 mat->setDocument(doc);
                 mat->setElement(typedElem);
-                mat->setMaterial(materials[i]);
+                mat->setMaterialElement(materials[i]);
                 newMaterials.push_back(mat);
             }
         }
@@ -1032,7 +1032,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 }
                 else
                 {
-                    mx::NodePtr materialNode = mat->getMaterial()->asA<mx::Node>();
+                    mx::NodePtr materialNode = mat->getMaterialElement()->asA<mx::Node>();
                     if (materialNode)
                     {
                         for (mx::MeshPartitionPtr part : _geometryList)
@@ -1191,7 +1191,7 @@ void Viewer::saveDotFiles()
             else
             {
                 mx::NodePtr shaderNode = elem->asA<mx::Node>();
-                if (shaderNode && material->getMaterial())
+                if (shaderNode && material->getMaterialElement())
                 {
                     for (mx::InputPtr input : shaderNode->getInputs())
                     {

--- a/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
@@ -64,6 +64,7 @@ void bindPyLook(py::module& mod)
         .def("setExclusive", &mx::MaterialAssign::setExclusive)
         .def("getExclusive", &mx::MaterialAssign::getExclusive)
         .def("getReferencedMaterial", &mx::MaterialAssign::getReferencedMaterial)
+        .def("getReferencedMaterialNode", &mx::MaterialAssign::getReferencedMaterialNode)
         .def_readonly_static("CATEGORY", &mx::MaterialAssign::CATEGORY);
 
     py::class_<mx::Visibility, mx::VisibilityPtr, mx::GeomElement>(mod, "Visibility")

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -18,6 +18,7 @@ void bindPyUtil(py::module& mod)
     mod.def("getVersionString", &mx::getVersionString);
     mod.def("getVersionIntegers", &mx::getVersionIntegers);
     mod.def("createValidName", &mx::createValidName, py::arg("name"), py::arg("replaceChar") = '_');
+    mod.def("makeVersionString", &mx::makeVersionString);
     mod.def("isValidName", &mx::isValidName);
     mod.def("incrementName", &mx::incrementName);
     mod.def("splitString", &mx::splitString);


### PR DESCRIPTION
Update #616 
- Add in new search logic to find renderable shader nodes and new transparency checker
- Modify shader generation to take in shader nodes as root node.
- Update render and generation tests to pass shader nodes to generators
- Update view to keep track of material nodes and shader nodes and use shader nodes to generate code. 
- Update texture baker to scan outputs on shader nodes for texture baking and to generate simplified document referencing the baked outputs.
