### PR TITLE
Add in additional runtime search paths

### DIFF
--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -209,6 +209,12 @@ class FileSearchPath
         return str;
     }
 
+    /// Clear the search paths
+    void clear()
+    {
+        _paths.clear();
+    }
+
     /// Append the given path to the sequence.
     void append(const FilePath& path)
     {

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -88,6 +88,22 @@ public:
         return RtPrimIterator(_masterPrimRoot, predicate);
     }
 
+    void clearSearchPath()
+    {
+        _searchPaths.clear();
+    }
+
+    void clearTextureSearchPath()
+    {
+        _textureSearchPaths.clear();
+    }
+
+    void clearImplementationSearchPath()
+    {
+        _implementationSearchPaths.clear();
+    }
+
+
     void setSearchPath(const FileSearchPath& searchPath)
     {
         _searchPaths.append(searchPath);
@@ -356,6 +372,21 @@ RtPrim RtApi::getMasterPrim(const RtToken& name)
 RtPrimIterator RtApi::getMasterPrims(RtObjectPredicate predicate)
 {
     return RtPrimIterator(_cast(_ptr)->_masterPrimRoot, predicate);
+}
+
+void RtApi::clearSearchPath()
+{
+    _cast(_ptr)->clearSearchPath();
+}
+
+void RtApi::clearTextureSearchPath()
+{
+    _cast(_ptr)->clearTextureSearchPath();
+}
+
+void RtApi::clearImplementationSearchPath()
+{
+    _cast(_ptr)->clearImplementationSearchPath();
 }
 
 void RtApi::setSearchPath(const FileSearchPath& searchPath)

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -93,6 +93,31 @@ public:
         _searchPaths.append(searchPath);
     }
 
+    void setTextureSearchPath(const FileSearchPath& searchPath)
+    {
+        _textureSearchPaths.append(searchPath);
+    }
+
+    void setImplementationSearchPath(const FileSearchPath& searchPath)
+    {
+        _implementationSearchPaths.append(searchPath);
+    }
+
+    const FileSearchPath& getSearchPath() const
+    {
+        return _searchPaths;
+    }
+
+    const FileSearchPath& getTextureSearchPath() const
+    {
+        return _textureSearchPaths;
+    }
+
+    const FileSearchPath& getImplementationSearchPath() const
+    {
+        return _implementationSearchPaths;
+    }
+
     void loadLibrary(const RtToken& name)
     {
         // If already loaded unload the old first,
@@ -236,6 +261,8 @@ public:
     }
 
     FileSearchPath _searchPaths;
+    FileSearchPath _implementationSearchPaths;
+    FileSearchPath _textureSearchPaths;
     RtStagePtr _libraryRoot;
     RtTokenMap<RtStagePtr> _libraries;
 
@@ -334,6 +361,31 @@ RtPrimIterator RtApi::getMasterPrims(RtObjectPredicate predicate)
 void RtApi::setSearchPath(const FileSearchPath& searchPath)
 {
     _cast(_ptr)->setSearchPath(searchPath);
+}
+
+void RtApi::setTextureSearchPath(const FileSearchPath& searchPath)
+{
+    _cast(_ptr)->setTextureSearchPath(searchPath);
+}
+
+void RtApi::setImplementationSearchPath(const FileSearchPath& searchPath)
+{
+    _cast(_ptr)->setImplementationSearchPath(searchPath);
+}
+
+const FileSearchPath& RtApi::getSearchPath() const
+{
+    return _cast(_ptr)->getSearchPath();
+}
+
+const FileSearchPath& RtApi::getTextureSearchPath() const
+{
+    return _cast(_ptr)->getTextureSearchPath();
+}
+
+const FileSearchPath& RtApi::getImplementationSearchPath() const
+{
+    return _cast(_ptr)->getImplementationSearchPath();
 }
 
 void RtApi::loadLibrary(const RtToken& name)

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -77,18 +77,34 @@ public:
         unregisterCreateFunction(T::typeName());
     }
 
-    /// Set search path for libraries. Can be called multiple times
+    /// Clear the definition search path
+    void clearSearchPath();
+
+    /// Clear the texture search path 
+    void clearTextureSearchPath();
+
+    /// Clear the implementation saerch path
+    void clearImplementationSearchPath();
+
+    /// Set search path for definition libraries. Can be called multiple times
     /// to append to the current search path.
     void setSearchPath(const FileSearchPath& searchPath);
 
+    /// Set search path for texture resources. Can be called multiple times
+    /// to append to the current search path.
     void setTextureSearchPath(const FileSearchPath& searchPath);
 
+    /// Set search path for implemntations used by libraries. Can be called multiple times
+    /// to append to the current search path.
     void setImplementationSearchPath(const FileSearchPath& searchPath);
 
+    /// Get the search path for definition libraries. 
     const FileSearchPath& getSearchPath() const;
 
+    /// Get search path for texture resources.
     const FileSearchPath& getTextureSearchPath() const;
 
+    /// Get search path for implemntations used by libraries. 
     const FileSearchPath& getImplementationSearchPath() const;
 
     /// Load a library.

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -81,6 +81,16 @@ public:
     /// to append to the current search path.
     void setSearchPath(const FileSearchPath& searchPath);
 
+    void setTextureSearchPath(const FileSearchPath& searchPath);
+
+    void setImplementationSearchPath(const FileSearchPath& searchPath);
+
+    const FileSearchPath& getSearchPath() const;
+
+    const FileSearchPath& getTextureSearchPath() const;
+
+    const FileSearchPath& getImplementationSearchPath() const;
+
     /// Load a library.
     void loadLibrary(const RtToken& name);
 

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -1418,7 +1418,7 @@ TEST_CASE("Runtime: NameResolvers", "[runtime]")
     REQUIRE(result4.str() == "test_fromTestResolver");
 }
 
-TEST_CASE("Runtime: materials", "[runtime]")
+TEST_CASE("Runtime: libraries", "[runtime]")
 {
     mx::RtScopedApiHandle api;
 
@@ -1428,6 +1428,22 @@ TEST_CASE("Runtime: materials", "[runtime]")
     api->loadLibrary(STDLIB);
     api->loadLibrary(PBRLIB);
     api->loadLibrary(BXDFLIB);
+
+    // Set and test search paths
+    api->clearSearchPath();
+    REQUIRE(api->getSearchPath().isEmpty());
+    api->setSearchPath(searchPath);
+    REQUIRE(api->getSearchPath().asString() == searchPath.asString());
+
+    REQUIRE(api->getTextureSearchPath().isEmpty());
+    mx::FileSearchPath texturePath(mx::FilePath::getCurrentPath() / mx::FilePath("resources/Images"));
+    api->setTextureSearchPath(texturePath);
+    REQUIRE(api->getTextureSearchPath().find("brass_color.jpg").exists());
+
+    REQUIRE(api->getImplementationSearchPath().isEmpty());
+    mx::FileSearchPath implPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/genglsl"));
+    api->setImplementationSearchPath(implPath);
+    REQUIRE(api->getImplementationSearchPath().find("stdlib_genglsl_unit_impl.mtlx").exists());    
 }
 
 #endif // MATERIALX_BUILD_RUNTIME


### PR DESCRIPTION
- Add in separate texture and implementation search paths
- Add in a clear() as RtAPI is a singleton and never clears paths.
