### PR TITLE
LOOKDEVX-146 : Add in runtime file I/O for look information 

### DIFF
--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -251,6 +251,8 @@ class LookGroup : public Element
     }
     virtual ~LookGroup() { }
 
+    ///
+
     /// Set comma-separated list of looks.
     void setLooks(const string& looks)
     {

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -251,8 +251,6 @@ class LookGroup : public Element
     }
     virtual ~LookGroup() { }
 
-    ///
-
     /// Set comma-separated list of looks.
     void setLooks(const string& looks)
     {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -943,6 +943,8 @@ void RtFileIo::read(const FilePath& documentPath, const FileSearchPath& searchPa
         if (readOptions)
         {
             xmlReadOptions.skipConflictingElements = readOptions->skipConflictingElements;
+            xmlReadOptions.desiredMajorVersion = readOptions->desiredMajorVersion;
+            xmlReadOptions.desiredMajorVersion = readOptions->desiredMinorVersion;
         }
         readFromXmlFile(document, documentPath, searchPaths, &xmlReadOptions);
 
@@ -964,6 +966,8 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* readOptions)
         if (readOptions)
         {
             xmlReadOptions.skipConflictingElements = readOptions->skipConflictingElements;
+            xmlReadOptions.desiredMajorVersion = readOptions->desiredMajorVersion;
+            xmlReadOptions.desiredMajorVersion = readOptions->desiredMinorVersion;
         }
         readFromXmlStream(document, stream, &xmlReadOptions);
 
@@ -976,12 +980,22 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* readOptions)
     }
 }
 
-void RtFileIo::readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths)
+void RtFileIo::readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths, const RtReadOptions* /*readOptions*/)
 {
     PvtStage* stage = PvtStage::ptr(_stage);
 
     // Load all content into a document.
     DocumentPtr doc = createDocument();
+#if 0
+    // TODO: Add readoptions here !
+    XmlReadOptions xmlReadOptions;
+    if (readOptions)
+    {
+        xmlReadOptions.desiredMajorVersion = readOptions->desiredMajorVersion;
+        xmlReadOptions.desiredMinorVersion = readOptions->desiredMinorVersion;
+        xmlReadOptions.skipConflictingElements = readOptions->skipConflictingElements;
+    }
+#endif
     MaterialX::loadLibraries(libraryPaths, searchPaths, doc);
 
     StringSet uris = doc->getReferencedSourceUris();

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -143,7 +143,7 @@ public:
 protected:
     /// Read all contents from one or more libraries.
     /// All MaterialX files found inside the given libraries will be read.
-    void readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths, const RtReadOptions* readOptions = nullptr);
+    void readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths);
     friend class PvtApi;
 
 private:

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -30,7 +30,9 @@ class RtReadOptions
     RtReadOptions() :
         skipConflictingElements(true),
         readFilter(nullptr),
-        readLookInformation(false)
+        readLookInformation(false),
+        desiredMajorVersion(1),
+        desiredMinorVersion(38)
     {
     }
     ~RtReadOptions() { }
@@ -45,6 +47,11 @@ class RtReadOptions
 
     /// Read look information
     bool readLookInformation;
+
+    ///
+    unsigned int desiredMajorVersion;
+
+    unsigned int desiredMinorVersion;
 };
     
 /// @class RtWriteOptions
@@ -136,7 +143,7 @@ public:
 protected:
     /// Read all contents from one or more libraries.
     /// All MaterialX files found inside the given libraries will be read.
-    void readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths);
+    void readLibraries(const StringVec& libraryPaths, const FileSearchPath& searchPaths, const RtReadOptions* readOptions = nullptr);
     friend class PvtApi;
 
 private:

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -29,7 +29,8 @@ class RtReadOptions
   public:
     RtReadOptions() :
         skipConflictingElements(true),
-        readFilter(nullptr)
+        readFilter(nullptr),
+        readLookInformation(false)
     {
     }
     ~RtReadOptions() { }
@@ -41,6 +42,9 @@ class RtReadOptions
     /// Filter function type used for filtering elements during read.
     /// If the filter returns false the element will not be read.
     ReadFilter readFilter;
+
+    /// Read look information
+    bool readLookInformation;
 };
     
 /// @class RtWriteOptions

--- a/source/MaterialXRuntime/RtLook.cpp
+++ b/source/MaterialXRuntime/RtLook.cpp
@@ -3,6 +3,7 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
+#include <MaterialXCore/Util.h>
 #include <MaterialXRuntime/RtLook.h>
 
 #include <MaterialXRuntime/Private/PvtPrim.h>
@@ -15,6 +16,7 @@ namespace
     static const RtToken INHERIT("inherit");
     static const RtToken MATERIAL("material");
     static const RtToken COLLECTION("collection");
+    static const RtToken GEOM("geom");
     static const RtToken EXCLUSIVE("exclusive");
     static const RtToken MATERIAL_ASSIGN("materialassign");
     static const RtToken ACTIVELOOK("active");
@@ -122,6 +124,8 @@ RtPrim RtMaterialAssign::createPrim(const RtToken& typeName, const RtToken& name
     prim->createRelationship(COLLECTION);
     PvtAttribute* exclusive = prim->createAttribute(EXCLUSIVE, RtType::BOOLEAN);
     exclusive->getValue().asBool() = true;
+    PvtAttribute* geom = prim->createAttribute(GEOM, RtType::STRING);
+    geom->getValue().asString() = EMPTY_STRING;
 
     return primH;
 }
@@ -134,6 +138,11 @@ RtRelationship RtMaterialAssign::getMaterial() const
 RtRelationship RtMaterialAssign::getCollection() const
 {
     return prim()->getRelationship(COLLECTION)->hnd();
+}
+
+RtAttribute RtMaterialAssign::getGeom() const
+{
+    return prim()->getAttribute(GEOM)->hnd();
 }
 
 RtAttribute RtMaterialAssign::getExclusive() const

--- a/source/MaterialXRuntime/RtLook.h
+++ b/source/MaterialXRuntime/RtLook.h
@@ -81,6 +81,9 @@ public:
     /// Return the collection relationship.
     RtRelationship getCollection() const;
 
+    /// Return the geometry attribute.
+    RtAttribute getGeom() const;
+
     /// Return the exclusive flag attribute.
     RtAttribute getExclusive() const;
 };

--- a/source/MaterialXRuntime/RtRelationship.cpp
+++ b/source/MaterialXRuntime/RtRelationship.cpp
@@ -60,4 +60,20 @@ RtConnectionIterator RtRelationship::getTargets() const
     return RtConnectionIterator(*this);
 }
 
+string RtRelationship::getTargetsAsString(const string& sep) const
+{
+    RtConnectionIterator iter = getTargets();
+    string str;
+    while (!iter.isDone())
+    {
+        str += (*iter).getName();
+        iter.operator++();
+        if (!iter.isDone())
+        {
+            str += sep;
+        }
+    }
+    return str;
+}
+
 }

--- a/source/MaterialXRuntime/RtRelationship.h
+++ b/source/MaterialXRuntime/RtRelationship.h
@@ -51,6 +51,9 @@ public:
 
     /// Return an iterator over all targets for this relationship.
     RtConnectionIterator getTargets() const;
+
+    // Return targets as a string
+    string getTargetsAsString(const string& sep = ",") const;
 };
 
 }

--- a/source/MaterialXRuntime/RtRelationship.h
+++ b/source/MaterialXRuntime/RtRelationship.h
@@ -52,7 +52,7 @@ public:
     /// Return an iterator over all targets for this relationship.
     RtConnectionIterator getTargets() const;
 
-    // Return targets as a string
+    /// Return targets as a string
     string getTargetsAsString(const string& sep = ",") const;
 };
 

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -1144,21 +1144,34 @@ TEST_CASE("Runtime: Looks", "[runtime]")
     assign1.getExclusive().setValue(mx::RtValue(true));
     REQUIRE(assign1.getExclusive().getValue().asBool() == true);
 
+    assign1.getGeom().setValueString("/mygeom");
+    REQUIRE(assign1.getGeom().getValueString() == "/mygeom");
+
     //
     // Test look
     //
     mx::RtPrim lo1 = stage->createPrim("look1", mx::RtLook::typeName());
     mx::RtLook look1(lo1);
+
+    mx::RtPrim pa2 = stage->createPrim("matassign2", mx::RtMaterialAssign::typeName());
+    mx::RtMaterialAssign assign2(pa2);
+    assign2.getCollection().addTarget(p2);
+    mx::RtPrim sm2 = stage->createPrim(mx::RtPath("/surfacematerial2"), matDef);
+    assign2.getMaterial().addTarget(sm2);
+    assign2.getExclusive().getValue().asBool() = false;
     look1.addMaterialAssign(pa);
+    look1.addMaterialAssign(pa2);
+
     mx::RtConnectionIterator iter3 = look1.getMaterialAssigns().getTargets();
-    REQUIRE(look1.getMaterialAssigns().targetCount() == 1);
+    REQUIRE(look1.getMaterialAssigns().targetCount() == 2);
     while (!iter3.isDone())
     {
         REQUIRE((*iter3).getName() == "matassign1");
         break;
     }
     look1.removeMaterialAssign(pa);
-    REQUIRE(look1.getMaterialAssigns().targetCount() == 0);
+    REQUIRE(look1.getMaterialAssigns().targetCount() == 1);
+    look1.addMaterialAssign(pa);
 
     mx::RtPrim lo2 = stage->createPrim("look2", mx::RtLook::typeName());
     mx::RtLook look2(lo2);
@@ -1175,9 +1188,14 @@ TEST_CASE("Runtime: Looks", "[runtime]")
     REQUIRE(lookgroup1.getLooks().targetCount() == 2);
     lookgroup1.removeLook(lo1);
     REQUIRE(lookgroup1.getLooks().targetCount() == 1);
-
+    
     lookgroup1.getActiveLook().setValueString("look1");
     REQUIRE(lookgroup1.getActiveLook().getValueString() == "look1");
+    
+    lookgroup1.addLook(lo1);
+
+    mx::RtFileIo stageIo(stage);
+    stageIo.write("rtLookExport.mtlx", nullptr);
 }
 
 mx::RtToken toTestResolver(const mx::RtToken& str, const mx::RtToken& type)

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -1110,8 +1110,9 @@ TEST_CASE("Runtime: Looks", "[runtime]")
     col1.addCollection(p3);
     mx::RtRelationship rel = col1.getIncludeCollection();
     REQUIRE(rel.targetCount() == 2); 
-    col1.removeCollection(p2);
+    col1.removeCollection(p3);
     REQUIRE(rel.targetCount() == 1);
+    col1.addCollection(p3);
 
     //
     // Test materialassign
@@ -1169,9 +1170,9 @@ TEST_CASE("Runtime: Looks", "[runtime]")
         REQUIRE((*iter3).getName() == "matassign1");
         break;
     }
-    look1.removeMaterialAssign(pa);
+    look1.removeMaterialAssign(pa2);
     REQUIRE(look1.getMaterialAssigns().targetCount() == 1);
-    look1.addMaterialAssign(pa);
+    look1.addMaterialAssign(pa2);
 
     mx::RtPrim lo2 = stage->createPrim("look2", mx::RtLook::typeName());
     mx::RtLook look2(lo2);
@@ -1194,8 +1195,19 @@ TEST_CASE("Runtime: Looks", "[runtime]")
     
     lookgroup1.addLook(lo1);
 
+    // Test file I/O
     mx::RtFileIo stageIo(stage);
     stageIo.write("rtLookExport.mtlx", nullptr);
+    std::stringstream stream1;
+    stageIo.write(stream1);
+
+    mx::RtStagePtr stage2 = api->createStage(ROOT);
+    mx::RtFileIo stageIo2(stage2);
+    stageIo2.read("rtLookExport.mtlx", mx::FileSearchPath(), nullptr);
+    stageIo2.write("rtLookExport_2.mtlx", nullptr);
+    std::stringstream stream2;
+    stageIo2.write(stream2);
+    REQUIRE(stream1.str() == stream2.str());
 }
 
 mx::RtToken toTestResolver(const mx::RtToken& str, const mx::RtToken& type)


### PR DESCRIPTION
LOOKDEVX-4, LOOKDEVX-146: 
- Add ability to read/write collections, materialassigns, looks, and look groups
- Add in geom support for collections.
- Update unit tests.
- Add in version option on read to allow for material-node conversion (by default) on read.
