### PR TITLE
Support for vertical layering through a layer operator node.

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -189,8 +189,11 @@
       <input name="color" type="color3" interfacename="sheen_color" />
       <input name="roughness" type="float" interfacename="sheen_roughness" />
       <input name="normal" type="vector3" interfacename="normal" />
-      <input name="base" type="BSDF" nodename="diffuse_bsdf" />
     </sheen_brdf>
+    <layer name="diffuse_layer" type="BSDF">
+      <input name="top" type="BSDF" nodename="sheen_bsdf" />
+      <input name="base" type="BSDF" nodename="diffuse_bsdf" />
+    </layer>
 
     <!-- Subsurface Layer -->
     <diffuse_btdf name="translucent_bsdf" type="BSDF">
@@ -222,7 +225,7 @@
     </mix>
     <mix name="subsurface_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="selected_subsurface_bsdf" />
-      <input name="bg" type="BSDF" nodename="sheen_bsdf" />
+      <input name="bg" type="BSDF" nodename="diffuse_layer" />
       <input name="mix" type="float" interfacename="subsurface" />
     </mix>
 
@@ -252,8 +255,11 @@
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="main_tangent" />
       <parameter name="distribution" type="string" value="ggx" />
-      <input name="base" type="BSDF" nodename="transmission_mix" />
     </dielectric_brdf>
+    <layer name="specular_layer" type="BSDF">
+      <input name="top" type="BSDF" nodename="specular_bsdf" />
+      <input name="base" type="BSDF" nodename="transmission_mix" />
+    </layer>
 
     <!-- Metal Layer -->
     <multiply name="metal_reflectivity" type="color3">
@@ -275,7 +281,7 @@
     </conductor_brdf>
     <mix name="metalness_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="metal_bsdf" />
-      <input name="bg" type="BSDF" nodename="specular_bsdf" />
+      <input name="bg" type="BSDF" nodename="specular_layer" />
       <input name="mix" type="float" interfacename="metalness" />
     </mix>
 
@@ -301,8 +307,11 @@
       <input name="normal" type="vector3" interfacename="coat_normal" />
       <input name="tangent" type="vector3" nodename="coat_tangent" />
       <parameter name="distribution" type="string" value="ggx" />
-      <input name="base" type="BSDF" nodename="metalness_mix_attenuated" />
     </dielectric_brdf>
+    <layer name="coat_layer" type="BSDF">
+      <input name="top" type="BSDF" nodename="coat_bsdf" />
+      <input name="base" type="BSDF" nodename="metalness_mix_attenuated" />
+    </layer>
 
     <!-- Emission Layer -->
     <multiply name="emission_weight" type="color3">
@@ -339,7 +348,7 @@
       <input name="in" type="color3" interfacename="opacity" />
     </luminance>
     <surface name="standard_surface_constructor" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="coat_bsdf" />
+      <input name="bsdf" type="BSDF" nodename="coat_layer" />
       <input name="edf" type="EDF" nodename="emission_edf" />
       <input name="opacity" type="float" nodename="opacity_luminance" channels="r"/>
     </surface>

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -28,6 +28,9 @@
   <!-- <sheen_brdf> -->
   <implementation name="IM_sheen_brdf_genglsl" nodedef="ND_sheen_brdf" file="pbrlib/genglsl/mx_sheen_brdf.glsl" function="mx_sheen_brdf" language="genglsl"/>
 
+  <!-- <layer> -->
+  <implementation name="IM_layer_bsdf_genglsl" nodedef="ND_layer_bsdf" language="genglsl"/>
+
   <!-- <mix> -->
   <implementation name="IM_mix_bsdf_genglsl" nodedef="ND_mix_bsdf" file="pbrlib/genglsl/mx_mix_bsdf.glsl" function="mx_mix_bsdf" language="genglsl"/>
   <implementation name="IM_mix_edf_genglsl" nodedef="ND_mix_edf" file="pbrlib/genglsl/mx_mix_edf.glsl" function="mx_mix_edf" language="genglsl"/>

--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -62,6 +62,9 @@
   <implementation name="IM_displacement_float_genmdl" nodedef="ND_displacement_float" sourcecode="mx::pbrlib::mx_displacement_float(mxp_displacement:{{displacement}}, mxp_scale:{{scale}})" language="genmdl"/>
   <implementation name="IM_displacement_vector3_genmdl" nodedef="ND_displacement_vector3" sourcecode="mx::pbrlib::mx_displacement_vector3(mxp_displacement:{{displacement}}, mxp_scale:{{scale}})" language="genmdl"/>
 
+  <!-- <layer> -->
+  <implementation name="IM_layer_bsdf_genmdl" nodedef="ND_layer_bsdf" language="genmdl"/>
+
   <!-- <mix> -->
   <implementation name="IM_mix_bsdf_genmdl" nodedef="ND_mix_bsdf" sourcecode="mx::pbrlib::mx_mix_bsdf(mxp_fg:{{fg}}, mxp_bg:{{bg}}, mxp_mix:{{mix}})" language="genmdl"/>
   <implementation name="IM_mix_edf_genmdl" nodedef="ND_mix_edf" sourcecode="mx::pbrlib::mx_mix_edf(mxp_fg:{{fg}}, mxp_bg:{{bg}}, mxp_mix:{{mix}})" language="genmdl"/>

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -31,6 +31,9 @@
   <!-- <uniform_edf> -->
   <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" file="pbrlib/genosl/mx_uniform_edf.inline" language="genosl"/>
 
+  <!-- <layer> -->
+  <implementation name="IM_layer_bsdf_genosl" nodedef="ND_layer_bsdf" language="genosl"/>
+
   <!-- <mix> -->
   <implementation name="IM_mix_bsdf_genosl" nodedef="ND_mix_bsdf" file="pbrlib/genosl/mx_mix.inline" language="genosl"/>
   <implementation name="IM_mix_edf_genosl" nodedef="ND_mix_edf" file="pbrlib/genosl/mx_mix.inline" language="genosl"/>

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -307,6 +307,16 @@
   <!-- ======================================================================== -->
 
   <!--
+    Node: <layer>
+  -->
+  <nodedef name="ND_layer_bsdf" node="layer" nodegroup="pbr" defaultinput="top"
+           doc="Layer two BSDF's with vertical layering.">
+    <input name="top" type="BSDF" value=""/>
+    <input name="base" type="BSDF" value=""/>
+    <output name="out" type="BSDF"/>
+  </nodedef>
+
+  <!--
     Node: <mix>
   -->
   <nodedef name="ND_mix_bsdf" node="mix" nodegroup="pbr" defaultinput="bg"

--- a/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
@@ -1,25 +1,36 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
+
+  <!--  Layering using explicit connection to 'base'.-->
   <nodegraph name="layer_bsdf_test1">
-    <diffuse_brdf name="diffuse_brdf1" type="BSDF">
-      <input name="color" type="color3" value="0.96, 0.1, 0.1" />
-      <input name="roughness" type="float" value="0.0" />
-      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
-    </diffuse_brdf>
-    <dielectric_brdf name="dielectric_brdf1" type="BSDF">
-      <input name="tint" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="ior" type="float" value="1.52" />
+    <diffuse_brdf name="diffuse_brdf_1" type="BSDF" />
+    <sheen_brdf name="sheen_brdf_1" type="BSDF">
+      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
+    </sheen_brdf>
+    <dielectric_brdf name="dielectric_brdf_1" type="BSDF">
+      <input name="base" type="BSDF" nodename="sheen_brdf_1" />
     </dielectric_brdf>
-    <layer name="layer_bsdf1" type="BSDF">
-      <input name="top" type="BSDF" nodename="dielectric_brdf1" />
-      <input name="base" type="BSDF" nodename="diffuse_brdf1" />
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="dielectric_brdf_1" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <!--  Layering using layer operator.-->
+  <nodegraph name="layer_bsdf_test2">
+    <diffuse_brdf name="diffuse_brdf_1" type="BSDF" />
+    <sheen_brdf name="sheen_brdf_1" type="BSDF" />
+    <dielectric_brdf name="dielectric_brdf_1" type="BSDF" />
+    <layer name="layer_bsdf_1" type="BSDF">
+      <input name="top" type="BSDF" nodename="sheen_brdf_1" />
+      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
     </layer>
-    <layer name="layer_bsdf2" type="BSDF">
-      <input name="top" type="BSDF" nodename="dielectric_brdf1" />
-      <input name="base" type="BSDF" nodename="layer_bsdf1" />
+    <layer name="layer_bsdf_2" type="BSDF">
+      <input name="top" type="BSDF" nodename="dielectric_brdf_1" />
+      <input name="base" type="BSDF" nodename="layer_bsdf_1" />
     </layer>
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="layer_bsdf2" />
+      <input name="bsdf" type="BSDF" nodename="layer_bsdf_2" />
     </surface>
     <output name="out" type="surfaceshader" nodename="surface1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<materialx version="1.37">
+  <nodegraph name="layer_bsdf_test1">
+    <diffuse_brdf name="diffuse_brdf1" type="BSDF">
+      <input name="color" type="color3" value="0.96, 0.1, 0.1" />
+      <input name="roughness" type="float" value="0.0" />
+      <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
+    </diffuse_brdf>
+    <dielectric_brdf name="dielectric_brdf1" type="BSDF">
+      <input name="tint" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="ior" type="float" value="1.52" />
+    </dielectric_brdf>
+    <layer name="layer_bsdf1" type="BSDF">
+      <input name="top" type="BSDF" nodename="dielectric_brdf1" />
+      <input name="base" type="BSDF" nodename="diffuse_brdf1" />
+    </layer>
+    <layer name="layer_bsdf2" type="BSDF">
+      <input name="top" type="BSDF" nodename="dielectric_brdf1" />
+      <input name="base" type="BSDF" nodename="layer_bsdf1" />
+    </layer>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="layer_bsdf2" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+</materialx>

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -36,6 +36,7 @@
 #include <MaterialXGenShader/Nodes/IfNode.h>
 #include <MaterialXGenShader/Nodes/BlurNode.h>
 #include <MaterialXGenShader/Nodes/HwImageNode.h>
+#include <MaterialXGenShader/Nodes/LayerNode.h>
 
 namespace MaterialX
 {
@@ -239,6 +240,8 @@ GlslShaderGenerator::GlslShaderGenerator() :
     registerImplementation("IM_surface_" + GlslShaderGenerator::LANGUAGE, SurfaceNodeGlsl::create);
     // <!-- <light> -->
     registerImplementation("IM_light_" + GlslShaderGenerator::LANGUAGE, LightNodeGlsl::create);
+    // <!-- <layer> -->
+    registerImplementation("IM_layer_bsdf_" + GlslShaderGenerator::LANGUAGE, LayerNode::create);
 
     // <!-- <point_light> -->
     registerImplementation("IM_point_light_" + GlslShaderGenerator::LANGUAGE, LightShaderNodeGlsl::create);

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -19,6 +19,7 @@
 #include <MaterialXGenShader/Nodes/SwizzleNode.h>
 #include <MaterialXGenShader/Nodes/ConvertNode.h>
 #include <MaterialXGenShader/Nodes/SwitchNode.h>
+#include <MaterialXGenShader/Nodes/LayerNode.h>
 
 namespace MaterialX
 {
@@ -200,6 +201,9 @@ MdlShaderGenerator::MdlShaderGenerator() :
 
     // <!-- <heighttonormal> -->
     registerImplementation("IM_heighttonormal_vector3_" + MdlShaderGenerator::LANGUAGE, HeightToNormalNodeMdl::create);
+
+    // <!-- <layer> -->
+    registerImplementation("IM_layer_bsdf_" + MdlShaderGenerator::LANGUAGE, LayerNode::create);
 }
 
 ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -17,6 +17,7 @@
 #include <MaterialXGenShader/Nodes/IfNode.h>
 #include <MaterialXGenShader/Nodes/BlurNode.h>
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
+#include <MaterialXGenShader/Nodes/LayerNode.h>
 
 namespace MaterialX
 {
@@ -186,6 +187,9 @@ OslShaderGenerator::OslShaderGenerator() :
     registerImplementation("IM_blur_vector2_" + OslShaderGenerator::LANGUAGE, BlurNode::create);
     registerImplementation("IM_blur_vector3_" + OslShaderGenerator::LANGUAGE, BlurNode::create);
     registerImplementation("IM_blur_vector4_" + OslShaderGenerator::LANGUAGE, BlurNode::create);
+
+    // <!-- <layer> -->
+    registerImplementation("IM_layer_bsdf_" + OslShaderGenerator::LANGUAGE, LayerNode::create);
 }
 
 ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -388,7 +388,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage, bool checkScope) const
 {
     // Omit node if it's tagged to be ignored.
-    if (node.getImplementation().getFlag(ShaderNodeImplFlag::IGNORE_FUNCTION_CALL))
+    if (node.getFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL))
     {
         return;
     }

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -387,7 +387,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 
 void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage, bool checkScope) const
 {
-    // Omit node if it's tagged to be ignored.
+    // Omit node if it's tagged to be excluded.
     if (node.getFlag(ShaderNodeFlag::EXCLUDE_FUNCTION_CALL))
     {
         return;

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -387,50 +387,55 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 
 void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage, bool checkScope) const
 {
+    // Omit node if it's tagged to be ignored.
+    if (node.getImplementation().getFlag(ShaderNodeImplFlag::IGNORE_FUNCTION_CALL))
+    {
+        return;
+    }
+
     // Omit node if it's only used inside a conditional branch
     if (checkScope && node.referencedConditionally())
     {
         emitComment("Omitted node '" + node.getName() + "'. Only used in conditional node '" + 
                     node.getScopeInfo().conditionalNode->getName() + "'", stage);
+        return;
+    }
+
+    bool match = true;
+
+    // Check if we have a closure context to modify the function call.
+    HwClosureContextPtr ccx = context.getUserData<HwClosureContext>(HW::USER_DATA_CLOSURE_CONTEXT);
+
+    if (ccx && node.hasClassification(ShaderNode::Classification::CLOSURE))
+    {
+        match =
+            // For reflection and indirect we don't support pure transmissive closures.
+            ((ccx->getType() == HwClosureContext::REFLECTION || ccx->getType() == HwClosureContext::INDIRECT) &&
+                node.hasClassification(ShaderNode::Classification::BSDF) &&
+                !node.hasClassification(ShaderNode::Classification::BSDF_T)) ||
+            // For transmissive we don't support pure reflective closures.
+            (ccx->getType() == HwClosureContext::TRANSMISSION &&
+                node.hasClassification(ShaderNode::Classification::BSDF) &&
+                !node.hasClassification(ShaderNode::Classification::BSDF_R)) ||
+            // For emission we only support emission closures.
+            (ccx->getType() == HwClosureContext::EMISSION &&
+                node.hasClassification(ShaderNode::Classification::EDF));
+    }
+
+    if (match)
+    {
+        // A match between closure context and node classification was found.
+        // So emit the function call in this context.
+        node.getImplementation().emitFunctionCall(node, context, stage);
     }
     else
     {
-        bool match = true;
-
-        // Check if we have a closure context to modify the function call.
-        HwClosureContextPtr ccx = context.getUserData<HwClosureContext>(HW::USER_DATA_CLOSURE_CONTEXT);
-
-        if (ccx && node.hasClassification(ShaderNode::Classification::CLOSURE))
-        {
-            match =
-                // For reflection and indirect we don't support pure transmissive closures.
-                ((ccx->getType() == HwClosureContext::REFLECTION || ccx->getType() == HwClosureContext::INDIRECT) &&
-                    node.hasClassification(ShaderNode::Classification::BSDF) &&
-                    !node.hasClassification(ShaderNode::Classification::BSDF_T)) ||
-                // For transmissive we don't support pure reflective closures.
-                (ccx->getType() == HwClosureContext::TRANSMISSION &&
-                    node.hasClassification(ShaderNode::Classification::BSDF) &&
-                    !node.hasClassification(ShaderNode::Classification::BSDF_R)) ||
-                // For emission we only support emission closures.
-                (ccx->getType() == HwClosureContext::EMISSION &&
-                    node.hasClassification(ShaderNode::Classification::EDF));
-        }
-
-        if (match)
-        {
-            // A match between closure context and node classification was found.
-            // So emit the function call in this context.
-            node.getImplementation().emitFunctionCall(node, context, stage);
-        }
-        else
-        {
-            // Context and node classification doen't match so just
-            // emit the output variable set to default value, in case
-            // it is referenced by another nodes in this context.
-            emitLineBegin(stage);
-            emitOutput(node.getOutput(), true, true, context, stage);
-            emitLineEnd(stage);
-        }
+        // Context and node classification doesn't match so just
+        // emit the output variable set to default value, in case
+        // it is referenced by another nodes in this context.
+        emitLineBegin(stage);
+        emitOutput(node.getOutput(), true, true, context, stage);
+        emitLineEnd(stage);
     }
 }
 

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -388,7 +388,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage, bool checkScope) const
 {
     // Omit node if it's tagged to be ignored.
-    if (node.getFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL))
+    if (node.getFlag(ShaderNodeFlag::EXCLUDE_FUNCTION_CALL))
     {
         return;
     }

--- a/source/MaterialXGenShader/Nodes/LayerNode.cpp
+++ b/source/MaterialXGenShader/Nodes/LayerNode.cpp
@@ -1,0 +1,54 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXGenShader/Nodes/LayerNode.h>
+#include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/ShaderNode.h>
+#include <MaterialXGenShader/ShaderStage.h>
+#include <MaterialXGenShader/ShaderGenerator.h>
+#include <MaterialXGenShader/TypeDesc.h>
+
+namespace MaterialX
+{
+
+const string LayerNode::TOP_STRING = "top";
+const string LayerNode::BASE_STRING = "base";
+
+ShaderNodeImplPtr LayerNode::create()
+{
+    return std::make_shared<LayerNode>();
+}
+
+void LayerNode::initialize(const InterfaceElement& element, GenContext& context)
+{
+}
+
+void LayerNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
+{
+    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+
+        const ShaderInput* top = node.getInput(TOP_STRING);
+        const ShaderInput* base = node.getInput(BASE_STRING);
+        const ShaderOutput* out = node.getOutput();
+        if (!(top && base && out))
+        {
+            throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid layer node");
+        }
+        if (!top->getConnection())
+        {
+            throw ExceptionShaderGenError("No top BSDF is connected on layer node '" + node.getName() + "'");
+        }
+        const ShaderNode* topBsdf = top->getConnection()->getNode();
+        const ShaderInput* topBsdfBase = topBsdf->getInput(BASE_STRING);
+        if (!topBsdfBase)
+        {
+            throw ExceptionShaderGenError("Node connected as top layer '" + topBsdf->getName() + "' is not a layerable BSDF");
+        }
+
+    END_SHADER_STAGE(stage, Stage::PIXEL)
+}
+
+} // namespace MaterialX

--- a/source/MaterialXGenShader/Nodes/LayerNode.h
+++ b/source/MaterialXGenShader/Nodes/LayerNode.h
@@ -1,0 +1,32 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_LAYERNODE_H
+#define MATERIALX_LAYERNODE_H
+
+#include <MaterialXGenShader/ShaderNodeImpl.h>
+
+namespace MaterialX
+{
+
+/// Layer node implementation
+class LayerNode : public ShaderNodeImpl
+{
+  public:
+    static ShaderNodeImplPtr create();
+
+    void initialize(const InterfaceElement& element, GenContext& context) override;
+
+    void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
+
+  protected:
+    /// String constants
+    static const string TOP_STRING;
+    static const string BASE_STRING;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXGenShader/Nodes/LayerNode.h
+++ b/source/MaterialXGenShader/Nodes/LayerNode.h
@@ -17,8 +17,6 @@ class LayerNode : public ShaderNodeImpl
   public:
     static ShaderNodeImplPtr create();
 
-    void initialize(const InterfaceElement& element, GenContext& context) override;
-
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   protected:

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -91,8 +91,8 @@ void ShaderGenerator::emitFunctionDefinition(const ShaderNode& node, GenContext&
 void ShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage,
                                        bool checkScope) const
 {
-    // Omit node if it's tagged to be ignored.
-    if (node.getFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL))
+    // Omit node if it's tagged to be excluded.
+    if (node.getFlag(ShaderNodeFlag::EXCLUDE_FUNCTION_CALL))
     {
         return;
     }

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -91,16 +91,22 @@ void ShaderGenerator::emitFunctionDefinition(const ShaderNode& node, GenContext&
 void ShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage,
                                        bool checkScope) const
 {
+    // Omit node if it's tagged to be ignored.
+    if (node.getImplementation().getFlag(ShaderNodeImplFlag::IGNORE_FUNCTION_CALL))
+    {
+        return;
+    }
+
     // Omit node if it's only used inside a conditional branch
     if (checkScope && node.referencedConditionally())
     {
         emitComment("Omitted node '" + node.getName() + "'. Only used in conditional node '" +
                     node.getScopeInfo().conditionalNode->getName() + "'", stage);
+        return;
     }
-    else
-    {
-        node.getImplementation().emitFunctionCall(node, context, stage);
-    }
+
+    // Emit the function call.
+    node.getImplementation().emitFunctionCall(node, context, stage);
 }
 
 void ShaderGenerator::emitFunctionDefinitions(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -92,7 +92,7 @@ void ShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& conte
                                        bool checkScope) const
 {
     // Omit node if it's tagged to be ignored.
-    if (node.getImplementation().getFlag(ShaderNodeImplFlag::IGNORE_FUNCTION_CALL))
+    if (node.getFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL))
     {
         return;
     }

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1275,7 +1275,7 @@ void ShaderGraph::finalize(GenContext& context)
                                                   "Resolve by using a layer operator for '" + node->getName() + "' as well.");
                 }
 
-                // Check if the BSDF is stricly used as top layer in vertical layering.
+                // Check if the BSDF is strictly used as top layer in vertical layering.
                 // If so we can exclude its function call since the layering node will
                 // emit this for each layering instance used.
                 bool exclude = true;

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1233,51 +1233,68 @@ void ShaderGraph::finalize(GenContext& context)
     // Set variable names for inputs and outputs in the graph.
     setVariableNames(context);
 
-    // Traverse all nodes to save data needed by shader nodes and BSDF nodes.
+    // Let the generator perform any custom edits on the graph
+    context.getShaderGenerator().finalizeShaderGraph(*this);
+
+    // Analyze the graph and extract information needed by shader nodes and BSDF nodes.
+    bool layerOperatorUsed = false;
     for (ShaderNode* node : _nodeOrder)
     {
+        // Track closure nodes used by surface shaders.
         if (node->hasClassification(ShaderNode::Classification::SHADER))
         {
-            // Track closure nodes used by this surface shader.
-            //
             // TODO: Optimize this search for closures.
             //       No need to do a full traversal when 
             //       texture nodes are reached.
             for (ShaderGraphEdge edge : ShaderGraph::traverseUpstream(node->getOutput()))
             {
-                if (edge.upstream)
+                if (edge.upstream && edge.upstream->getNode()->hasClassification(ShaderNode::Classification::CLOSURE))
                 {
-                    if (edge.upstream->getNode()->hasClassification(ShaderNode::Classification::CLOSURE))
-                    {
-                        node->_usedClosures.insert(edge.upstream->getNode());
-                    }
+                    node->_usedClosures.insert(edge.upstream->getNode());
                 }
             }
         }
-        else if (node->hasClassification(ShaderNode::Classification::BSDF))
+        else if (node->hasClassification(ShaderNode::Classification::LAYER))
         {
-            // Check if the BSDF is only used as top layer in vertical layering.
-            // If so we can ignore its function call since the layering node will
-            // emit this for each layering instance used.
-            const ShaderOutput* output = node->getOutput();
-            bool ignoreFunctionCall = true;
-            for (const ShaderInput* downstreamInput : output->getConnections())
-            {
-                if (!downstreamInput->getNode()->hasClassification(ShaderNode::Classification::LAYER) || 
-                    downstreamInput->getName() != "top")
-                {
-                    // This is not a connection to a vertical layer "top" input.
-                    // So we cannot ignore this function call.
-                    ignoreFunctionCall = false;
-                    break;
-                }
-            }
-            node->setFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL, ignoreFunctionCall);
+            layerOperatorUsed = true;
         }
     }
+    if (layerOperatorUsed)
+    {
+        for (ShaderNode* node : _nodeOrder)
+        {
+            if (node->hasClassification(ShaderNode::Classification::BSDF) &&
+                !node->hasClassification(ShaderNode::Classification::LAYER))
+            {
+                // Dissalow using explicit 'base' connections in a graph where
+                // layer operators are used.
+                ShaderInput* base = node->getInput("base");
+                if (base && base->getType() == Type::BSDF && base->getConnection())
+                {
+                    throw ExceptionShaderGenError("Explicit 'base' connection to '" + node->getName() + "' is not supported in a graph where layer operators are used." +
+                                                  "Resolve by using a layer operator for '" + node->getName() + "' as well.");
+                }
 
-    // Let the generator perform any custom edits on the graph
-    context.getShaderGenerator().finalizeShaderGraph(*this);
+                // Check if the BSDF is stricly used as top layer in vertical layering.
+                // If so we can exclude its function call since the layering node will
+                // emit this for each layering instance used.
+                bool exclude = true;
+                const ShaderOutput* output = node->getOutput();
+                for (const ShaderInput* downstreamInput : output->getConnections())
+                {
+                    if (!downstreamInput->getNode()->hasClassification(ShaderNode::Classification::LAYER) ||
+                        downstreamInput->getName() != "top")
+                    {
+                        // This is not a connection to a layer operator "top" input.
+                        // So we should not exclude this function call.
+                        exclude = false;
+                        break;
+                    }
+                }
+                node->setFlag(ShaderNodeFlag::EXCLUDE_FUNCTION_CALL, exclude);
+            }
+        }
+    }
 }
 
 void ShaderGraph::disconnect(ShaderNode* node) const

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1272,7 +1272,7 @@ void ShaderGraph::finalize(GenContext& context)
                     break;
                 }
             }
-            node->getImplementation().setFlag(ShaderNodeImplFlag::IGNORE_FUNCTION_CALL, ignoreFunctionCall);
+            node->setFlag(ShaderNodeFlag::IGNORE_FUNCTION_CALL, ignoreFunctionCall);
         }
     }
 

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -131,6 +131,7 @@ ShaderNode::ShaderNode(const ShaderGraph* parent, const string& name) :
     _parent(parent),
     _name(name),
     _classification(0),
+    _flags(0),
     _impl(nullptr)
 {
 }

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -310,7 +310,7 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
             newNode->_classification |= Classification::BSDF_T;
         }
 
-        // Check specificaly for the vertical layering node
+        // Check specifically for the vertical layering node
         if (nodeDef.getName() == "ND_layer_bsdf")
         {
             newNode->_classification |= Classification::LAYER;

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -308,6 +308,12 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
         {
             newNode->_classification |= Classification::BSDF_T;
         }
+
+        // Check specificaly for the vertical layering node
+        if (nodeDef.getName() == "ND_layer_bsdf")
+        {
+            newNode->_classification |= Classification::LAYER;
+        }
     }
     else if (primaryOutput->getType() == Type::EDF)
     {

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -205,7 +205,7 @@ class ShaderPort : public std::enable_shared_from_this<ShaderPort>
     /// Return the on|off state of a given flag.
     bool getFlag(ShaderPortFlag flag) const
     {
-        return _flags & uint32_t(flag);
+        return ((_flags & uint32_t(flag)) != 0);
     }
 
     /// Set the uniform flag this port to true.

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -308,30 +308,31 @@ class ShaderNode
     {
     public:
         // Node classes
-        static const unsigned int TEXTURE     = 1 << 0;  /// Any node that outputs floats, colors, vectors, etc.
-        static const unsigned int CLOSURE     = 1 << 1;  /// Any node that represents light integration
-        static const unsigned int SHADER      = 1 << 2;  /// Any node that outputs a shader
+        static const unsigned int TEXTURE       = 1 << 0;  /// Any node that outputs floats, colors, vectors, etc.
+        static const unsigned int CLOSURE       = 1 << 1;  /// Any node that represents light integration
+        static const unsigned int SHADER        = 1 << 2;  /// Any node that outputs a shader
         // Specific texture node types
-        static const unsigned int FILETEXTURE = 1 << 3;  /// A file texture node
-        static const unsigned int CONDITIONAL = 1 << 4;  /// A conditional node
-        static const unsigned int CONSTANT    = 1 << 5;  /// A constant node
+        static const unsigned int FILETEXTURE   = 1 << 3;  /// A file texture node
+        static const unsigned int CONDITIONAL   = 1 << 4;  /// A conditional node
+        static const unsigned int CONSTANT      = 1 << 5;  /// A constant node
         // Specific closure types
-        static const unsigned int BSDF        = 1 << 6;  /// A BDFS node
-        static const unsigned int BSDF_R      = 1 << 7;  /// A BDFS node only for reflection
-        static const unsigned int BSDF_T      = 1 << 8;  /// A BDFS node only for transmission
-        static const unsigned int EDF         = 1 << 9;  /// A EDF node
-        static const unsigned int VDF         = 1 << 10; /// A VDF node
+        static const unsigned int BSDF          = 1 << 6;  /// A BDFS node
+        static const unsigned int BSDF_R        = 1 << 7;  /// A BDFS node only for reflection
+        static const unsigned int BSDF_T        = 1 << 8;  /// A BDFS node only for transmission
+        static const unsigned int EDF           = 1 << 9;  /// A EDF node
+        static const unsigned int VDF           = 1 << 10; /// A VDF node
+        static const unsigned int LAYER         = 1 << 11; /// A node for vertical layering of other closure nodes
         // Specific shader types
-        static const unsigned int SURFACE     = 1 << 11; /// A surface shader node
-        static const unsigned int VOLUME      = 1 << 12; /// A volume shader node
-        static const unsigned int LIGHT       = 1 << 13; /// A light shader node
+        static const unsigned int SURFACE       = 1 << 12; /// A surface shader node
+        static const unsigned int VOLUME        = 1 << 13; /// A volume shader node
+        static const unsigned int LIGHT         = 1 << 14; /// A light shader node
         // Specific conditional types
-        static const unsigned int IFELSE      = 1 << 14; /// An if-else statement
-        static const unsigned int SWITCH      = 1 << 15; /// A switch statement
+        static const unsigned int IFELSE        = 1 << 15; /// An if-else statement
+        static const unsigned int SWITCH        = 1 << 16; /// A switch statement
         // Types based on nodegroup
-        static const unsigned int SAMPLE2D    = 1 << 16; /// Can be sampled in 2D (uv space)
-        static const unsigned int SAMPLE3D    = 1 << 17; /// Can be sampled in 3D (position)
-        static const unsigned int CONVOLUTION2D = 1 << 18; /// Performs a convolution in 2D (uv space)
+        static const unsigned int SAMPLE2D      = 1 << 17; /// Can be sampled in 2D (uv space)
+        static const unsigned int SAMPLE3D      = 1 << 18; /// Can be sampled in 3D (position)
+        static const unsigned int CONVOLUTION2D = 1 << 19; /// Performs a convolution in 2D (uv space)
     };
 
     /// @struct ScopeInfo
@@ -411,6 +412,12 @@ class ShaderNode
     const string& getName() const
     {
         return _name;
+    }
+
+    /// Return the implementation used for this node.
+    ShaderNodeImpl& getImplementation()
+    {
+        return *_impl;
     }
 
     /// Return the implementation used for this node.

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -315,8 +315,8 @@ class ShaderOutput : public ShaderPort
 /// Flags for tagging shader nodes.
 enum class ShaderNodeFlag
 {
-    /// Ignore the function call for this node.
-    IGNORE_FUNCTION_CALL = 0x1 << 0,
+    /// Omit the function call for this node.
+    EXCLUDE_FUNCTION_CALL = 0x1 << 0,
 };
 
 /// @class ShaderNode

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -316,7 +316,7 @@ class ShaderOutput : public ShaderPort
 enum class ShaderNodeFlag
 {
     /// Omit the function call for this node.
-    EXCLUDE_FUNCTION_CALL = 0x1 << 0,
+    EXCLUDE_FUNCTION_CALL = 1 << 0,
 };
 
 /// @class ShaderNode
@@ -435,12 +435,6 @@ class ShaderNode
     const string& getName() const
     {
         return _name;
-    }
-
-    /// Return the implementation used for this node.
-    ShaderNodeImpl& getImplementation()
-    {
-        return *_impl;
     }
 
     /// Return the implementation used for this node.

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -532,7 +532,7 @@ class ShaderNode
     /// Return the on|off state of a given flag.
     bool getFlag(ShaderNodeFlag flag) const
     {
-        return _flags & uint32_t(flag);
+        return ((_flags & uint32_t(flag)) != 0);
     }
 
   protected:

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -110,16 +110,19 @@ protected:
 using ShaderMetadataRegistryPtr = shared_ptr<ShaderMetadataRegistry>;
 
 
+/// Flags set on shader ports.
+enum class ShaderPortFlag
+{
+    UNIFORM     = 1 << 0,
+    EMITTED     = 1 << 1,
+    BIND_INPUT  = 1 << 2
+};
+
 /// @class ShaderPort
 /// An input or output port on a ShaderNode
 class ShaderPort : public std::enable_shared_from_this<ShaderPort>
 {
   public:
-    /// Flags set on shader ports.
-    static const unsigned int UNIFORM = 1 << 0;
-    static const unsigned int EMITTED = 1 << 1;
-    static const unsigned int BIND_INPUT = 1 << 2;
-
     /// Constructor.
     ShaderPort(ShaderNode* node, const TypeDesc* type, const string& name, ValuePtr value = nullptr);
 
@@ -187,29 +190,41 @@ class ShaderPort : public std::enable_shared_from_this<ShaderPort>
     /// Return the path to this port.
     const string& getPath() const { return _path; }
 
-    /// Set the uniform flag this port to true.
-    void setUniform() { _flags |= UNIFORM; }
-
-    /// Return the uniform flag on this port.
-    bool isUniform() const { return (_flags & UNIFORM) != 0; }
-
-    /// Set the emitted state on this port to true.
-    void setEmitted() { _flags |= EMITTED; }
-
-    /// Return the emitted state of this port.
-    bool isEmitted() const { return (_flags & EMITTED) != 0; }
-
-    /// Set the bind input state on this port to true.
-    void setBindInput() { _flags |= BIND_INPUT; }
-
-    /// Return the emitted state of this port.
-    bool isBindInput() const { return (_flags & BIND_INPUT) != 0; }
-
     /// Set flags on this port.
-    void setFlags(unsigned int flags) { _flags = flags; }
+    void setFlags(uint32_t flags) { _flags = flags; }
 
     /// Return flags set on this port.
-    unsigned int getFlags() const { return _flags; }
+    uint32_t getFlags() const { return _flags; }
+
+    /// Set the on|off state of a given flag.
+    void setFlag(ShaderPortFlag flag, bool value)
+    {
+        _flags = value ? (_flags | uint32_t(flag)) : (_flags & ~uint32_t(flag));
+    }
+
+    /// Return the on|off state of a given flag.
+    bool getFlag(ShaderPortFlag flag) const
+    {
+        return _flags & uint32_t(flag);
+    }
+
+    /// Set the uniform flag this port to true.
+    void setUniform() { _flags |= uint32_t(ShaderPortFlag::UNIFORM); }
+
+    /// Return the uniform flag on this port.
+    bool isUniform() const { return (_flags & uint32_t(ShaderPortFlag::UNIFORM)) != 0; }
+
+    /// Set the emitted state on this port to true.
+    void setEmitted() { _flags |= uint32_t(ShaderPortFlag::EMITTED); }
+
+    /// Return the emitted state of this port.
+    bool isEmitted() const { return (_flags & uint32_t(ShaderPortFlag::EMITTED)) != 0; }
+
+    /// Set the bind input state on this port to true.
+    void setBindInput() { _flags |= uint32_t(ShaderPortFlag::BIND_INPUT); }
+
+    /// Return the emitted state of this port.
+    bool isBindInput() const { return (_flags & uint32_t(ShaderPortFlag::BIND_INPUT)) != 0; }
 
     /// Set the metadata vector.
     void setMetadata(ShaderMetadataVecPtr metadata) { _metadata = metadata; }
@@ -231,7 +246,7 @@ class ShaderPort : public std::enable_shared_from_this<ShaderPort>
     string _unit;
     string _geomprop;
     ShaderMetadataVecPtr _metadata;
-    unsigned int _flags;
+    uint32_t _flags;
 };
 
 /// @class ShaderInput
@@ -296,6 +311,14 @@ class ShaderOutput : public ShaderPort
     friend class ShaderInput;
 };
 
+
+/// Flags for tagging shader nodes.
+enum class ShaderNodeFlag
+{
+    /// Ignore the function call for this node.
+    IGNORE_FUNCTION_CALL = 0x1 << 0,
+};
+
 /// @class ShaderNode
 /// Class representing a node in the shader generation DAG
 class ShaderNode
@@ -308,31 +331,31 @@ class ShaderNode
     {
     public:
         // Node classes
-        static const unsigned int TEXTURE       = 1 << 0;  /// Any node that outputs floats, colors, vectors, etc.
-        static const unsigned int CLOSURE       = 1 << 1;  /// Any node that represents light integration
-        static const unsigned int SHADER        = 1 << 2;  /// Any node that outputs a shader
+        static const uint32_t TEXTURE       = 1 << 0;  /// Any node that outputs floats, colors, vectors, etc.
+        static const uint32_t CLOSURE       = 1 << 1;  /// Any node that represents light integration
+        static const uint32_t SHADER        = 1 << 2;  /// Any node that outputs a shader
         // Specific texture node types
-        static const unsigned int FILETEXTURE   = 1 << 3;  /// A file texture node
-        static const unsigned int CONDITIONAL   = 1 << 4;  /// A conditional node
-        static const unsigned int CONSTANT      = 1 << 5;  /// A constant node
+        static const uint32_t FILETEXTURE   = 1 << 3;  /// A file texture node
+        static const uint32_t CONDITIONAL   = 1 << 4;  /// A conditional node
+        static const uint32_t CONSTANT      = 1 << 5;  /// A constant node
         // Specific closure types
-        static const unsigned int BSDF          = 1 << 6;  /// A BDFS node
-        static const unsigned int BSDF_R        = 1 << 7;  /// A BDFS node only for reflection
-        static const unsigned int BSDF_T        = 1 << 8;  /// A BDFS node only for transmission
-        static const unsigned int EDF           = 1 << 9;  /// A EDF node
-        static const unsigned int VDF           = 1 << 10; /// A VDF node
-        static const unsigned int LAYER         = 1 << 11; /// A node for vertical layering of other closure nodes
+        static const uint32_t BSDF          = 1 << 6;  /// A BDFS node
+        static const uint32_t BSDF_R        = 1 << 7;  /// A BDFS node only for reflection
+        static const uint32_t BSDF_T        = 1 << 8;  /// A BDFS node only for transmission
+        static const uint32_t EDF           = 1 << 9;  /// A EDF node
+        static const uint32_t VDF           = 1 << 10; /// A VDF node
+        static const uint32_t LAYER         = 1 << 11; /// A node for vertical layering of other closure nodes
         // Specific shader types
-        static const unsigned int SURFACE       = 1 << 12; /// A surface shader node
-        static const unsigned int VOLUME        = 1 << 13; /// A volume shader node
-        static const unsigned int LIGHT         = 1 << 14; /// A light shader node
+        static const uint32_t SURFACE       = 1 << 12; /// A surface shader node
+        static const uint32_t VOLUME        = 1 << 13; /// A volume shader node
+        static const uint32_t LIGHT         = 1 << 14; /// A light shader node
         // Specific conditional types
-        static const unsigned int IFELSE        = 1 << 15; /// An if-else statement
-        static const unsigned int SWITCH        = 1 << 16; /// A switch statement
+        static const uint32_t IFELSE        = 1 << 15; /// An if-else statement
+        static const uint32_t SWITCH        = 1 << 16; /// A switch statement
         // Types based on nodegroup
-        static const unsigned int SAMPLE2D      = 1 << 17; /// Can be sampled in 2D (uv space)
-        static const unsigned int SAMPLE3D      = 1 << 18; /// Can be sampled in 3D (position)
-        static const unsigned int CONVOLUTION2D = 1 << 19; /// Performs a convolution in 2D (uv space)
+        static const uint32_t SAMPLE2D      = 1 << 17; /// Can be sampled in 2D (uv space)
+        static const uint32_t SAMPLE3D      = 1 << 18; /// Can be sampled in 3D (position)
+        static const uint32_t CONVOLUTION2D = 1 << 19; /// Performs a convolution in 2D (uv space)
     };
 
     /// @struct ScopeInfo
@@ -403,7 +426,7 @@ class ShaderNode
     }
 
     /// Return true if this node matches the given classification.
-    bool hasClassification(unsigned int c) const
+    bool hasClassification(uint32_t c) const
     {
         return (_classification & c) == c;
     }
@@ -500,13 +523,26 @@ class ShaderNode
         return (!_impl || _impl->isEditable(input));
     }
 
+    /// Set the on|off state of a given flag.
+    void setFlag(ShaderNodeFlag flag, bool value)
+    {
+        _flags = value ? (_flags | uint32_t(flag)) : (_flags & ~uint32_t(flag));
+    }
+
+    /// Return the on|off state of a given flag.
+    bool getFlag(ShaderNodeFlag flag) const
+    {
+        return _flags & uint32_t(flag);
+    }
+
   protected:
     /// Create metadata from the nodedef according to registered metadata.
     void createMetadata(const NodeDef& nodeDef, GenContext& context);
 
     const ShaderGraph* _parent;
     string _name;
-    unsigned int _classification;
+    uint32_t _classification;
+    uint32_t _flags;
 
     std::unordered_map<string, ShaderInputPtr> _inputMap;
     vector<ShaderInput*> _inputOrder;

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -23,13 +23,6 @@ using ShaderGraphInputSocket = ShaderOutput;
 /// Shared pointer to a ShaderNodeImpl
 using ShaderNodeImplPtr = shared_ptr<class ShaderNodeImpl>;
 
-/// Flags for tagging shader node implementation.
-enum class ShaderNodeImplFlag
-{
-    /// Ignore the function call for this node.
-    IGNORE_FUNCTION_CALL = 0x1 << 0,
-};
-
 /// @class ShaderNodeImpl
 /// Class handling the shader generation implementation for a node.
 /// Responsible for emitting the function definition and function call 
@@ -109,18 +102,6 @@ class ShaderNodeImpl
         return true;
     }
 
-    /// Set the on|off state of a given flag.
-    void setFlag(ShaderNodeImplFlag flag, bool value)
-    {
-        _flags = value ? (_flags | uint32_t(flag)) : (_flags & ~uint32_t(flag));
-    }
-
-    /// Return the on|off state of a given flag.
-    bool getFlag(ShaderNodeImplFlag flag) const
-    {
-        return _flags & uint32_t(flag);
-    }
-
   protected:
     /// Protected constructor
     ShaderNodeImpl();
@@ -128,7 +109,6 @@ class ShaderNodeImpl
   protected:
     string _name;
     size_t _hash;
-    uint32_t _flags;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -23,6 +23,13 @@ using ShaderGraphInputSocket = ShaderOutput;
 /// Shared pointer to a ShaderNodeImpl
 using ShaderNodeImplPtr = shared_ptr<class ShaderNodeImpl>;
 
+/// Flags for tagging shader node implementation.
+enum class ShaderNodeImplFlag
+{
+    /// Ignore the function call for this node.
+    IGNORE_FUNCTION_CALL = 0x1 << 0,
+};
+
 /// @class ShaderNodeImpl
 /// Class handling the shader generation implementation for a node.
 /// Responsible for emitting the function definition and function call 
@@ -102,6 +109,18 @@ class ShaderNodeImpl
         return true;
     }
 
+    /// Set the on|off state of a given flag.
+    void setFlag(ShaderNodeImplFlag flag, bool value)
+    {
+        _flags = value ? (_flags | uint32_t(flag)) : (_flags & ~uint32_t(flag));
+    }
+
+    /// Return the on|off state of a given flag.
+    bool getFlag(ShaderNodeImplFlag flag) const
+    {
+        return _flags & uint32_t(flag);
+    }
+
   protected:
     /// Protected constructor
     ShaderNodeImpl();
@@ -109,6 +128,7 @@ class ShaderNodeImpl
   protected:
     string _name;
     size_t _hash;
+    uint32_t _flags;
 };
 
 } // namespace MaterialX


### PR DESCRIPTION
This change list adds a new `layer` node for doing vertical layering with an operator node.

Our existing BSDF nodes with layering support has not been changed. The new `layer` node is supported through codegen which generates the same layering code as with the existing BSDF nodes. In code it transforms the layering operator setup into a nested layering setup.

So now a user can choose to specify BSDF layering through either the same old nesting of BSDF's or through the new layer operator node. Mixing both methods in the same graph is not allowed, so you have to choose.

Examples comparing the syntaxes:
```
  <!--  Layering using explicit connection to 'base'.-->
  <nodegraph name="layer_bsdf_test1">
    <diffuse_brdf name="diffuse_brdf_1" type="BSDF" />
    <sheen_brdf name="sheen_brdf_1" type="BSDF">
      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
    </sheen_brdf>
    <dielectric_brdf name="dielectric_brdf_1" type="BSDF">
      <input name="base" type="BSDF" nodename="sheen_brdf_1" />
    </dielectric_brdf>
    <surface name="surface1" type="surfaceshader">
      <input name="bsdf" type="BSDF" nodename="dielectric_brdf_1" />
    </surface>
    <output name="out" type="surfaceshader" nodename="surface1" />
  </nodegraph>

  <!--  Layering using layer operator.-->
  <nodegraph name="layer_bsdf_test2">
    <diffuse_brdf name="diffuse_brdf_1" type="BSDF" />
    <sheen_brdf name="sheen_brdf_1" type="BSDF" />
    <dielectric_brdf name="dielectric_brdf_1" type="BSDF" />
    <layer name="layer_bsdf_1" type="BSDF">
      <input name="top" type="BSDF" nodename="sheen_brdf_1" />
      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
    </layer>
    <layer name="layer_bsdf_2" type="BSDF">
      <input name="top" type="BSDF" nodename="dielectric_brdf_1" />
      <input name="base" type="BSDF" nodename="layer_bsdf_1" />
    </layer>
    <surface name="surface1" type="surfaceshader">
      <input name="bsdf" type="BSDF" nodename="layer_bsdf_2" />
    </surface>
    <output name="out" type="surfaceshader" nodename="surface1" />
  </nodegraph>
```

And resulting OSL code for both:
```
    BSDF diffuse_brdf_1_out = diffuse_brdf_1_color * diffuse_brdf_1_weight * oren_nayar(geomprop_Nworld_out, diffuse_brdf_1_roughness);

    BSDF sheen_brdf_1_out = null_closure;
    mx_sheen_brdf(sheen_brdf_1_weight, sheen_brdf_1_color, sheen_brdf_1_roughness, geomprop_Nworld_out, diffuse_brdf_1_out, sheen_brdf_1_out);

    BSDF dielectric_brdf_1_out = null_closure;
    mx_dielectric_brdf(dielectric_brdf_1_weight, dielectric_brdf_1_tint, dielectric_brdf_1_ior, dielectric_brdf_1_roughness, geomprop_Nworld_out, geomprop_Tworld_out, dielectric_brdf_1_distribution, sheen_brdf_1_out, dielectric_brdf_1_out);

--------------------------------------------

    BSDF diffuse_brdf_1_out = diffuse_brdf_1_color * diffuse_brdf_1_weight * oren_nayar(geomprop_Nworld_out, diffuse_brdf_1_roughness);

    BSDF layer_bsdf_1_out = null_closure;
    mx_sheen_brdf(sheen_brdf_1_weight, sheen_brdf_1_color, sheen_brdf_1_roughness, geomprop_Nworld_out, diffuse_brdf_1_out, layer_bsdf_1_out);

    BSDF layer_bsdf_2_out = null_closure;
    mx_dielectric_brdf(dielectric_brdf_1_weight, dielectric_brdf_1_tint, dielectric_brdf_1_ior, dielectric_brdf_1_roughness, geomprop_Nworld_out, geomprop_Tworld_out, dielectric_brdf_1_distribution, layer_bsdf_1_out, layer_bsdf_2_out);
```
