### PR TITLE
Add build options for MDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ option(MATERIALX_BUILD_GEN_OGSFX "Build the OGSFX shader generator back-end." ON
 mark_as_advanced(MATERIALX_BUILD_GEN_OGSFX)
 option(MATERIALX_BUILD_GEN_ARNOLD "Build the Arnold OSL shader generator back-end." ON)
 mark_as_advanced(MATERIALX_BUILD_GEN_ARNOLD)
+option(MATERIALX_BUILD_GEN_MDL "Build MDL code generator." ON)
+mark_as_advanced(MATERIALX_BUILD_GEN_MDL)
 
 # Disable render module building option
 option(MATERIALX_DISABLE_BUILD_RENDER "Disable building render modules." OFF)
@@ -86,6 +88,17 @@ add_definitions(-DMATERIALX_TESTRENDER_EXECUTABLE=\"${MATERIALX_TESTRENDER_EXECU
 set(MATERIALX_OSL_INCLUDE_PATH "" CACHE PATH "Full path to osl include paths. e.g. location of stdosl.h")
 mark_as_advanced(MATERIALX_OSL_INCLUDE_PATH)
 add_definitions(-DMATERIALX_OSL_INCLUDE_PATH=\"${MATERIALX_OSL_INCLUDE_PATH}\")
+
+# Helpers for MDL validation
+set(MATERIALX_MDLC_EXECUTABLE "" CACHE FILEPATH "Full path to the mdlc binary.")
+mark_as_advanced(MATERIALX_MDLC_EXECUTABLE)
+add_definitions(-DMATERIALX_MDLC_EXECUTABLE=\"${MATERIALX_MDLC_EXECUTABLE}\")
+set(MATERIALX_MDL_RENDER_EXECUTABLE "" CACHE FILEPATH "Full path to the mdl renderer binary.")
+mark_as_advanced(MATERIALX_MDL_RENDER_EXECUTABLE)
+add_definitions(-DMATERIALX_MDL_RENDER_EXECUTABLE=\"${MATERIALX_MDL_RENDER_EXECUTABLE}\")
+set(MATERIALX_MDL_MODULE_PATHS "" CACHE FILEPATH "Comma separated list of MDL module paths.")
+mark_as_advanced(MATERIALX_MDL_MODULE_PATHS)
+add_definitions(-DMATERIALX_MDL_MODULE_PATHS=\"${MATERIALX_MDL_MODULE_PATHS}\")
 
 # Adjust the default installation path
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -147,10 +160,13 @@ add_subdirectory(source/MaterialXFormat)
 
 # Add shader generation subdirectories
 add_subdirectory(source/MaterialXGenShader)
-add_subdirectory(source/MaterialXGenMdl)
 add_subdirectory(source/MaterialXGenOsl)
 add_subdirectory(source/MaterialXGenGlsl)
 
+if (MATERIALX_BUILD_GEN_MDL)
+    add_definitions(-DMATERIALX_BUILD_GEN_MDL)
+    add_subdirectory(source/MaterialXGenMdl)
+endif()
 if (MATERIALX_BUILD_CROSS)
     add_definitions(-DMATERIALX_BUILD_CROSS)
     add_subdirectory(source/MaterialXCross)

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -409,7 +409,7 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
             emitString(" [[ " + it->second + " ]]", stage);
         }
 
-        if (i < inputs.size() - 1)
+        if (i < inputs.size())
         {
             emitString(",", stage);
         }

--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -5,6 +5,11 @@ include_directories(
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
+if (NOT MATERIALX_BUILD_GEN_MDL)
+    LIST (REMOVE_ITEM materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/GenMdl.cpp")
+    LIST (REMOVE_ITEM materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/RenderMdl.cpp")
+endif()
+
 assign_source_group("Source Files" ${materialx_source})
 assign_source_group("Header Files" ${materialx_headers})
 
@@ -52,8 +57,7 @@ set_target_properties(
 set(LIBS
     MaterialXCore
     MaterialXFormat
-    MaterialXGenShader
-    MaterialXGenMdl
+    MaterialXGenShader    
     MaterialXGenOsl
     MaterialXGenGlsl
     MaterialXRender
@@ -63,6 +67,9 @@ set(LIBS
 )
 
 # Add language specific generators
+if (MATERIALX_BUILD_GEN_MDL)
+    LIST(APPEND LIBS "MaterialXGenMdl")
+endif()
 if (MATERIALX_BUILD_GEN_ARNOLD)
     LIST(APPEND LIBS "MaterialXGenArnold")
 endif()

--- a/source/MaterialXTest/GenArnold.cpp
+++ b/source/MaterialXTest/GenArnold.cpp
@@ -53,7 +53,8 @@ static void generateArnoldOslCode()
     srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/osl"));
     const mx::FilePath logPath("genosl_arnold_generate_test.txt");
 
-    OslShaderGeneratorTester tester(mx::ArnoldShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
+    bool writeShadersToDisk = false;
+    OslShaderGeneratorTester tester(mx::ArnoldShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");

--- a/source/MaterialXTest/GenGlsl.cpp
+++ b/source/MaterialXTest/GenGlsl.cpp
@@ -133,7 +133,8 @@ static void generateGlslCode()
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genglsl_glsl400_generate_test.txt");
 
-    GlslShaderGeneratorTester tester(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
+    bool writeShadersToDisk = false;
+    GlslShaderGeneratorTester tester(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");

--- a/source/MaterialXTest/GenGlsl.h
+++ b/source/MaterialXTest/GenGlsl.h
@@ -18,8 +18,8 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 
     GlslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
                               const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                              const mx::FilePath& logFilePath) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath)
+                              const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override

--- a/source/MaterialXTest/GenMdl.cpp
+++ b/source/MaterialXTest/GenMdl.cpp
@@ -95,6 +95,7 @@ TEST_CASE("GenShader: MDL Implementation Check", "[genmdl]")
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 65);
 }
 
+
 TEST_CASE("GenShader: MDL Unique Names", "[genmdl]")
 {
     mx::GenContext context(mx::MdlShaderGenerator::create());
@@ -108,7 +109,7 @@ TEST_CASE("GenShader: MDL Unique Names", "[genmdl]")
 }
 */
 
-/*
+
 TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
@@ -125,11 +126,12 @@ TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
 
     const mx::FilePath logPath("genmdl_mdl_generate_test.txt");
 
-    MdlShaderGeneratorTester tester(mx::MdlShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
+    bool writeShadersToDisk = true;
+    MdlShaderGeneratorTester tester(mx::MdlShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
     tester.addSkipLibraryFiles();
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }
-*/
+

--- a/source/MaterialXTest/GenMdl.h
+++ b/source/MaterialXTest/GenMdl.h
@@ -8,8 +8,6 @@
 
 #include <MaterialXTest/Catch/catch.hpp>
 
-#include <MaterialXGenOsl/OslShaderGenerator.h>
-
 #include <MaterialXTest/GenShaderUtil.h>
 
 namespace mx = MaterialX;
@@ -21,8 +19,8 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 
     MdlShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const std::vector<mx::FilePath>& testRootPaths,
                              const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath,
-                             const mx::FilePath& logFilePath) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath)
+                             const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override

--- a/source/MaterialXTest/GenOgsXml.cpp
+++ b/source/MaterialXTest/GenOgsXml.cpp
@@ -30,14 +30,16 @@ public:
         const mx::FilePathVec& testRootPaths,
         const mx::FilePath& libSearchPath,
         const mx::FileSearchPath& srcSearchPath,
-        const mx::FilePath& logFilePath
+        const mx::FilePath& logFilePath, 
+        bool writeShadersToDisk
     )
         : GlslShaderGeneratorTester(
             mx::GlslFragmentGenerator::create(),
             testRootPaths,
             libSearchPath,
             srcSearchPath,
-            logFilePath
+            logFilePath,
+            writeShadersToDisk
         )
     {
         dumpMaterials = { "Tiled_Brass", "Brass_Wire_Mesh" };
@@ -118,7 +120,8 @@ static void generateXmlCode()
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genogsxml_generate_test.txt");
 
-    OgsXmlShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath);
+    bool writeShadersToDisk = false;
+    OgsXmlShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPaths.front() / mx::FilePath("_options.mtlx");

--- a/source/MaterialXTest/GenOgsfx.cpp
+++ b/source/MaterialXTest/GenOgsfx.cpp
@@ -85,8 +85,9 @@ class OgsFxShaderGeneratorTester : public GlslShaderGeneratorTester
 {
   public:
     OgsFxShaderGeneratorTester(const mx::FilePathVec& testRootPaths, const mx::FilePath& libSearchPath,
-                                 const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath) :
-            GlslShaderGeneratorTester(mx::OgsFxShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logFilePath)
+                               const mx::FileSearchPath& srcSearchPath, const mx::FilePath& logFilePath, 
+                               bool writeShadersToDisk) :
+            GlslShaderGeneratorTester(mx::OgsFxShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override
@@ -120,7 +121,9 @@ static void generateOgsFxCode()
     const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genglsl_ogsfx_generate_test.txt");
-    OgsFxShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath);
+
+    bool writeShadersToDisk = false;
+    OgsFxShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");

--- a/source/MaterialXTest/GenOsl.cpp
+++ b/source/MaterialXTest/GenOsl.cpp
@@ -121,7 +121,8 @@ static void generateOslCode()
     srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/osl"));
     const mx::FilePath logPath("genosl_vanilla_generate_test.txt");
 
-    OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath);
+    bool writeShadersToDisk = false;
+    OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
     tester.addSkipLibraryFiles();
 
     const mx::GenOptions genOptions;

--- a/source/MaterialXTest/GenOsl.h
+++ b/source/MaterialXTest/GenOsl.h
@@ -21,8 +21,8 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 
     OslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const std::vector<mx::FilePath>& testRootPaths,
                              const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath,
-                             const mx::FilePath& logFilePath) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath)
+                             const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -793,7 +793,8 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                     }
                     else if (sourceCode.size())
                     {
-                        mx::FilePath path = mx::FilePath::getCurrentPath() / "generatedshaders";
+                        std::string sourceURI = doc->getActiveSourceUri();
+                        mx::FilePath path = mx::FilePath(sourceURI.substr(0, sourceURI.size() - 4)) / "generatedshaders";
                         if (!path.exists())
                         {
                             path.createDirectory();

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -791,10 +791,9 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                         _logFile << ">> Failed to generate code for nodedef: " << nodeDefName << std::endl;
                         codeGenerationFailures++;
                     }
-                    else if (sourceCode.size())
+                    else if (_writeShadersToDisk && sourceCode.size())
                     {
-                        std::string sourceURI = doc->getActiveSourceUri();
-                        mx::FilePath path = mx::FilePath(sourceURI.substr(0, sourceURI.size() - 4)) / "generatedshaders";
+                        mx::FilePath path = mx::FilePath::getCurrentPath() / "generatedshaders";
                         if (!path.exists())
                         {
                             path.createDirectory();
@@ -816,6 +815,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                                 const mx::FilePath filename = path / (elementName + "." + _testStages[i] + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage()));
                                 std::ofstream file(filename.asString());
                                 file << sourceCode[i];
+                                file.close();
                             }
                         }
                         else
@@ -823,6 +823,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                             path = path / (elementName + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage()));
                             std::ofstream file(path.asString());
                             file << sourceCode[0];
+                            file.close();
                         }
                     }
                 }

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -149,13 +149,14 @@ class ShaderGeneratorTester
   public:
     ShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
                             const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                            const mx::FilePath& logFilePath) :
+                            const mx::FilePath& logFilePath, bool writeShadersToDisk) :
         _shaderGenerator(shaderGenerator),
         _languageTargetString(shaderGenerator ? (shaderGenerator->getLanguage() + "_" + shaderGenerator->getTarget()) : "NULL"),
         _testRootPaths(testRootPaths),
         _libSearchPath(libSearchPath),
         _srcSearchPath(srcSearchPath),
-        _logFilePath(logFilePath)
+        _logFilePath(logFilePath),
+        _writeShadersToDisk(writeShadersToDisk)
     {
     }
 
@@ -232,6 +233,7 @@ class ShaderGeneratorTester
     const mx::FilePath _libSearchPath;
     const mx::FileSearchPath _srcSearchPath;
     const mx::FilePath _logFilePath;
+    bool _writeShadersToDisk;
 
     mx::StringSet _skipFiles;
     mx::StringSet _skipLibraryFiles;


### PR DESCRIPTION
- MATERIALX_BUILD_GEN_MDL : Option to build MDL or not
- MATERIALX_MDLC_EXECUTABLE : mdlc location
- MATERIALX_MDL_RENDER_EXECUTABLE : mdl renderer location
- MATERIALX_MDL_MODULE_PATHS : comma separated list of mdl module paths

Also fix osl generator as it was omiitting a "," in the main function signature so would not compile.

