### PR TITLE
Fix USD definition load into runtime

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -266,7 +266,7 @@
     </surface>
 
     <!-- Output -->
-    <output name="surface" type="surfaceshader" nodename="surface_constructor" />
+    <output name="out" type="surfaceshader" nodename="surface_constructor" />
   </nodegraph>
 
   <!-- Node: UsdUVTexture -->
@@ -299,43 +299,43 @@
     <geompropvalue name="primvar" type="integer">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="integer" nodename="primvar"/>
+    <output name="out" type="integer" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_boolean" nodedef="ND_UsdPrimvarReader_boolean">
     <geompropvalue name="primvar" type="boolean">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="boolean" nodename="primvar"/>
+    <output name="out" type="boolean" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_string" nodedef="ND_UsdPrimvarReader_string">
     <geompropvalue name="primvar" type="string">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="string" nodename="primvar"/>
+    <output name="out" type="string" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_float" nodedef="ND_UsdPrimvarReader_float">
     <geompropvalue name="primvar" type="float">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="float" nodename="primvar"/>
+    <output name="out" type="float" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector2" nodedef="ND_UsdPrimvarReader_vector2">
     <geompropvalue name="primvar" type="vector2">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="vector2" nodename="primvar"/>
+    <output name="out" type="vector2" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector3" nodedef="ND_UsdPrimvarReader_vector3">
     <geompropvalue name="primvar" type="vector3">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="vector3" nodename="primvar"/>
+    <output name="out" type="vector3" nodename="primvar"/>
   </nodegraph>
   <nodegraph name="IMP_UsdPrimvarReader_vector4" nodedef="ND_UsdPrimvarReader_vector4">
     <geompropvalue name="primvar" type="vector4">
       <parameter name="geomprop" type="string" interfacename="varname"/>
     </geompropvalue>
-    <output name="result" type="vector4" nodename="primvar"/>
+    <output name="out" type="vector4" nodename="primvar"/>
   </nodegraph>
 
   <!-- Node: UsdTransform2d -->
@@ -346,7 +346,7 @@
       <input name="rotate" type="float" interfacename="rotation"/>
       <input name="offset" type="vector2" interfacename="translation"/>
     </place2d>
-    <output name="result" type="vector2" nodename="placement"/>
+    <output name="out" type="vector2" nodename="placement"/>
   </nodegraph>
 
 </materialx>

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -1422,8 +1422,6 @@ TEST_CASE("Runtime: materials", "[runtime]")
 {
     mx::RtScopedApiHandle api;
 
-    mx::RtStagePtr stage = api->createStage(ROOT);
-
     // Load in all libraries required for materials
     mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
     api->setSearchPath(searchPath);

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -68,6 +68,7 @@ namespace
     const mx::RtToken NONAME("");
     const mx::RtToken STDLIB("stdlib");
     const mx::RtToken PBRLIB("pbrlib");
+    const mx::RtToken BXDFLIB("bxdf");
 
     bool compareFiles(const mx::FilePath& filename1, const mx::FilePath& filename2)
     {
@@ -1415,6 +1416,20 @@ TEST_CASE("Runtime: NameResolvers", "[runtime]")
     REQUIRE(result3.str() == "test_toTestResolver");
     mx::RtToken result4 = registry->resolveIdentifier(pathToGeom, mx::RtNameResolverInfo::FILENAME_TYPE, false);
     REQUIRE(result4.str() == "test_fromTestResolver");
+}
+
+TEST_CASE("Runtime: materials", "[runtime]")
+{
+    mx::RtScopedApiHandle api;
+
+    mx::RtStagePtr stage = api->createStage(ROOT);
+
+    // Load in all libraries required for materials
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    api->setSearchPath(searchPath);
+    api->loadLibrary(STDLIB);
+    api->loadLibrary(PBRLIB);
+    api->loadLibrary(BXDFLIB);
 }
 
 #endif // MATERIALX_BUILD_RUNTIME


### PR DESCRIPTION
Restore modifications made to usd material definition to make runtime load work.
Add in test to make sure this is always tested in the future.
A fix or validation check should be added to catch this in core/runtime later.
