### PR TITLE
Fix input traversal so "output" attribute is optional if nodename/nodegraph specified.

### DIFF
--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<materialx version="1.37">
+   <standard_surface name="MappedShader" type="surfaceshader">
+      <input name="base" type="float" value="1" />
+      <input name="base_color" type="color3" nodegraph="RedRamp" />
+      <input name="metalness" type="float" value="1" />
+      <input name="specular" type="float" value="0" />
+      <input name="coat" type="float" value="1" />
+   </standard_surface>
+   <nodegraph name="RedRamp">
+      <ramp4 name="ramp4" type="color3">
+         <parameter name="valuetl" type="color3" value="1, 0, 0" />
+      </ramp4>
+      <output name="out" type="color3" nodename="ramp4" />
+   </nodegraph>
+   <surfacematerial name="MappedShaderMaterial" type="material">
+      <input name="surfaceshader" type="surfaceshader" nodename="MappedShader" />
+      <input name="displacementshader" type="displacementshader" />
+   </surfacematerial>
+</materialx>

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -272,10 +272,7 @@ NodePtr Parameter::getConnectedNode() const
 OutputPtr Input::getConnectedOutput() const
 {
     const string& outputString = getOutputString();
-    if (outputString.empty())
-    {
-        return OutputPtr();
-    }
+    OutputPtr result = nullptr;
 
     // Look for an output in a nodegraph
     if (hasNodeGraphName())
@@ -283,7 +280,18 @@ OutputPtr Input::getConnectedOutput() const
         NodeGraphPtr nodeGraph = resolveRootNameReference<NodeGraph>(getNodeGraphName());
         if (nodeGraph)
         {
-            return nodeGraph->getOutput(outputString);
+            std::vector<OutputPtr> outputs = nodeGraph->getOutputs();
+            if (!outputs.empty())
+            {
+                if (outputString.empty())
+                {
+                    result = outputs[0];
+                }
+                else
+                {
+                    result = nodeGraph->getOutput(outputString);
+                }
+            }
         }
     }
     // Look for output on a node
@@ -293,11 +301,26 @@ OutputPtr Input::getConnectedOutput() const
         NodePtr node = graph ? graph->getNode(getNodeName()) : nullptr;
         if (node)
         {
-            return node->getOutput(outputString);
+            std::vector<OutputPtr> outputs = node->getOutputs();
+            if (!outputs.empty())
+            {
+                if (outputString.empty())
+                {
+                    result = outputs[0];
+                }
+                else
+                {
+                    result = node->getOutput(outputString);
+                }
+            }
         }
     }
     // Look for output in the document
-    return getDocument()->getOutput(outputString);
+    if (!result)
+    {
+        result = getDocument()->getOutput(outputString);
+    }
+    return result;
 }
 
 NodePtr Input::getConnectedNode() const

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -75,8 +75,8 @@ vector<MaterialAssignPtr> getGeometryBindings(NodePtr materialNode, const string
 /// Find any material node elements which are renderable (have input shaders)
 /// @param doc Document to examine
 /// @param elements List of renderable elements (returned)
-/// @param includeRefencedGraphs Whether to check for outputs on referenced graphs
-/// @param graphOutputs List of outputs examined. Graph outputs are added if they do
+/// @param includeReferencedGraphs Whether to check for outputs on referenced graphs
+/// @param processedOutputs List of outputs examined. Graph outputs are added if they do
 ///     not already exist
 void findRenderableMaterialNodes(ConstDocumentPtr doc, 
                                  vector<TypedElementPtr>& elements, 


### PR DESCRIPTION
Affects LOOKDEVX-182
Fix #883

Fix logic to find output from input so that it is optional. If not specified find the first 
output on any upstream node or nodegraph.
(Regression most like the result of some bad merges.)