### PR TITLE
LOOKDEVX-235 : Fix up version handling in runtime

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -123,7 +123,11 @@ namespace
                 continue;
             }
             const RtTypedValue* md = src->getMetadata(name);
-            dest->setAttribute(name.str(), md->getValueString());
+            std::string valueString = md->getValueString();
+            if (!valueString.empty())
+            {
+                dest->setAttribute(name.str(), md->getValueString());
+            }
         }
     }
 

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -126,7 +126,7 @@ namespace
             std::string valueString = md->getValueString();
             if (!valueString.empty())
             {
-                dest->setAttribute(name.str(), md->getValueString());
+                dest->setAttribute(name.str(), valueString);
             }
         }
     }

--- a/source/MaterialXRuntime/RtNode.cpp
+++ b/source/MaterialXRuntime/RtNode.cpp
@@ -47,6 +47,25 @@ RtPrim RtNode::createPrim(const RtToken& typeName, const RtToken& name, RtPrim p
     PvtRelationship* nodedefRelation = node->createRelationship(NODEDEF);
     nodedefRelation->addTarget(nodedef);
 
+    // Copy over meta-data from nodedef to node. 
+    // TODO: Checks with ILM need to be made to make sure that the appropriate
+    // meta-data set. TBD if target should be set.
+    RtTokenSet copyList = { RtNodeDef::VERSION };
+    const vector<RtToken>& metadata = nodedef->getMetadataOrder();
+    for (const RtToken dataName : metadata)
+    { 
+        if (copyList.count(dataName))
+        {
+            const RtTypedValue* src = nodedef->getMetadata(dataName);
+            RtTypedValue* v = src ? node->addMetadata(dataName, src->getType()) : nullptr;
+            if (v)
+            {
+                RtToken valueToCopy = src->getValue().asToken();
+                v->getValue().asToken() = valueToCopy;
+            }
+        }
+    }
+
     // Create the interface according to nodedef.
     for (const PvtDataHandle& attrH : nodedef->getAllAttributes())
     {


### PR DESCRIPTION
- Fix so that version is set on RtNodes if the RtNodedef has a version. 
To verify the complete set which is required (e.g. `target` seems like it's required but to confirm)
- Make sure that target and version are settable on the RtNodedef and saved to MTLX.
- Fix to that empty metadata values are not saved.

Updated definition output looks like this:
```
<?xml version="1.0"?>
<materialx version="1.38">
  <nodedef name="ND_add_float" node="add">
    <input name="in1" type="float" value="0" />
    <input name="in2" type="float" value="0" />
    <output name="out" type="float" value="0" />
  </nodedef>
  <nodegraph name="NG_addgraph" nodedef="ND_addgraph">
    <input name="a" type="float" />
    <input name="b" type="float" />
    <add name="add1" type="float">
      <input name="in1" type="float" interfacename="a" />
      <input name="in2" type="float" interfacename="b" />
    </add>
    <add name="add2" type="float">
      <input name="in1" type="float" nodename="add1" />
      <input name="in2" type="float" interfacename="a" />
    </add>
    <output name="out" type="float" nodename="add2" />
  </nodegraph>
  <nodedef name="ND_addgraph" node="addgraph" nodegroup="math" version="3.4" target="mytarget">
    <input name="a" type="float" value="0.3" />
    <input name="b" type="float" value="0.1" />
    <output name="out" type="float" value="0" />
  </nodedef>
</materialx>
```
with an instance looking like this:
```
  <addgraph name="addgraph1" type="float" version="3.4" />
```