### PR TITLE
Harmonization on singular unit names.

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -63,8 +63,8 @@
 
   <unittypedef name="angle"/>
   <unitdef name="UD_stdlib_angle" unittype="angle">
-    <unit name="degrees" scale="1.0" />
-    <unit name="radians" scale="57.295779513" />
+    <unit name="degree" scale="1.0" />
+    <unit name="radian" scale="57.295779513" />
   </unitdef>
 
   <!-- ======================================================================== -->
@@ -1258,7 +1258,7 @@
     values represent greater accessibility to ambient light, 0 means "fully occluded".
   -->
   <nodedef name="ND_ambientocclusion_float" node="ambientocclusion" nodegroup="global">
-    <parameter name="coneangle" type="float" value="90.0" unittype="angle" unit="degrees"/>
+    <parameter name="coneangle" type="float" value="90.0" unittype="angle" unit="degree"/>
     <parameter name="maxdistance" type="float" value="1e38"/>
     <output name="out" type="float" default="1.0"/>
   </nodedef>
@@ -2593,7 +2593,7 @@
   -->
   <nodedef name="ND_rotate2d_vector2" node="rotate2d" nodegroup="math">
     <input name="in" type="vector2" value="0.0, 0.0"/>
-    <input name="amount" type="float" value="0.0" unittype="angle" unit="degrees"/>
+    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree"/>
     <output name="out" type="vector2" defaultinput="in"/>
   </nodedef>
 
@@ -2603,7 +2603,7 @@
   -->
   <nodedef name="ND_rotate3d_vector3" node="rotate3d" nodegroup="math">
     <input name="in" type="vector3" value="0.0, 0.0, 0.0"/>
-    <input name="amount" type="float" value="0.0" unittype="angle" unit="degrees"/>
+    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree"/>
     <parameter name="axis" type="vector3" value="0.0, 1.0, 0.0"/>
     <output name="out" type="vector3" defaultinput="in"/>
   </nodedef>
@@ -2616,7 +2616,7 @@
     <input name="texcoord" type="vector2" value="0.0, 0.0"/>
     <parameter name="pivot" type="vector2" value="0.0,0.0"/>
     <input name="scale" type="vector2" value="1.0,1.0"/>
-    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degrees"/>
+    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree"/>
     <input name="offset" type="vector2" value="0.0,0.0"/>
     <output name="out" type="vector2" defaultinput="texcoord"/>
   </nodedef>

--- a/resources/Materials/TestSuite/stdlib/math/transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/transform.mtlx
@@ -191,7 +191,7 @@ Basic transform function tests each test is in a separate graph for each variati
         <input name="texcoord" type="vector2" nodename="texcoord1"/>
         <parameter name="pivot" type="vector2" value="0.5,0.5"/>
         <input name="scale" type="vector2" value="2.0,2.0"/>
-        <input name="rotate" type="float" value="1.0" unittype="angle" unit="radians"/>
+        <input name="rotate" type="float" value="1.0" unittype="angle" unit="radian"/>
         <input name="offset" type="vector2" value="0.2,0.2"/>
     </place2d>
     <output name="out" type="vector2" nodename="place2d1_1" />

--- a/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
@@ -83,7 +83,7 @@ Basic vector math function tests each test is in a separate graph for each varia
       <output name="out" type="vector2" nodename="rotate1" />
       <rotate2d name="rotate1" type="vector2" xpos="5.62998" ypos="7.07692">
          <input name="in" type="vector2" value="0.0, 0.0" nodename="swizzle1" />
-         <input name="amount" type="float" value="1.5708" unittype="angle" unit="radians" />
+         <input name="amount" type="float" value="1.5708" unittype="angle" unit="radian" />
       </rotate2d>
       <swizzle name="swizzle1" type="vector2" xpos="4.31739" ypos="5.3662">
          <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
@@ -96,7 +96,7 @@ Basic vector math function tests each test is in a separate graph for each varia
       </position>
       <rotate3d name="rotate1" type="vector3" xpos="5.19248" ypos="5.306">
          <input name="in" type="vector3" value="0.0, 0.0, 0.0" nodename="position1" />
-         <input name="amount" type="float" value="180.0000" unittype="angle" unit="degrees" />
+         <input name="amount" type="float" value="180.0000" unittype="angle" unit="degree" />
          <parameter name="axis" type="vector3" value="0.0, 1.0000, 1.0000" />
       </rotate3d>
       <output name="out" type="vector3" nodename="rotate1" />

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
@@ -34,11 +34,11 @@ Upgrade path test from 1.36 to 1.37
    <!-- rotate to rotate2d and rotate3d -->
    <rotate name="rotate1" type="vector2">
       <input name="in" type="vector2" value="0.0, 0.0"/>
-      <input name="amount" type="float" value="1.5708" unittype="angle" unit="radians" />
+      <input name="amount" type="float" value="1.5708" unittype="angle" unit="radian" />
    </rotate>
    <rotate name="rotate2" type="vector3" xpos="5.19248" ypos="5.306">
       <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="amount" type="float" value="180.0000" unittype="angle" unit="degrees" />
+      <input name="amount" type="float" value="180.0000" unittype="angle" unit="degree" />
       <parameter name="axis" type="vector3" value="0.0, 1.0000, 1.0000" />
    </rotate>
 

--- a/source/MaterialXTest/Units.cpp
+++ b/source/MaterialXTest/Units.cpp
@@ -52,12 +52,12 @@ TEST_CASE("UnitAttribute", "[units]")
     // Test for target unit specified on a nodedef
     mx::NodeDefPtr customNodeDef = doc->addNodeDef("ND_dummy", "float", "dummy");
     mx::InputPtr input = customNodeDef->setInputValue("angle", 23.0f, "float");
-    input->setUnit("degrees");
+    input->setUnit("degree");
     mx::NodePtr custom = doc->addNodeInstance(customNodeDef);
     input = custom->setInputValue("angle", 45.0f, "float");
-    input->setUnit("radians");
-    REQUIRE(input->getUnit() == "radians");
-    REQUIRE(input->getActiveUnit() == "degrees");
+    input->setUnit("radian");
+    REQUIRE(input->getUnit() == "radian");
+    REQUIRE(input->getActiveUnit() == "degree");
 }
 
 TEST_CASE("UnitEvaluation", "[units]")
@@ -111,9 +111,9 @@ TEST_CASE("UnitEvaluation", "[units]")
     registry->addUnitConverter(angleTypeDef, converter2);
     mx::UnitConverterPtr uconverter2 = registry->getUnitConverter(angleTypeDef);
     REQUIRE(uconverter2);
-    result = converter2->convert(2.5f, "degrees", "degrees");
+    result = converter2->convert(2.5f, "degree", "degree");
     REQUIRE((result - 2.5f) < EPSILON);
-    result = converter2->convert(2.0f, "radians", "degrees");
+    result = converter2->convert(2.0f, "radian", "degree");
     REQUIRE((result - 114.591559026f) < EPSILON);
 }
 


### PR DESCRIPTION
Using https://physics.nist.gov/cuu/Units/units.html as a reference to use singular naming convention.
e.g. angle is 30 degree instead of degrees