### PR TITLE
LOOKDEVX-158 : Add support for units in Runtime

### DIFF
--- a/source/MaterialXGenShader/UnitConverter.cpp
+++ b/source/MaterialXGenShader/UnitConverter.cpp
@@ -47,6 +47,33 @@ LinearUnitConverterPtr LinearUnitConverter::create(UnitTypeDefPtr unitTypeDef)
     return std::shared_ptr<LinearUnitConverter>(new LinearUnitConverter(unitTypeDef));
 }
 
+void LinearUnitConverter::write(DocumentPtr doc) const
+{
+    static const string SCALE_ATTRIBUTE = "scale";
+
+    if (!doc->getUnitTypeDef(_unitType))
+    {
+        // Add a unittypedef
+        UnitTypeDefPtr unitTypeDef = doc->addUnitTypeDef(_unitType);
+
+        // Add a unitdef definition
+        string unitdefName = "UD_stdlib_" + _unitType;
+        if (!doc->getUnitDef(unitdefName))
+        {
+            UnitDefPtr unitDef = doc->addUnitDef(unitdefName);
+            unitDef->setUnitType(_unitType);
+
+            // Add in units to the definition
+            for (auto unitScale : _unitScale)
+            {
+                const string& unitName = unitScale.first;
+                UnitPtr unitPtr = unitDef->addUnit(unitName);
+                unitPtr->setAttribute(SCALE_ATTRIBUTE, std::to_string(unitScale.second));
+            }
+        }
+    }
+}
+
 float LinearUnitConverter::conversionRatio(const string& inputUnit, const string& outputUnit) const
 {
     auto it = _unitScale.find(inputUnit);
@@ -187,6 +214,14 @@ int UnitConverterRegistry::getUnitAsInteger(const string& unitName) const
     }
 
     return -1;
+}
+
+void UnitConverterRegistry::write(DocumentPtr doc) const
+{
+    for (auto it : _unitConverters)
+    {
+        it.second->write(doc);
+    }
 }
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/UnitConverter.cpp
+++ b/source/MaterialXGenShader/UnitConverter.cpp
@@ -54,7 +54,7 @@ void LinearUnitConverter::write(DocumentPtr doc) const
     if (!doc->getUnitTypeDef(_unitType))
     {
         // Add a unittypedef
-        UnitTypeDefPtr unitTypeDef = doc->addUnitTypeDef(_unitType);
+        doc->addUnitTypeDef(_unitType);
 
         // Add a unitdef definition
         string unitdefName = "UD_stdlib_" + _unitType;

--- a/source/MaterialXGenShader/UnitConverter.cpp
+++ b/source/MaterialXGenShader/UnitConverter.cpp
@@ -54,7 +54,10 @@ void LinearUnitConverter::write(DocumentPtr doc) const
     if (!doc->getUnitTypeDef(_unitType))
     {
         // Add a unittypedef
-        doc->addUnitTypeDef(_unitType);
+        if (!doc->getUnitTypeDef(_unitType))
+        {
+            doc->addUnitTypeDef(_unitType);
+        }
 
         // Add a unitdef definition
         string unitdefName = "UD_stdlib_" + _unitType;

--- a/source/MaterialXGenShader/UnitConverter.h
+++ b/source/MaterialXGenShader/UnitConverter.h
@@ -98,7 +98,7 @@ class LinearUnitConverter : public UnitConverter
         return _unitType;
     }
 
-    /// Create a unit definitions in a document based on the converter
+    /// Create unit definitions in a document based on the converter
     void write(DocumentPtr doc) const override;
 
     /// @name Conversion

--- a/source/MaterialXGenShader/UnitConverter.h
+++ b/source/MaterialXGenShader/UnitConverter.h
@@ -78,7 +78,7 @@ class UnitConverter
     /// @param outputUnit Unit for output value
     virtual Vector4 convert(const Vector4& input, const string& inputUnit, const string& outputUnit) const = 0;
 
-    /// Create a unit definitions in a document based on the converter
+    /// Create unit definitions in a document based on the converter
     virtual void write(DocumentPtr doc) const = 0;
 };
 
@@ -195,7 +195,7 @@ class UnitConverterRegistry
     /// Returns -1 value if not found
     int getUnitAsInteger(const string& unitName) const;
 
-    /// Create a unit definitions in a document based on registered converters
+    /// Create unit definitions in a document based on registered converters
     void write(DocumentPtr doc) const;
 
   private:

--- a/source/MaterialXGenShader/UnitConverter.h
+++ b/source/MaterialXGenShader/UnitConverter.h
@@ -13,6 +13,7 @@
 
 #include <MaterialXCore/Definition.h>
 #include <MaterialXCore/Types.h>
+#include <MaterialXCore/Document.h>
 
 namespace MaterialX
 {
@@ -76,6 +77,9 @@ class UnitConverter
     /// @param inputUnit Unit of input value
     /// @param outputUnit Unit for output value
     virtual Vector4 convert(const Vector4& input, const string& inputUnit, const string& outputUnit) const = 0;
+
+    /// Create a unit definitions in a document based on the converter
+    virtual void write(DocumentPtr doc) const = 0;
 };
 
 /// @class LinearUnitConverter
@@ -93,6 +97,9 @@ class LinearUnitConverter : public UnitConverter
     {
         return _unitType;
     }
+
+    /// Create a unit definitions in a document based on the converter
+    void write(DocumentPtr doc) const override;
 
     /// @name Conversion
     /// @{
@@ -156,6 +163,9 @@ class LinearUnitConverter : public UnitConverter
     string _unitType;
 };
 
+/// Map of unit converters
+using UnitConverterPtrMap = std::unordered_map<string, UnitConverterPtr>;
+
 /// @class UnitConverterRegistry
 /// A registry for unit converters.
 class UnitConverterRegistry
@@ -185,6 +195,9 @@ class UnitConverterRegistry
     /// Returns -1 value if not found
     int getUnitAsInteger(const string& unitName) const;
 
+    /// Create a unit definitions in a document based on registered converters
+    void write(DocumentPtr doc) const;
+
   private:
     UnitConverterRegistry(const UnitConverterRegistry&) = delete;
     UnitConverterRegistry() { }
@@ -192,7 +205,7 @@ class UnitConverterRegistry
     UnitConverterRegistry& operator=(const UnitConverterRegistry&) = delete;
 
   private:
-    std::unordered_map<string, UnitConverterPtr> _unitConverters;
+     UnitConverterPtrMap _unitConverters;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRuntime/Private/PvtAttribute.cpp
+++ b/source/MaterialXRuntime/Private/PvtAttribute.cpp
@@ -12,6 +12,7 @@ namespace MaterialX
 const RtToken PvtAttribute::DEFAULT_OUTPUT_NAME("out");
 const RtToken PvtAttribute::COLOR_SPACE("colorspace");
 const RtToken PvtAttribute::UNIT("unit");
+const RtToken PvtAttribute::UNIT_TYPE("unittype");
 
 RT_DEFINE_RUNTIME_OBJECT(PvtAttribute, RtObjType::ATTRIBUTE, "PvtAttribute")
 

--- a/source/MaterialXRuntime/Private/PvtAttribute.h
+++ b/source/MaterialXRuntime/Private/PvtAttribute.h
@@ -104,9 +104,26 @@ public:
         md->getValue().asToken() = unit;
     }
 
+    const RtToken& getUnitType() const
+    {
+        const RtTypedValue* md = getMetadata(PvtAttribute::UNIT_TYPE);
+        return md ? md->getValue().asToken() : EMPTY_TOKEN;
+    }
+
+    void setUnitType(const RtToken& unit)
+    {
+        RtTypedValue* md = getMetadata(PvtAttribute::UNIT_TYPE);
+        if (!md)
+        {
+            md = addMetadata(PvtAttribute::UNIT_TYPE, RtType::TOKEN);
+        }
+        md->getValue().asToken() = unit;
+    }
+
     static const RtToken DEFAULT_OUTPUT_NAME;
     static const RtToken COLOR_SPACE;
     static const RtToken UNIT;
+    static const RtToken UNIT_TYPE;
     static const RtToken ATTRIBUTE;
 
 protected:

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -472,7 +472,7 @@ RtTokenVec RtApi::getStageNames() const
     return _cast(_ptr)->getStageNames();
 }
 
-UnitConverterPtrMap& RtApi::getUnitDefinitions()
+UnitConverterRegistryPtr RtApi::getUnitDefinitions()
 {
     return _cast(_ptr)->getUnitDefinitions();
 }

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -262,7 +262,7 @@ public:
         return names;
     }
 
-    RtUnitTypeDefVec& getUnitDefinitions()
+    UnitConverterRegistryPtr& getUnitDefinitions()
     {
         return _unitDefinitions;
     }
@@ -280,7 +280,7 @@ public:
         _libraries.clear();
         _libraryRoot = RtStage::createNew(libRootName);
 
-        _unitDefinitions.clear();
+        _unitDefinitions = UnitConverterRegistry::create();
     }
 
     FileSearchPath _searchPaths;
@@ -288,7 +288,7 @@ public:
     FileSearchPath _textureSearchPaths;
     RtStagePtr _libraryRoot;
     RtTokenMap<RtStagePtr> _libraries;
-    RtUnitTypeDefVec  _unitDefinitions;
+    UnitConverterRegistryPtr  _unitDefinitions;
 
     PvtDataHandle _masterPrimRoot;
     RtTokenMap<RtPrimCreateFunc> _createFunctions;
@@ -472,7 +472,7 @@ RtTokenVec RtApi::getStageNames() const
     return _cast(_ptr)->getStageNames();
 }
 
-RtUnitTypeDefVec& RtApi::getUnitDefinitions()
+UnitConverterPtrMap& RtApi::getUnitDefinitions()
 {
     return _cast(_ptr)->getUnitDefinitions();
 }

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -262,6 +262,11 @@ public:
         return names;
     }
 
+    RtUnitTypeDefVec& getUnitDefinitions()
+    {
+        return _unitDefinitions;
+    }
+
     void reset()
     {
         static const RtTypeInfo masterPrimRootType("api_masterprimroot");
@@ -274,6 +279,8 @@ public:
         _libraryRoot.reset();
         _libraries.clear();
         _libraryRoot = RtStage::createNew(libRootName);
+
+        _unitDefinitions.clear();
     }
 
     FileSearchPath _searchPaths;
@@ -281,6 +288,7 @@ public:
     FileSearchPath _textureSearchPaths;
     RtStagePtr _libraryRoot;
     RtTokenMap<RtStagePtr> _libraries;
+    RtUnitTypeDefVec  _unitDefinitions;
 
     PvtDataHandle _masterPrimRoot;
     RtTokenMap<RtPrimCreateFunc> _createFunctions;
@@ -462,6 +470,11 @@ RtToken RtApi::renameStage(const RtToken& name, const RtToken& newName)
 RtTokenVec RtApi::getStageNames() const
 {
     return _cast(_ptr)->getStageNames();
+}
+
+RtUnitTypeDefVec& RtApi::getUnitDefinitions()
+{
+    return _cast(_ptr)->getUnitDefinitions();
 }
 
 RtApi& RtApi::get()

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -138,7 +138,7 @@ public:
     RtTokenVec getStageNames() const;
 
     /// Return a registry of unit definitions
-    UnitConverterRegistryPtr RtApi::getUnitDefinitions();
+    UnitConverterRegistryPtr getUnitDefinitions();
 
     /// Get the singleton API instance.
     static RtApi& get();

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -15,6 +15,8 @@
 
 #include <MaterialXFormat/File.h>
 
+#include <MaterialXGenShader/UnitConverter.h>
+
 namespace MaterialX
 {
 
@@ -135,8 +137,8 @@ public:
     /// Return a list of all stages created.
     RtTokenVec getStageNames() const;
 
-    /// Return a list of unit definitions
-    RtUnitTypeDefVec& RtApi::getUnitDefinitions();
+    /// Return a registry of unit definitions
+    UnitConverterRegistryPtr RtApi::getUnitDefinitions();
 
     /// Get the singleton API instance.
     static RtApi& get();

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -11,6 +11,7 @@
 
 #include <MaterialXRuntime/Library.h>
 #include <MaterialXRuntime/RtPrim.h>
+#include <MaterialXRuntime/RtTypeDef.h>
 
 #include <MaterialXFormat/File.h>
 
@@ -45,7 +46,7 @@ public:
     RtPrimCreateFunc getCreateFunction(const RtToken& typeName);
 
     /// Register a master prim to be used for creating instances from.
-    /// A typical usecase is for registering a nodedef prim to be used for
+    /// A typical use case is for registering a nodedef prim to be used for
     /// creating node instances.
     void registerMasterPrim(const RtPrim& prim);
 
@@ -133,6 +134,9 @@ public:
 
     /// Return a list of all stages created.
     RtTokenVec getStageNames() const;
+
+    /// Return a list of unit definitions
+    RtUnitTypeDefVec& RtApi::getUnitDefinitions();
 
     /// Get the singleton API instance.
     static RtApi& get();

--- a/source/MaterialXRuntime/RtAttribute.cpp
+++ b/source/MaterialXRuntime/RtAttribute.cpp
@@ -68,6 +68,16 @@ void RtAttribute::setUnit(const RtToken& unit)
     return hnd()->asA<PvtAttribute>()->setUnit(unit);
 }
 
+const RtToken& RtAttribute::getUnitType() const
+{
+    return hnd()->asA<PvtAttribute>()->getUnitType();
+}
+
+void RtAttribute::setUnitType(const RtToken& unit)
+{
+    return hnd()->asA<PvtAttribute>()->setUnitType(unit);
+}
+
 
 RT_DEFINE_RUNTIME_OBJECT(RtInput, RtObjType::INPUT, "RtInput")
 

--- a/source/MaterialXRuntime/RtAttribute.h
+++ b/source/MaterialXRuntime/RtAttribute.h
@@ -74,6 +74,12 @@ public:
 
     /// Set the default unit for this attribute.
     void setUnit(const RtToken& unit);
+
+    /// Return the default unit type for this attribute.
+    const RtToken& getUnitType() const;
+
+    /// Set the default unit type for this attribute.
+    void setUnitType(const RtToken& unit);
 };
 
 

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -30,7 +30,7 @@ namespace
 {
     // Lists of known metadata which are handled explicitly by import/export.
     static const RtTokenSet nodedefMetadata     = { RtToken("name"), RtToken("type"), RtToken("node") };
-    static const RtTokenSet attrMetadata        = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("colorspace"), RtToken("unit") };
+    static const RtTokenSet attrMetadata        = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("colorspace"), RtToken("unit"), RtToken("unittype") };
     static const RtTokenSet nodeMetadata        = { RtToken("name"), RtToken("type"), RtToken("node") };
     static const RtTokenSet nodegraphMetadata   = { RtToken("name") };
     static const RtTokenSet genericMetadata     = { RtToken("name"), RtToken("kind") };
@@ -136,6 +136,11 @@ namespace
             if (!unitStr.empty())
             {
                 attr.setUnit(RtToken(unitStr));
+            }
+            const string& unitTypeStr = elem->getUnitType();
+            if (!unitTypeStr.empty())
+            {
+                attr.setUnitType(RtToken(unitTypeStr));
             }
 
             readMetadata(elem, PvtObject::ptr<PvtObject>(attr), attrMetadata);
@@ -274,6 +279,21 @@ namespace
             {
                 const RtToken portType(elem->getType());
                 RtValue::fromString(portType, valueStr, input->getValue());
+            }
+            const string& colorSpace = elem->getColorSpace();
+            if (!colorSpace.empty())
+            {
+                input->setColorSpace(RtToken(elem->getColorSpace()));
+            }
+            const string& unitStr = elem->getUnit();
+            if (!unitStr.empty())
+            {
+                input->setUnit(RtToken(unitStr));
+            }
+            const string& unitTypeStr = elem->getUnitType();
+            if (!unitTypeStr.empty())
+            {
+                input->setUnitType(RtToken(unitTypeStr));
             }
         }
 
@@ -683,6 +703,10 @@ namespace
             {
                 destPort->setUnit(attr->getUnit().str());
             }
+            if (attr->getUnitType())
+            {
+                destPort->setUnitType(attr->getUnitType().str());
+            }
 
             writeMetadata(attr, destPort, attrMetadata);
         }
@@ -791,6 +815,11 @@ namespace
                     if (unit != EMPTY_TOKEN)
                     {
                         valueElem->setUnit(unit.str());
+                    }
+                    const RtToken unitType = input.getUnitType();
+                    if (unitType != EMPTY_TOKEN)
+                    {
+                        valueElem->setUnitType(unitType.str());
                     }
                 }
                 else if(numOutputs > 1)

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1166,9 +1166,12 @@ void RtFileIo::read(const FilePath& documentPath, const FileSearchPath& searchPa
             xmlReadOptions.desiredMinorVersion = readOptions->desiredMinorVersion;
         }
         readFromXmlFile(document, documentPath, searchPaths, &xmlReadOptions);
+
         string errorMessage;
-        writeUnitDefinitions(document);
-        if (document->validate(&errorMessage))
+        DocumentPtr validationDocument = createDocument();
+        writeUnitDefinitions(validationDocument);
+        validationDocument->copyContentFrom(document);
+        if (validationDocument->validate(&errorMessage))
         {
             PvtStage* stage = PvtStage::ptr(_stage);
             readDocument(document, stage, readOptions);
@@ -1197,19 +1200,22 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* readOptions)
             xmlReadOptions.desiredMajorVersion = readOptions->desiredMajorVersion;
             xmlReadOptions.desiredMajorVersion = readOptions->desiredMinorVersion;
         }
-        string errorMessage;
-        writeUnitDefinitions(document);
-        if (document->validate(&errorMessage))
+        readFromXmlStream(document, stream, &xmlReadOptions);
+
+        string errorMessage; 
+        DocumentPtr validationDocument = createDocument();
+        writeUnitDefinitions(validationDocument);
+        validationDocument->copyContentFrom(document);
+        if (validationDocument->validate(&errorMessage))
         {
-            readFromXmlStream(document, stream, &xmlReadOptions);
+            PvtStage* stage = PvtStage::ptr(_stage);
+            readDocument(document, stage, readOptions);
         }
         else
         {
             throw ExceptionRuntimeError("Failed validation: " + errorMessage);
         }
 
-        PvtStage* stage = PvtStage::ptr(_stage);
-        readDocument(document, stage, readOptions);
     }
     catch (Exception& e)
     {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -127,12 +127,16 @@ namespace
             {
                 RtValue::fromString(attrType, valueStr, attr.getValue());
             }
-            if (elem->hasColorSpace())
+            const string& colorSpace = elem->getColorSpace();
+            if (!colorSpace.empty())
             {
                 attr.setColorSpace(RtToken(elem->getColorSpace()));
             }
-            // TODO: fix when units are implemented in core
-            // input->setUnit(RtToken(elem->getUnit()));
+            const string& unitStr = elem->getUnit();
+            if (!unitStr.empty())
+            {
+                attr.setUnit(unitStr);
+            }
 
             readMetadata(elem, PvtObject::ptr<PvtObject>(attr), attrMetadata);
         }
@@ -675,11 +679,10 @@ namespace
             {
                 destPort->setColorSpace(attr->getColorSpace().str());
             }
-            // TODO: fix when units are implemented in core.
-            //if (attr->getUnit())
-            //{
-            //    destInput->setUnit(input->getUnit().str());
-            //}
+            if (attr->getUnit())
+            {
+                destPort->setUnit(attr->getUnit().str());
+            }
 
             writeMetadata(attr, destPort, attrMetadata);
         }
@@ -784,11 +787,11 @@ namespace
                     {
                         valueElem->setColorSpace(colorspace.str());
                     }
-                    //if (input.getUnit())
-                    //{
-                    //    TODO: fix when units are implemented in core.
-                    //    valueElem->setUnit(input->getUnit().str());
-                    //}
+                    const RtToken unit = input.getUnit();
+                    if (unit != EMPTY_TOKEN)
+                    {
+                        valueElem->setUnit(unit.str());
+                    }
                 }
                 else if(numOutputs > 1)
                 {

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -48,6 +48,11 @@ const RtToken& RtStage::getName() const
     return _cast(_ptr)->getName();
 }
 
+const RtTokenVec& RtStage::getSourceUri() const
+{
+    return _cast(_ptr)->getSourceUri();
+}
+
 RtPrim RtStage::createPrim(const RtToken& typeName)
 {
     return createPrim(RtPath("/"), EMPTY_TOKEN, typeName);

--- a/source/MaterialXRuntime/RtStage.h
+++ b/source/MaterialXRuntime/RtStage.h
@@ -31,6 +31,9 @@ public:
     /// Return the name of the stage.
     const RtToken& getName() const;
 
+    /// Return a list of source Uri loaded into a stage
+    const RtTokenVec& getSourceUri() const;
+
     /// Create a new prim at the root of the stage.
     RtPrim createPrim(const RtToken& typeName);
 

--- a/source/MaterialXRuntime/RtTypeDef.h
+++ b/source/MaterialXRuntime/RtTypeDef.h
@@ -206,34 +206,6 @@ private:
     void* _ptr;
 };
 
-/// @class RtUnitTypeDef
-/// Unit type definition
-class RtUnitTypeDef
-{
-  public:
-    RtUnitTypeDef(const string unitType)
-        : _unitType(unitType)
-    {
-    }
-
-    const string& getUnitType()
-    {
-        return _unitType;
-    }
-
-    StringVec& getUnitNames()
-    {
-        return _unitNames;
-    }
-
-  private:
-      string _unitType;
-      StringVec _unitNames;
-};
-
-/// Class representing a vector of tokens
-using RtUnitTypeDefVec = std::vector<RtUnitTypeDef>;
-
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXRuntime/RtTypeDef.h
+++ b/source/MaterialXRuntime/RtTypeDef.h
@@ -206,6 +206,34 @@ private:
     void* _ptr;
 };
 
+/// @class RtUnitTypeDef
+/// Unit type definition
+class RtUnitTypeDef
+{
+  public:
+    RtUnitTypeDef(const string unitType)
+        : _unitType(unitType)
+    {
+    }
+
+    const string& getUnitType()
+    {
+        return _unitType;
+    }
+
+    StringVec& getUnitNames()
+    {
+        return _unitNames;
+    }
+
+  private:
+      string _unitType;
+      StringVec _unitNames;
+};
+
+/// Class representing a vector of tokens
+using RtUnitTypeDefVec = std::vector<RtUnitTypeDef>;
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXTest/Runtime.cpp
+++ b/source/MaterialXTest/Runtime.cpp
@@ -1675,4 +1675,37 @@ TEST_CASE("Runtime: libraries", "[runtime]")
     REQUIRE(api->getImplementationSearchPath().find("stdlib_genglsl_unit_impl.mtlx").exists());    
 }
 
+TEST_CASE("Runtime: units", "[runtime]")
+{
+    mx::RtScopedApiHandle api;
+
+    // Load in all libraries required for materials
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    api->setSearchPath(searchPath);
+    api->loadLibrary(STDLIB);
+    api->loadLibrary(PBRLIB);
+    api->loadLibrary(BXDFLIB);
+
+    // Read in test document with units
+    mx::FileSearchPath testSearchPath(mx::FilePath::getCurrentPath() /
+        "resources" /
+        "Materials" /
+        "TestSuite" /
+        "stdlib" /
+        "units");
+    mx::RtStagePtr stage = api->createStage(mx::RtToken("stage"));
+    mx::RtFileIo fileIo(stage);
+    mx::StringVec tests{ "distance_units.mtlx",
+                         "image_unit.mtlx",
+                         "standard_surface_unit.mtlx",
+                         "texture_units.mtlx",
+                         "tiledimage_unit.mtlx" };
+    mx::RtReadOptions options;
+    options.desiredMinorVersion = 38;
+    for (auto test : tests)
+    {
+        fileIo.read(test, testSearchPath, &options);
+    }
+}
+
 #endif // MATERIALX_BUILD_RUNTIME


### PR DESCRIPTION
* Keep track of set of unit information at RtApi level. 
* Populate UnitConverterRegistry (which is Document independent) during library load. This is cumulative until a reset is performed.
* Add in "validation document" which has unit information added to it just for validation (not save)
based on the UnitConverterRegistry
* Add in unit tests.
 