### PR TITLE
Add support to write out RtNodeDefs to document

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -125,6 +125,9 @@ public:
     /// will be written to the document.
     void write(const FilePath& documentPath, const RtWriteOptions* writeOptions = nullptr);
 
+    void writeDefinitions(std::ostream& stream, const RtTokenVec& names);
+    void writeDefinitions(const FilePath& documentPath, const RtTokenVec& names);
+
 protected:
     /// Read all contents from one or more libraries.
     /// All MaterialX files found inside the given libraries will be read.

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -39,19 +39,19 @@ RtPrim RtNodeDef::createPrim(const RtToken& typeName, const RtToken& name, RtPri
 const RtToken& RtNodeDef::getNode() const
 {
     RtTypedValue* v = prim()->getMetadata(NODE);
-    return v->getValue().asToken();
+    return v ? v->getValue().asToken() : EMPTY_TOKEN;
 }
 
 void RtNodeDef::setNode(const RtToken& node)
 {
-    RtTypedValue* v = prim()->getMetadata(NODE);
+    RtTypedValue* v = prim()->addMetadata(NODE, RtType::TOKEN);
     v->getValue().asToken() = node;
 }
 
 const RtToken& RtNodeDef::getNodeGroup() const
 {
-    RtTypedValue* v = prim()->addMetadata(NODEGROUP, RtType::TOKEN);
-    return v->getValue().asToken();
+    RtTypedValue* v = prim()->getMetadata(NODEGROUP);
+    return v ? v->getValue().asToken() : EMPTY_TOKEN;
 }
 
 void RtNodeDef::setNodeGroup(const RtToken& nodegroup)

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -17,6 +17,7 @@ namespace
     static const RtTypeInfo SOCKETS_TYPE_INFO("_nodegraph_internal_sockets");
     static const RtToken SOCKETS("_nodegraph_internal_sockets");
     static const RtToken NODEGRAPH1("nodegraph1");
+    static const RtToken NODEDEF("nodedef");
 }
 
 DEFINE_TYPED_SCHEMA(RtNodeGraph, "node:nodegraph");
@@ -128,6 +129,19 @@ RtPrimIterator RtNodeGraph::getNodes() const
 {
     RtSchemaPredicate<RtNode> predicate;
     return RtPrimIterator(hnd(), predicate);
+}
+
+const RtToken& RtNodeGraph::getDefinition() const
+{
+    RtTypedValue* v = prim()->getMetadata(NODEDEF);
+    return v ? v->getValue().asToken() : EMPTY_TOKEN;
+}
+
+/// Set the associated definition name.
+void RtNodeGraph::setDefinition(const RtToken& value)
+{
+    RtTypedValue* v = prim()->addMetadata(NODEDEF, RtType::TOKEN);
+    v->getValue().asToken() = value;
 }
 
 string RtNodeGraph::asStringDot() const

--- a/source/MaterialXRuntime/RtNodeGraph.h
+++ b/source/MaterialXRuntime/RtNodeGraph.h
@@ -57,6 +57,12 @@ public:
     /// Return an iterator over the nodes in the graph.
     RtPrimIterator getNodes() const;
 
+    /// Return any associated definition name.
+    const RtToken& getDefinition() const;
+
+    /// Set the associated definition name.
+    void setDefinition(const RtToken& value);
+
     /// Convert this graph to a string in the DOT language syntax. This can be
     /// used to visualise the graph using GraphViz (http://www.graphviz.org).
     string asStringDot() const;

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -171,6 +171,13 @@ RtPrim RtStage::createNodeDef(RtNodeGraph& nodeGraph,
         nodedef.setNodeGroup(nodeGroup);
     }
 
+    // Add an output per nodegraph input
+    for (auto input : nodeGraph.getInputs())
+    {
+        RtAttribute attr = nodedef.createInput(input.getName(), input.getType());
+        attr.setValue(input.getValue());
+    }
+
     // Add an output per nodegraph output
     for (auto output : nodeGraph.getOutputs())
     {

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -178,8 +178,8 @@ RtPrim RtStage::createNodeDef(RtNodeGraph& nodeGraph,
         attr.setValue(output.getValue());
     }
 
-    // Set up relationship between nodegraph and nodedef
-    nodeGraph.setNodeDef(prim->hnd());
+    // Set up definition on nodegraph
+    nodeGraph.setDefinition(nodeDefName);
 
     // Add definiion
     nodedef.registerMasterPrim();

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -794,6 +794,11 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(addgraphDef.getNodeGroup() == MATH_GROUP);
     addgraphDef.setVersion(ADDGRAPH_VERSION);
     REQUIRE(addgraphDef.getVersion() == ADDGRAPH_VERSION);
+
+    mx::RtFileIo stageIo(stage);
+    mx::RtTokenVec names;
+    names.insert(ND_ADDGRAPH);
+    stageIo.writeDefinitions("test_ng.mtlx", names);
 }
 
 TEST_CASE("Runtime: FileIo", "[runtime]")

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -731,8 +731,10 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(!stage->getPrimAtPath(add3Path));
 
     // Add an interface to the graph.
-    graph1.createInput(A, mx::RtType::FLOAT);
-    graph1.createInput(B, mx::RtType::FLOAT);
+    mx::RtInput Ainput = graph1.createInput(A, mx::RtType::FLOAT);
+    Ainput.setValueString("0.3");
+    mx::RtInput Binput = graph1.createInput(B, mx::RtType::FLOAT);
+    Binput.setValueString("0.1");
     graph1.createOutput(OUT, mx::RtType::FLOAT);
     REQUIRE(graph1.getPrim().getAttribute(A));
     REQUIRE(graph1.getPrim().getAttribute(B));
@@ -777,16 +779,18 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(graph1.getPrim().getParent() == stage->getRootPrim());
 
     // Test creating a nodedef from a nodegraph
+    const mx::RtToken NG_ADDGRAPH("NG_addgraph");
     const mx::RtToken ND_ADDGRAPH("ND_addgraph");
     const mx::RtToken ADDGRAPH("addgraph");
     const mx::RtToken MATH_GROUP("math");
     const mx::RtToken ADDGRAPH_VERSION("3.4");
+    stage->renamePrim(graph1.getPath(), NG_ADDGRAPH);
     mx::RtPrim addgraphPrim = stage->createNodeDef(graph1, ND_ADDGRAPH, ADDGRAPH, MATH_GROUP);
-    mx::RtNodeDef addgraphDef(addgraphPrim);
+    mx::RtNodeDef addgraphDef(addgraphPrim);    
 
     REQUIRE(addgraphDef.isMasterPrim());
-    REQUIRE(graph1.getNodeDef().getName() == ND_ADDGRAPH);
-    REQUIRE(addgraphDef.numInputs() == 0);
+    REQUIRE(graph1.getDefinition() == ND_ADDGRAPH);
+    REQUIRE(addgraphDef.numInputs() == 2);
     REQUIRE(addgraphDef.numOutputs() == 1);
     REQUIRE(addgraphDef.getOutput().getName() == OUT);
     REQUIRE(addgraphDef.getName() == ND_ADDGRAPH);
@@ -797,8 +801,54 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
 
     mx::RtFileIo stageIo(stage);
     mx::RtTokenVec names;
-    names.insert(ND_ADDGRAPH);
-    stageIo.writeDefinitions("test_ng.mtlx", names);
+    names.push_back(ND_ADDGRAPH);
+    stageIo.writeDefinitions("ND_addgraph.mtlx", names);
+
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::readFromXmlFile(doc, "ND_addgraph.mtlx");
+    mx::NodeDefPtr nodeDef = doc->getNodeDef(ND_ADDGRAPH.str());
+    REQUIRE(nodeDef);
+    std::vector<mx::InputPtr> inputs = nodeDef->getInputs();
+    bool inputCheck = 
+        (inputs.size() == 2) &&
+        (inputs[0]->getName() == "a") &&
+        (inputs[0]->getType() == "float") &&
+        (inputs[0]->getValueString() == "0.3") &&
+        (inputs[1]->getName() == "b") &&
+        (inputs[1]->getType() == "float") &&
+        (inputs[1]->getValueString() == "0.1");
+    REQUIRE(inputCheck);
+    mx::OutputPtr out = nodeDef->getOutput("out");
+    bool outputCheck = out && 
+        (out->getName() == "out") &&
+        (out->getType() == "float") &&
+        (out->getValueString() == "0");
+    REQUIRE(outputCheck);
+    mx::NodeGraphPtr nodeGraph = doc->getNodeGraph(NG_ADDGRAPH.str());
+    REQUIRE((nodeGraph && nodeGraph->getOutputs().size() == 1));
+    for (mx::TreeIterator it = nodeGraph->traverseTree().begin(); it != mx::TreeIterator::end(); ++it)
+    {
+        mx::ValueElementPtr input = it.getElement()->asA<mx::ValueElement>();
+        if (input)
+        {
+            if (input->getName() == "in1" && input->getAttribute("nodename").empty())
+            {
+                REQUIRE((input->getInterfaceName() == "a"));
+            }
+            else if (input->getName() == "in2")
+            {
+                if (input->getParent())
+                {
+                    bool interfaceNameMatched = true;
+                    if (input->getParent()->getName() == "add2")
+                        interfaceNameMatched = (input->getInterfaceName() == "a");
+                    else
+                        interfaceNameMatched = (input->getInterfaceName() == "b");
+                    REQUIRE(interfaceNameMatched);
+                }
+            }
+        }
+    }
 }
 
 TEST_CASE("Runtime: FileIo", "[runtime]")


### PR DESCRIPTION
- Change to use metadata vs relationship for RtNodeDef / RtNodeGraph relathonship (which is not used anywhere)
- Add support create inputs on an RtNodeDef if there are inputs on a RtNodeGraph.
- Add support to write out an RtNodeDef + corresponding nodegraph (if exists).
- Add Runtime test to test save to MTLX.
- Note: there are issues in core with haveing a `version` attribute on a nodedef. Node::getNodeDef() does not seem to be able to find the corresponding nodegraph. See issue: #874.

The following is the result of the unit test which takes a RtNodeGraph and creates a RtNodeDef + modifies the RtNodeGraph. Test then saves and reloads to test validity.
```
<?xml version="1.0"?>
<materialx version="1.37">
  <nodedef name="ND_addgraph" node="addgraph" nodegroup="math" version="3.4">
    <input name="a" type="float" value="0.3" />
    <input name="b" type="float" value="0.1" />
    <output name="out" type="float" value="0" />
  </nodedef>
  <nodegraph name="NG_addgraph" nodedef="ND_addgraph">
    <input name="a" type="float" />
    <input name="b" type="float" />
    <add name="add1" type="float">
      <input name="in1" type="float" interfacename="a" />
      <input name="in2" type="float" interfacename="b" />
    </add>
    <add name="add2" type="float">
      <input name="in1" type="float" nodename="add1" />
      <input name="in2" type="float" interfacename="a" />
    </add>
    <output name="out" type="float" nodename="add2" />
  </nodegraph>
</materialx>
```