### PR TITLE
Use ShaderGen options to disable lights.

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -66,9 +66,8 @@ void LightCompoundNodeGlsl::createVariables(const ShaderNode&, GenContext& conte
         lightData.add(u->getSelf());
     }
 
-    // Create uniform for number of active light sources
-    ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, ps);
-    numActiveLights->setValue(Value::createValue<int>(0));
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+    shadergen.addStageLightingUniforms(context, ps);
 }
 
 void LightCompoundNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -32,7 +32,7 @@ ShaderNodeImplPtr LightNodeGlsl::create()
     return std::make_shared<LightNodeGlsl>();
 }
 
-void LightNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shader) const
+void LightNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
     ShaderStage& ps = shader.getStage(Stage::PIXEL);
 
@@ -42,9 +42,8 @@ void LightNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shad
     lightUniforms.add(Type::FLOAT, "exposure", Value::createValue<float>(0.0f));
     lightUniforms.add(Type::VECTOR3, "direction", Value::createValue<Vector3>(Vector3(0.0f,1.0f,0.0f)));
 
-    // Create uniform for number of active light sources
-    ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, ps);
-    numActiveLights->setValue(Value::createValue<int>(0));
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+    shadergen.addStageLightingUniforms(context, ps);
 }
 
 void LightNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
@@ -58,7 +58,7 @@ void LightShaderNodeGlsl::initialize(const InterfaceElement& element, GenContext
     }
 }
 
-void LightShaderNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shader) const
+void LightShaderNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
     ShaderStage& ps = shader.getStage(Stage::PIXEL);
 
@@ -70,9 +70,8 @@ void LightShaderNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader
         lightData.add(u->getType(), u->getName());
     }
 
-    // Create uniform for number of active light sources
-    ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, ps);
-    numActiveLights->setValue(Value::createValue<int>(0));
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+    shadergen.addStageLightingUniforms(context, ps);
 }
 
 void LightShaderNodeGlsl::emitFunctionCall(const ShaderNode&, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -39,7 +39,7 @@ ShaderNodeImplPtr SurfaceNodeGlsl::create()
     return std::make_shared<SurfaceNodeGlsl>();
 }
 
-void SurfaceNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shader) const
+void SurfaceNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
     // TODO: 
     // The surface shader needs position, normal, view position and light sources. We should solve this by adding some 
@@ -58,8 +58,9 @@ void SurfaceNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& sh
     addStageConnector(HW::VERTEX_DATA, Type::VECTOR3, HW::T_NORMAL_WORLD, vs, ps);
 
     addStageUniform(HW::PRIVATE_UNIFORMS, Type::VECTOR3, HW::T_VIEW_POSITION, ps);
-    ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, ps);
-    numActiveLights->setValue(Value::createValue<int>(0));
+
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+    shadergen.addStageLightingUniforms(context, ps);
 }
 
 void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
@@ -141,29 +142,36 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         }
         shadergen.emitLineBreak(stage);
 
-        shadergen.emitComment("Light loop", stage);
         shadergen.emitLine("vec3 N = normalize(" + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_NORMAL_WORLD + ")", stage);
         shadergen.emitLine("vec3 V = normalize(" + HW::T_VIEW_POSITION + " - " + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ")", stage);
-        shadergen.emitLine("int numLights = numActiveLightSources()", stage);
-        shadergen.emitLine("lightshader lightShader", stage);
-        shadergen.emitLine("for (int activeLightIndex = 0; activeLightIndex < numLights; ++activeLightIndex)", stage, false);
 
-        shadergen.emitScopeBegin(stage);
+        // 
+        // Generate Light loop if requested
+        //
+        if (context.getOptions().hwMaxActiveLightSources > 0)
+        {
+            shadergen.emitComment("Light loop", stage);
+            shadergen.emitLine("int numLights = numActiveLightSources()", stage);
+            shadergen.emitLine("lightshader lightShader", stage);
+            shadergen.emitLine("for (int activeLightIndex = 0; activeLightIndex < numLights; ++activeLightIndex)", stage, false);
 
-        shadergen.emitLine("sampleLightSource(" + HW::T_LIGHT_DATA_INSTANCE + "[activeLightIndex], " + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ", lightShader)", stage);
-        shadergen.emitLine("vec3 L = lightShader.direction", stage);
-        shadergen.emitLineBreak(stage);
+            shadergen.emitScopeBegin(stage);
 
-        shadergen.emitComment("Calculate the BSDF response for this light source", stage);
-        string bsdf;
-        shadergen.emitBsdfNodes(graph, node, _callReflection, context, stage, bsdf);
-        shadergen.emitLineBreak(stage);
+            shadergen.emitLine("sampleLightSource(" + HW::T_LIGHT_DATA_INSTANCE + "[activeLightIndex], " + HW::T_VERTEX_DATA_INSTANCE + "." + HW::T_POSITION_WORLD + ", lightShader)", stage);
+            shadergen.emitLine("vec3 L = lightShader.direction", stage);
+            shadergen.emitLineBreak(stage);
 
-        shadergen.emitComment("Accumulate the light's contribution", stage);
-        shadergen.emitLine(outColor + " += lightShader.intensity * shadowOcc * " + bsdf, stage);
+            shadergen.emitComment("Calculate the BSDF response for this light source", stage);
+            string bsdf;
+            shadergen.emitBsdfNodes(graph, node, _callReflection, context, stage, bsdf);
+            shadergen.emitLineBreak(stage);
 
-        shadergen.emitScopeEnd(stage);
-        shadergen.emitLineBreak(stage);
+            shadergen.emitComment("Accumulate the light's contribution", stage);
+            shadergen.emitLine(outColor + " += lightShader.intensity * shadowOcc * " + bsdf, stage);
+
+            shadergen.emitScopeEnd(stage);
+            shadergen.emitLineBreak(stage);
+        }
 
         //
         // Handle indirect lighting.
@@ -192,6 +200,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
 
         shadergen.emitComment("Add indirect contribution", stage);
         shadergen.emitScopeBegin(stage);
+        string bsdf;
         shadergen.emitBsdfNodes(graph, node, _callIndirect, context, stage, bsdf);
         shadergen.emitLineBreak(stage);
         shadergen.emitLine(outColor + " += ambOcc * " + bsdf, stage);

--- a/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
@@ -26,7 +26,7 @@ const string& SurfaceShaderNodeGlsl::getTarget() const
     return GlslShaderGenerator::TARGET;
 }
 
-void SurfaceShaderNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shader) const
+void SurfaceShaderNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
     // TODO: 
     // The surface shader needs position, view position and light sources. We should solve this by adding some 
@@ -41,8 +41,9 @@ void SurfaceShaderNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shad
     addStageConnector(HW::VERTEX_DATA, Type::VECTOR3, HW::T_POSITION_WORLD, vs, ps);
 
     addStageUniform(HW::PRIVATE_UNIFORMS, Type::VECTOR3, HW::T_VIEW_POSITION, ps);
-    ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, ps);
-    numActiveLights->setValue(Value::createValue<int>(0));
+
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+    shadergen.addStageLightingUniforms(context, ps);
 }
 
 void SurfaceShaderNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -593,4 +593,14 @@ ShaderNodeImplPtr HwShaderGenerator::createCompoundImplementation(const NodeGrap
     return HwCompoundNode::create();
 }
 
+void HwShaderGenerator::addStageLightingUniforms(GenContext& context, ShaderStage& stage) const
+{
+    // Create uniform for number of active light sources
+    if (context.getOptions().hwMaxActiveLightSources > 0)
+    {
+        ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, stage);
+        numActiveLights->setValue(Value::createValue<int>(0));
+    }
+}
+
 } // namespace MaterialX

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -350,6 +350,9 @@ public:
     virtual void emitEdfNodes(const ShaderGraph& graph, const ShaderNode& shaderNode, HwClosureContextPtr ccx,
                               GenContext& context, ShaderStage& stage, string& edf) const;
 
+    /// Emit code for active light count definitions and uniforms
+    virtual void addStageLightingUniforms(GenContext& context, ShaderStage& stage) const;
+
     /// Return the closure contexts defined for the given node.
     void getNodeClosureContexts(const ShaderNode& node, vector<HwClosureContextPtr>& ccx) const;
 


### PR DESCRIPTION
Allow users to disable light loop and light structs for direct lights by setting `hwMaxActiveLightSources=0`