### PR TITLE
Add size control to utility rendering

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -44,7 +44,7 @@
       <parameter name="renderImages" type="boolean" value="true" />
       
       <!-- Rendered image size if render validation test enabled -->
-      <parameter name="renderSize" type="vector2" value="480, 512" />
+      <parameter name="renderSize" type="vector2" value="512, 512" />
 
       <!-- Perform saving of image. Can only be disabled for GLSL tests -->
       <parameter name="saveImages" type="boolean" value="true" />

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -42,6 +42,9 @@
 
       <!-- Perform rendering validation test -->
       <parameter name="renderImages" type="boolean" value="true" />
+      
+      <!-- Rendered image size if render validation test enabled -->
+      <parameter name="renderSize" type="vector2" value="480, 512" />
 
       <!-- Perform saving of image. Can only be disabled for GLSL tests -->
       <parameter name="saveImages" type="boolean" value="true" />

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -33,9 +33,6 @@ class ShaderRenderer
   public:
     virtual ~ShaderRenderer() { }
 
-    /// Set the size of the output buffer
-    virtual void setSize(unsigned int /*width*/, unsigned int /*height*/) = 0;
-
     /// @name Setup
     /// @{
 
@@ -105,6 +102,9 @@ class ShaderRenderer
 
     /// Validate inputs for the program 
     virtual void validateInputs() = 0;
+
+    /// Set the size of the rendered image
+    virtual void setSize(unsigned int /*width*/, unsigned int /*height*/) = 0;
 
     /// Render the current program to produce an image
     virtual void render() = 0;

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -33,6 +33,9 @@ class ShaderRenderer
   public:
     virtual ~ShaderRenderer() { }
 
+    /// Set the size of the output buffer
+    virtual void setSize(unsigned int /*width*/, unsigned int /*height*/) = 0;
+
     /// @name Setup
     /// @{
 
@@ -121,9 +124,20 @@ class ShaderRenderer
 
   protected:
     // Protected constructor
-    ShaderRenderer() { }
+    ShaderRenderer() :
+        _width(0),
+        _height(0)
+    { }
+
+    ShaderRenderer(unsigned int width, unsigned int height) :
+        _width(width),
+        _height(height)
+    { }
 
   protected:
+    unsigned int _width;
+    unsigned int _height;
+
     ImageHandlerPtr _imageHandler;
     GeometryHandlerPtr _geometryHandler;
     LightHandlerPtr _lightHandler;

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -129,6 +129,10 @@ GLFramebuffer::~GLFramebuffer()
 
 void GLFramebuffer::resize(unsigned int width, unsigned int height)
 {
+    if (width * height <= 0)
+    {
+        return;
+    }
     if (width != _width || _height != height)
     {
         unbind();
@@ -137,13 +141,16 @@ void GLFramebuffer::resize(unsigned int width, unsigned int height)
         GLTextureHandler::mapTextureFormatToGL(_baseType, _channelCount, true, glType, glFormat, glInternalFormat);
 
         glBindTexture(GL_TEXTURE_2D, _colorTexture);
-        glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, _width, _height, 0, glFormat, glType, nullptr);
+        glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, width, height, 0, glFormat, glType, nullptr);
 
         glBindTexture(GL_TEXTURE_2D, _depthTexture);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, _width, _height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
 
         glBindTexture(GL_TEXTURE_2D, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
         glDrawBuffer(GL_NONE);
+
+        _width = width;
+        _height = height;
     }
 }
 

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -127,6 +127,27 @@ GLFramebuffer::~GLFramebuffer()
     }
 }
 
+void GLFramebuffer::resize(unsigned int width, unsigned int height)
+{
+    if (width != _width || _height != height)
+    {
+        unbind();
+
+        int glType, glFormat, glInternalFormat;
+        GLTextureHandler::mapTextureFormatToGL(_baseType, _channelCount, true, glType, glFormat, glInternalFormat);
+
+        glBindTexture(GL_TEXTURE_2D, _colorTexture);
+        glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, _width, _height, 0, glFormat, glType, nullptr);
+
+        glBindTexture(GL_TEXTURE_2D, _depthTexture);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, _width, _height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
+
+        glBindTexture(GL_TEXTURE_2D, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
+        glDrawBuffer(GL_NONE);
+    }
+}
+
+
 void GLFramebuffer::bind()
 {
     if (!_frameBuffer)

--- a/source/MaterialXRenderGlsl/GLFramebuffer.h
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.h
@@ -30,6 +30,9 @@ class GLFramebuffer
     /// Destructor
     virtual ~GLFramebuffer();
 
+    /// Resize the framebuffer
+    void resize(unsigned int width, unsigned int height);
+
     /// Set the encode sRGB flag, which controls whether values written
     /// to the framebuffer are encoded to the sRGB color space.
     void setEncodeSrgb(bool encode)

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -207,13 +207,15 @@ void GlslRenderer::updateViewInformation(const Vector3& eye,
                                            float farDist,
                                            float objectScale)
 {
+    float aspectRatio = float(_width) / float(_height);
     float fH = std::tan(viewAngle / 360.0f * PI) * nearDist;
-    float fW = fH * 1.0f;
+    float fW = fH * aspectRatio;
 
+    float geometryRatio = _height < _width ?  aspectRatio : (1.0f / aspectRatio);
     Vector3 boxMin = _geometryHandler->getMinimumBounds();
     Vector3 boxMax = _geometryHandler->getMaximumBounds();
     Vector3 sphereCenter = (boxMax + boxMin) / 2.0;
-    float sphereRadius = (sphereCenter - boxMin).getMagnitude();
+    float sphereRadius = (sphereCenter - boxMin).getMagnitude() * geometryRatio;
     float meshFit = 2.0f / sphereRadius;
     Vector3 modelTranslation = sphereCenter * -1.0f;
 

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -25,13 +25,13 @@ const float FAR_PLANE_PERSP = 100.0f;
 // GlslRenderer methods
 //
 
-GlslRendererPtr GlslRenderer::create(unsigned int res)
+GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height)
 {
-    return GlslRendererPtr(new GlslRenderer(res));
+    return GlslRendererPtr(new GlslRenderer(width, height));
 }
 
-GlslRenderer::GlslRenderer(unsigned int res) :
-    _res(res),
+GlslRenderer::GlslRenderer(unsigned int width, unsigned int height) :
+    ShaderRenderer(width, height),
     _initialized(false)
 {
     _program = GlslProgram::create();
@@ -58,6 +58,23 @@ GlslRenderer::~GlslRenderer()
     _window = nullptr;
 }
 
+void GlslRenderer::setSize(unsigned int width, unsigned int height)
+{
+    if (_context->makeCurrent())
+    {
+        if (_frameBuffer)
+        {
+            _frameBuffer->resize(width, height);
+        }
+        else
+        {
+            _frameBuffer = GLFramebuffer::create(width, height, 4, Image::BaseType::UINT8);
+        }
+        _width = width;
+        _height = height;
+    }
+}
+
 void GlslRenderer::initialize()
 {
     StringVec errors;
@@ -69,7 +86,7 @@ void GlslRenderer::initialize()
         _window = SimpleWindow::create();
 
         const char* windowName = "Renderer Window";
-        if (!_window->initialize(const_cast<char *>(windowName), _res, _res, nullptr))
+        if (!_window->initialize(const_cast<char *>(windowName), _width, _height, nullptr))
         {
             errors.push_back("Failed to create window for testing.");
             throw ExceptionShaderRenderError(errorType, errors);
@@ -97,7 +114,7 @@ void GlslRenderer::initialize()
             glClearColor(0.4f, 0.4f, 0.4f, 1.0f);
             glClearStencil(0);
 
-            _frameBuffer = GLFramebuffer::create(_res, _res, 4, Image::BaseType::UINT8);
+            _frameBuffer = GLFramebuffer::create(_width, _height, 4, Image::BaseType::UINT8);
 
             _initialized = true;
         }

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -46,9 +46,6 @@ class GlslRenderer : public ShaderRenderer
     /// Destructor
     virtual ~GlslRenderer();
 
-    /// Set the size of the output buffer
-    void setSize(unsigned int width, unsigned int height) override;
-
     /// @name Setup
     /// @{
 
@@ -72,6 +69,9 @@ class GlslRenderer : public ShaderRenderer
 
     /// Validate inputs for the program
     void validateInputs() override;
+
+    /// Set the size of the rendered image
+    void setSize(unsigned int width, unsigned int height) override;
 
     /// Render the current program to an offscreen buffer.
     void render() override;

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -41,10 +41,13 @@ class GlslRenderer : public ShaderRenderer
 {
   public:
     /// Create a GLSL renderer instance
-    static GlslRendererPtr create(unsigned int res = 512);
+    static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512);
 
     /// Destructor
     virtual ~GlslRenderer();
+
+    /// Set the size of the output buffer
+    void setSize(unsigned int width, unsigned int height) override;
 
     /// @name Setup
     /// @{
@@ -105,7 +108,7 @@ class GlslRenderer : public ShaderRenderer
     /// @}
 
   protected:
-    GlslRenderer(unsigned int res);
+    GlslRenderer(unsigned int width, unsigned int height);
 
     void updateViewInformation(const Vector3& eye,
                                const Vector3& center,
@@ -122,7 +125,6 @@ class GlslRenderer : public ShaderRenderer
     GlslProgramPtr _program;
 
     GLFrameBufferPtr _frameBuffer;
-    unsigned int _res;
 
     bool _initialized;
 

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -10,8 +10,8 @@
 namespace MaterialX
 {
 
-TextureBaker::TextureBaker(unsigned int res) :
-    GlslRenderer(res),
+TextureBaker::TextureBaker(unsigned int width, unsigned int height) :
+    GlslRenderer(width, height),
     _generator(GlslShaderGenerator::create()),
     _extension(ImageLoader::PNG_EXTENSION)
 {

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -24,9 +24,9 @@ using TextureBakerPtr = shared_ptr<class TextureBaker>;
 class TextureBaker : public GlslRenderer
 {
   public:
-    static TextureBakerPtr create(unsigned int res = 1024)
+    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024)
     {
-        return TextureBakerPtr(new TextureBaker(res));
+        return TextureBakerPtr(new TextureBaker(width, height));
     }
 
     /// Set the file extension for baked textures.
@@ -57,7 +57,7 @@ class TextureBaker : public GlslRenderer
     void writeBakedDocument(NodePtr shader, const FilePath& filename);
 
   protected:
-    TextureBaker(unsigned int res);
+    TextureBaker(unsigned int width, unsigned int height);
 
     // Generate a texture filename for the given graph output.
     FilePath generateTextureFilename(OutputPtr output);

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -23,18 +23,28 @@ string OslRenderer::OSL_CLOSURE_COLOR_STRING("closure color");
 // OslRenderer methods
 //
 
-OslRendererPtr OslRenderer::create()
+OslRendererPtr OslRenderer::create(unsigned int width, unsigned int height)
 {
-    return std::shared_ptr<OslRenderer>(new OslRenderer());
+    return std::shared_ptr<OslRenderer>(new OslRenderer(width, height));
 }
 
-OslRenderer::OslRenderer() :
+OslRenderer::OslRenderer(unsigned int width, unsigned int height) :
+    ShaderRenderer(width, height),
     _useTestRender(true) // By default use testrender
 {
 }
 
 OslRenderer::~OslRenderer()
 {
+}
+
+void OslRenderer::setSize(unsigned int width, unsigned int height)
+{
+    if (_width != width || _height != height)
+    {
+        _width = width;
+        _height = height;
+    }
 }
 
 void OslRenderer::initialize()
@@ -162,7 +172,7 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
     string command(_oslTestRenderExecutable);
     command += " " + sceneFileName;
     command += " " + outputFileName;
-    command += " -r 512 512 --path " + osoPaths;
+    command += " -r " + std::to_string(_width) + " " + std::to_string(_height) + " --path " + osoPaths;
     if (isColorClosure)
     {
         command += " -aa 4 "; // Images are very noisy without anti-aliasing

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -48,9 +48,6 @@ class OslRenderer : public ShaderRenderer
     /// The exception will contain a list of initialization errors.
     void initialize() override;
 
-    /// Set the size of the output buffer
-    void setSize(unsigned int width, unsigned int height) override;
-
     /// @}
     /// @name Rendering
     /// @{
@@ -75,6 +72,9 @@ class OslRenderer : public ShaderRenderer
     /// Validate inputs for the compiled OSL program.
     /// Note: Currently no validation has been implemented.
     void validateInputs() override;
+
+    /// Set the size for rendered image
+    void setSize(unsigned int width, unsigned int height) override;
 
     /// Render OSL program to disk.
     /// This is done by using either "testshade" or "testrender".

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -32,7 +32,7 @@ class OslRenderer : public ShaderRenderer
 {
   public:
     /// Create an OSL renderer instance
-    static OslRendererPtr create();
+    static OslRendererPtr create(unsigned int width = 512, unsigned int height = 512);
 
     /// Destructor
     virtual ~OslRenderer();
@@ -47,6 +47,9 @@ class OslRenderer : public ShaderRenderer
     /// An exception is thrown on failure.
     /// The exception will contain a list of initialization errors.
     void initialize() override;
+
+    /// Set the size of the output buffer
+    void setSize(unsigned int width, unsigned int height) override;
 
     /// @}
     /// @name Rendering
@@ -223,7 +226,7 @@ class OslRenderer : public ShaderRenderer
     void renderOSL(const FilePath& dirPath, const string& shaderName, const string& outputName);
 
     /// Constructor
-    OslRenderer();
+    OslRenderer(unsigned int width, unsigned int height);
 
   private:
     /// Path to "oslc" executable`

--- a/source/MaterialXTest/GenShaderUtil.cpp
+++ b/source/MaterialXTest/GenShaderUtil.cpp
@@ -839,6 +839,7 @@ void TestSuiteOptions::print(std::ostream& output) const
     output << "\tValidate Element To Render: " << validateElementToRender << std::endl;
     output << "\tCompile code: " << compileCode << std::endl;
     output << "\tRender Images: " << renderImages << std::endl;
+    output << "\tRender Size: " << renderSize[0] << "," << renderSize[1] << std::endl;
     output << "\tSave Images: " << saveImages << std::endl;
     output << "\tDump uniforms and Attributes  " << dumpUniformsAndAttributes << std::endl;
     output << "\tNon-Shaded Geometry: " << unShadedGeometry.asString() << std::endl;
@@ -866,6 +867,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     const std::string VALIDATE_ELEMENT_TO_RENDER_STRING("validateElementToRender");
     const std::string COMPILE_CODE_STRING("compileCode");
     const std::string RENDER_IMAGES_STRING("renderImages");
+    const std::string RENDER_SIZE_STRING("renderSize");
     const std::string SAVE_IMAGES_STRING("saveImages");
     const std::string DUMP_UNIFORMS_AND_ATTRIBUTES_STRING("dumpUniformsAndAttributes");
     const std::string CHECK_IMPL_COUNT_STRING("checkImplCount");
@@ -935,6 +937,10 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     else if (name == RENDER_IMAGES_STRING)
                     {
                         renderImages = val->asA<bool>();
+                    }
+                    else if (name == RENDER_SIZE_STRING)
+                    {
+                        renderSize = val->asA<mx::Vector2>();
                     }
                     else if (name == SAVE_IMAGES_STRING)
                     {

--- a/source/MaterialXTest/GenShaderUtil.h
+++ b/source/MaterialXTest/GenShaderUtil.h
@@ -96,6 +96,9 @@ class TestSuiteOptions
     // Perform rendering validation test
     bool renderImages = true;
 
+    // Render size
+    mx::Vector2 renderSize = { 512, 512 };
+
     // Perform saving of image.
     bool saveImages = true;
 

--- a/source/MaterialXTest/RenderGLSL.cpp
+++ b/source/MaterialXTest/RenderGLSL.cpp
@@ -478,6 +478,7 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                     {
                         RenderUtil::AdditiveScopedTimer renderTimer(profileTimes.languageTimes.renderTime, "GLSL render time");
                         _renderer->getImageHandler()->setSearchPath(imageSearchPath);
+                        _renderer->setSize(static_cast<unsigned int>(testOptions.renderSize[0]), static_cast<unsigned int>(testOptions.renderSize[1]));
                         _renderer->render();
                     }
 

--- a/source/MaterialXTest/RenderOSL.cpp
+++ b/source/MaterialXTest/RenderOSL.cpp
@@ -198,6 +198,8 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
                 if (testOptions.renderImages)
                 {
+                    _renderer->setSize(static_cast<unsigned int>(testOptions.renderSize[0]), static_cast<unsigned int>(testOptions.renderSize[1]));
+
                     const mx::ShaderStage& stage = shader->getStage(mx::Stage::PIXEL);
 
                     // Look for textures and build parameter override string for each image

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -80,6 +80,7 @@ void bindPyShaderRenderer(py::module& mod)
 {
     py::class_<mx::ShaderRenderer, PyShaderRenderer, mx::ShaderRendererPtr>(mod, "ShaderRenderer")
         .def("initialize", &mx::ShaderRenderer::initialize)
+        .def("setSize", &mx::ShaderRenderer::setSize)
         .def("setImageHandler", &mx::ShaderRenderer::setImageHandler)
         .def("getImageHandler", &mx::ShaderRenderer::getImageHandler)
         .def("setLightHandler", &mx::ShaderRenderer::setLightHandler)


### PR DESCRIPTION
Change:
* Add ability to set and reset rendered size (both width and height now vs just rendering square images)
* Accessible on GLFrameBuffer, and ShaderRenderer interfaces or directly in C++ / Python
* Expose in unit tests (via _options.mtlx) 
  * GLSL and OSL render tests use new _options.mtlx option: `renderSize`. OSL just sends
    arguments to external renderer.
* Rendering for material preview can use new option.
* Rendering for texture baking can use new option.

Example sizes:
![wide_render](https://user-images.githubusercontent.com/14275104/77091992-b3991900-69df-11ea-9547-a7bbe8f5172f.png)
![narrwo_render](https://user-images.githubusercontent.com/14275104/77091995-b3991900-69df-11ea-9d86-9bab83b37fb0.png)