### PR TITLE
fix broken images and links in doxygen docs

### DIFF
--- a/documents/CMakeLists.txt
+++ b/documents/CMakeLists.txt
@@ -21,12 +21,14 @@ find_package(Doxygen)
 
 if(DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-    add_custom_target(MaterialXDocs ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    add_custom_target(MaterialXDocs ALL ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       COMMENT "Generating HTML documentation: ${DOXYGEN_HTML_OUTPUT_DIR}/index.html")
     add_custom_command(TARGET MaterialXDocs PRE_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy_directory
-                       ${CMAKE_SOURCE_DIR}/resources/Images ${CMAKE_CURRENT_BINARY_DIR})
+                       ${CMAKE_SOURCE_DIR}/documents/Images ${DOXYGEN_OUTPUT_DIR}/Images)
     install(DIRECTORY ${DOXYGEN_HTML_OUTPUT_DIR}
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/documents" MESSAGE_NEVER)
+    install(DIRECTORY "${DOXYGEN_OUTPUT_DIR}/Images"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/documents" MESSAGE_NEVER)
 endif(DOXYGEN_FOUND)

--- a/documents/DeveloperGuide/README.md
+++ b/documents/DeveloperGuide/README.md
@@ -1,5 +1,0 @@
-# Developer Information
-
--   [MainPage.md](MainPage.md) : Main developer information
--   [CodeExamples.md](CodeExamples.md) : Code examples
--   [ShaderGeneration.md](ShaderGeneration.md) : Shader generation documentation.

--- a/documents/DeveloperGuide/ShaderGeneration.md
+++ b/documents/DeveloperGuide/ShaderGeneration.md
@@ -1,11 +1,11 @@
-# Shader Generation
+# Shader Generation {#shadergeneration}
 
 ## 1.1 Scope
 A shader generation framework is implemented as part of MaterialX. This can help applications to transform the agnostic MaterialX data description into executable shader code for a specific renderer. A library module named MaterialXGenShader contains the core shader generation features, and support for specific languages resides in separate libraries, e.g. [MaterialXGenGlsl](/source/MaterialXGenGlsl), [MaterialXGenOsl](/source/MaterialXGenOsl).
 
 Note that this system has no runtime and the output produced is source code, not binary executable code. The source code produced needs to be compiled by a shading language compiler before being executed by the renderer. See Figure 1 for a high level overview of the system.
 
-![Shader generation with multiple shader generators](/documents/Images/shadergen.png)
+![Shader generation with multiple shader generators](../Images/shadergen.png)
 
 **Figure 1**: Shader generation with multiple shader generators.
 

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -5,10 +5,10 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 ### Example Images
 
 **Figure 1:** Standard Surface Shader with procedural and uniform materials
-<p><img src="/documents/Images/MaterialXView_StandardSurface_01.png" width="1024"></p>
+<p><img src="../Images/MaterialXView_StandardSurface_01.png" width="1024"></p>
 
 **Figure 2:** Standard Surface Shader with textured, color-space-managed materials
-<p><img src="/documents/Images/MaterialXView_StandardSurface_02.png" width="640"></p>
+<p><img src="../Images/MaterialXView_StandardSurface_02.png" width="640"></p>
 
 ## Building The MaterialX Viewer
 Select the `MATERIALX_BUILD_VIEWER` option in CMake to build the MaterialX Viewer.  Installation will copy the **MaterialXView** executable to a `/bin` directory within the selected install folder.

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -118,7 +118,8 @@ class ShaderGraph : public ShaderNode
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
     /// @param upstreamElement Element representing  the node to connect from
-    /// @param connectionElement If non-null, specifies the element on on the downstream node to connect to.
+    /// @param connectingElement If non-null, specifies the element on on the downstream node to connect to.
+    /// @param context Context for generation.
     /// @param rootNode Root node for downstream element. Only required for handing ShaderRef elements.
     void createConnectedNodes(const ElementPtr& downstreamElement,
                               const ElementPtr& upstreamElement,

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -102,8 +102,8 @@ vector<MaterialAssignPtr> getGeometryBindings(NodePtr materialNode, const string
 /// Find any material node elements which are renderable (have input shaders)
 /// @param doc Document to examine
 /// @param elements List of renderable elements (returned)
-/// @param includeRefencedGraphs Whether to check for outputs on referenced graphs
-/// @param graphOutputs List of outputs examined. Graph outputs are added if they do
+/// @param includeReferencedGraphs Whether to check for outputs on referenced graphs
+/// @param processedOutputs List of outputs examined. Graph outputs are added if they do
 ///     not already exist
 void findRenderableMaterialNodes(ConstDocumentPtr doc, 
                                  vector<TypedElementPtr>& elements, 
@@ -113,8 +113,8 @@ void findRenderableMaterialNodes(ConstDocumentPtr doc,
 /// Find any shaderrefs elements which are renderable
 /// @param doc Document to examine
 /// @param elements List of renderable elements (returned)
-/// @param includeRefencedGraphs Whether to check for outputs on referenced graphs
-/// @param graphOutputs List of outputs examined. Graph outputs are added if they do
+/// @param includeReferencedGraphs Whether to check for outputs on referenced graphs
+/// @param processedOutputs List of outputs examined. Graph outputs are added if they do
 ///     not already exist
 void findRenderableShaderRefs(ConstDocumentPtr doc,
                               vector<TypedElementPtr>& elements, 


### PR DESCRIPTION
Update #802 

Fixes these issues:
- All images were broken due to incorrect links
- The wrong images folder was being copied
- Docs would not be build on building the `install` target
- Build warnings due to misspelled or missing `@param`s
- Links in docuements/DeveloperGuide/README.md were broken and the whole file was redundant