### PR TITLE
LOOKDEVX-269: Add option for MTLX validation on Runtime read

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1299,11 +1299,6 @@ void RtFileIo::read(const FilePath& documentPath, const FileSearchPath& searchPa
         bool validateDocument = readOptions ? readOptions->validateDocument : true;
         if (validateDocument)
         {
-            PvtStage* stage = PvtStage::ptr(_stage);
-            readDocument(document, stage, readOptions);
-        }
-        else
-        {
             string errorMessage;
             DocumentPtr validationDocument = createDocument();
             writeUnitDefinitions(validationDocument);
@@ -1341,22 +1336,25 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* readOptions)
         }
         readFromXmlStream(document, stream, &xmlReadOptions);
 
-        string errorMessage; 
-        DocumentPtr validationDocument = createDocument();
-        writeUnitDefinitions(validationDocument);
-        CopyOptions cops;
-        cops.skipConflictingElements = true;
-        validationDocument->copyContentFrom(document, &cops);
-        if (validationDocument->validate(&errorMessage))
+        bool validateDocument = readOptions ? readOptions->validateDocument : true;
+        if (validateDocument)
         {
-            PvtStage* stage = PvtStage::ptr(_stage);
-            readDocument(document, stage, readOptions);
+            string errorMessage;
+            DocumentPtr validationDocument = createDocument();
+            writeUnitDefinitions(validationDocument);
+            CopyOptions cops;
+            cops.skipConflictingElements = true;
+            validationDocument->copyContentFrom(document, &cops);
+            if (validationDocument->validate(&errorMessage))
+            {
+                PvtStage* stage = PvtStage::ptr(_stage);
+                readDocument(document, stage, readOptions);
+            }
+            else
+            {
+                throw ExceptionRuntimeError("Failed validation: " + errorMessage);
+            }
         }
-        else
-        {
-            throw ExceptionRuntimeError("Failed validation: " + errorMessage);
-        }
-
     }
     catch (Exception& e)
     {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -21,7 +21,6 @@
 #include <MaterialXCore/Types.h>
 
 #include <MaterialXFormat/Util.h>
-#include <MaterialXFormat/Environ.h>
 #include <sstream>
 #include <fstream>
 #include <map>

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1268,7 +1268,8 @@ namespace
 RtReadOptions::RtReadOptions() :
     readFilter(nullptr),
     readLookInformation(false),
-    applyFutureUpdates(true)
+    applyFutureUpdates(true),
+    validateDocument(true)
 {
 }
 
@@ -1295,8 +1296,8 @@ void RtFileIo::read(const FilePath& documentPath, const FileSearchPath& searchPa
         }
         readFromXmlFile(document, documentPath, searchPaths, &xmlReadOptions);
 
-        bool accessNodeDefGraphs = !getEnviron("ACCESS_NODEDEF_GRAPHS").empty();
-        if (accessNodeDefGraphs)
+        bool validateDocument = readOptions ? readOptions->validateDocument : true;
+        if (validateDocument)
         {
             PvtStage* stage = PvtStage::ptr(_stage);
             readDocument(document, stage, readOptions);

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -34,11 +34,14 @@ class RtReadOptions
     /// If the filter returns false the element will not be read.
     ReadFilter readFilter;
 
-    /// Read look information
+    /// Read look information. The default value is false.
     bool readLookInformation;
 
-    /// Apply latest updates
+    /// Apply the latest MaterialX feature updates. The default value is true.
     bool applyFutureUpdates;
+
+    /// Validate MaterialX documents read. The default is true.
+    bool validateDocument;
 };
     
 /// @class RtWriteOptions

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -983,6 +983,30 @@ TEST_CASE("Runtime: FileIo", "[runtime]")
     }
 }
 
+TEST_CASE("Runtime: FileIo no validatioon", "[runtime2]")
+{
+    mx::RtScopedApiHandle api;
+    mx::FileSearchPath bxdfPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries") / mx::FilePath("bxdf"));
+    mx::RtReadOptions options;
+    options.validateDocument = false;
+
+    mx::RtStagePtr stage = api->createStage(MAIN);
+    mx::RtFileIo fileIo(stage);
+    REQUIRE_THROWS(fileIo.read("standard_surface.mtlx", bxdfPath));
+    REQUIRE_NOTHROW(fileIo.read("standard_surface.mtlx", bxdfPath, &options));
+
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::readFromXmlFile(doc, "standard_surface.mtlx", bxdfPath);
+    std::stringstream stream;
+    mx::writeToXmlStream(doc, stream);
+    stage = api->createStage(MAIN);
+    mx::RtFileIo fileIo2(stage);
+    REQUIRE_THROWS(fileIo2.read(stream));
+    std::stringstream stream2;
+    mx::writeToXmlStream(doc, stream2);
+    REQUIRE_NOTHROW(fileIo2.read(stream2, &options));
+}
+
 TEST_CASE("Runtime: DefaultLook", "[runtime]")
 {
     mx::RtScopedApiHandle api;


### PR DESCRIPTION
Put this up for discussion.
If loading in a library def file the current doc does not have existing definitions include geompropdef
so will fail validation. 
 