### PR TITLE
Add support for generating height-to-normalmap MDL code.

### DIFF
--- a/libraries/stdlib/genmdl/materialx/sampling.mdl
+++ b/libraries/stdlib/genmdl/materialx/sampling.mdl
@@ -8,17 +8,16 @@ export const int MX_MAX_SAMPLE_COUNT = 49;
 // Size of all weights for all levels (including level 1)
 export const int MX_WEIGHT_ARRAY_SIZE = 84;
 
-// Q: How to implement this in MDL?
+// This is not available in MDL so just use a "small" number
 float2 dFdx(float2 uv)
 {
-    return uv;
+    return uv+0.0001;
 }
 
 float2 dFdy(float2 uv)
 {
-    return uv;
+    return uv+0.0001;
 }
-
 
 //
 // Function to compute the sample size relative to a texture coordinate

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -851,8 +851,7 @@
   <implementation name="IM_blur_vector4_genmdl" nodedef="ND_blur_vector4" language="genmdl"/>
 
   <!-- <heighttonormal> -->
-  <implementation name="IM_heighttonormal_vector3_genmdl" nodedef="ND_heighttonormal_vector3" file="stdlib/genmdl/materialx/stdlib.mdl" function="mx_heighttonormal_vector3" language="genmdl" />
-
+  <implementation name="IM_heighttonormal_vector3_genmdl" nodedef="ND_heighttonormal_vector3" language="genmdl" />
 
   <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -9,6 +9,7 @@
 #include <MaterialXGenMdl/Nodes/CompoundNodeMdl.h>
 #include <MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h>
 #include <MaterialXGenMdl/Nodes/SurfaceNodeMdl.h>
+#include <MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h>
 
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/Shader.h>
@@ -19,7 +20,6 @@
 #include <MaterialXGenShader/Nodes/SwitchNode.h>
 #include <MaterialXGenShader/Nodes/IfNode.h>
 #include <MaterialXGenShader/Nodes/BlurNode.h>
-
 
 namespace MaterialX
 {
@@ -198,6 +198,9 @@ MdlShaderGenerator::MdlShaderGenerator() :
     registerImplementation("IM_blur_vector2_" + MdlShaderGenerator::LANGUAGE, BlurNode::create);
     registerImplementation("IM_blur_vector3_" + MdlShaderGenerator::LANGUAGE, BlurNode::create);
     registerImplementation("IM_blur_vector4_" + MdlShaderGenerator::LANGUAGE, BlurNode::create);
+
+    // <!-- <heighttonormal> -->
+    registerImplementation("IM_heighttonormal_vector3_" + MdlShaderGenerator::LANGUAGE, HeightToNormalNodeMdl::create);
 }
 
 ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -1,0 +1,118 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h>
+#include <MaterialXGenMdl/MdlShaderGenerator.h>
+
+#include <MaterialXGenShader/Shader.h>
+#include <MaterialXGenShader/GenContext.h>
+
+namespace MaterialX
+{
+
+namespace
+{
+    /// Name of filter function to call to compute normals from input samples
+    const string filterFunctionName = "mx_normal_from_samples_sobel";
+
+    /// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
+    /// as input, and return a 2 channel vector as output
+    const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+
+    const unsigned int sampleCount = 9;
+    const unsigned int filterWidth = 3;
+    const float filterSize = 1.0;
+    const float filterOffset = 0.0;
+}
+
+HeightToNormalNodeMdl::HeightToNormalNodeMdl()
+{
+}
+
+ShaderNodeImplPtr HeightToNormalNodeMdl::create()
+{
+    return std::shared_ptr<HeightToNormalNodeMdl>(new HeightToNormalNodeMdl());
+}
+
+void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+                                                        unsigned int, StringVec& offsetStrings) const
+{
+    // Build a 3x3 grid of samples that are offset by the provided sample size
+    for (int row = -1; row <= 1; row++)
+    {
+        for (int col = -1; col <= 1; col++)
+        {
+            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString +  "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+        }
+    }
+}
+
+bool HeightToNormalNodeMdl::acceptsInputType(const TypeDesc* type) const
+{
+    // Only support inputs which are float scalar
+    return (type == Type::FLOAT && type->isScalar());
+}
+
+void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
+{
+    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+    
+        const ShaderInput* inInput = node.getInput("in");
+        const ShaderInput* scaleInput = node.getInput("scale");
+
+        if (!inInput || !scaleInput)
+        {
+            throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid heighttonormal node");
+        }
+
+        // Create the input "samples". This means to emit the calls to 
+        // compute the sames and return a set of strings containaing
+        // the variables to assign to the sample grid.
+        //  
+        StringVec sampleStrings;
+        emitInputSamplesUV(node, sampleCount, filterWidth, 
+                           filterSize, filterOffset, sampleSizeFunctionUV, 
+                           context, stage, sampleStrings);
+
+        const ShaderOutput* output = node.getOutput();
+
+        // Emit code to evaluate samples.
+        //
+        string sampleName(output->getVariable() + "_samples");
+        string arrayDeclaration = "float[" + std::to_string(sampleCount) + "]";
+        shadergen.emitLine(arrayDeclaration + " " + sampleName + " = " + arrayDeclaration + "(", stage, false);
+        for (unsigned int i = 0; i < sampleCount; i++)
+        {
+            shadergen.emitLineBegin(stage);
+            shadergen.emitString("    " + sampleStrings[i], stage);
+            if (i+1 < sampleCount)
+            {
+                shadergen.emitLine(",", stage, false);
+            }
+        }
+        shadergen.emitLine(")", stage);
+        shadergen.emitLineBegin(stage);
+        shadergen.emitOutput(output, true, false, context, stage);
+        shadergen.emitString(" = " + filterFunctionName, stage);
+        shadergen.emitString("(" + sampleName + ", ", stage);
+        shadergen.emitInput(scaleInput, context, stage);
+        shadergen.emitString(")", stage);
+        shadergen.emitLineEnd(stage);
+    END_SHADER_STAGE(shader, Stage::PIXEL)
+}
+
+const string& HeightToNormalNodeMdl::getLanguage() const
+{
+    return MdlShaderGenerator::LANGUAGE;
+}
+
+const string& HeightToNormalNodeMdl::getTarget() const
+{
+    return MdlShaderGenerator::TARGET;
+}
+
+
+} // namespace MaterialX

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
@@ -1,0 +1,39 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_HEIGHTTONORMALNODEMDL_H
+#define MATERIALX_HEIGHTTONORMALNODEMDL_H
+
+#include <MaterialXGenShader/Nodes/ConvolutionNode.h>
+
+namespace MaterialX
+{
+
+/// HeightToNormal node implementation for MDL
+class HeightToNormalNodeMdl : public ConvolutionNode
+{
+  public:
+    static ShaderNodeImplPtr create();
+
+    void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
+
+    const string& getLanguage() const override;
+    const string& getTarget() const override;
+
+  protected:
+    /// Constructor
+    HeightToNormalNodeMdl();
+
+    /// Return if given type is an acceptible input
+    bool acceptsInputType(const TypeDesc* type) const override;
+
+    /// Compute offset strings for sampling
+    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+                                    unsigned int filterWidth, StringVec& offsetStrings) const override;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -143,7 +143,7 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node,
                         sampleSizeFunctionUV + "(" +
                         sampleInputValue + "," +
                         std::to_string(filterSize) + "," +
-                        std::to_string(filterOffset) + ");"
+                        std::to_string(filterOffset) + ")"
                     );
                     shadergen.emitLine(sampleCall, stage);
 

--- a/source/MaterialXTest/GenMdl.cpp
+++ b/source/MaterialXTest/GenMdl.cpp
@@ -145,17 +145,19 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
     mdlcCommand += " > " + errorFile.asString() + " 2>&1";
 
     int returnValue = std::system(mdlcCommand.c_str());
-    if (returnValue != 0)
+    std::ifstream errorStream(errorFile);
+    mx::StringVec result;
+    std::string line;
+    bool writeErrorCode = false;
+    while (std::getline(errorStream, line))
     {
-        _logFile << mdlcCommand << std::endl;
-        _logFile << "\tReturn code: " << std::to_string(returnValue) << std::endl;
-        std::ifstream errorStream(errorFile);
-        mx::StringVec result;
-        std::string line;
-        while (std::getline(errorStream, line))
+        if (!writeErrorCode)
         {
-            _logFile << "\tError: " << line << std::endl;
+            _logFile << mdlcCommand << std::endl;
+            _logFile << "\tReturn code: " << std::to_string(returnValue) << std::endl;
+            writeErrorCode = true;
         }
+        _logFile << "\tError: " << line << std::endl;
     }
 }
 


### PR DESCRIPTION
* Need to add in the custom node which will generate the MDL code required.
* Similar to the GLSL one with mostly the array syntax handling being different.
* Fix a small issue in code generation which would output a line with 2 semi-colons at the end of line ";;". This is consider to be invalid when checking with mdlc.

