### PR TITLE
Enable GlslShaderGenerator to add `layout` in generated code.

### DIFF
--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -16,6 +16,16 @@ GlslResourceBindingContext::GlslResourceBindingContext()
     _requiredExtensions.insert("GL_ARB_shading_language_420pack");
 }
 
+void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage& stage)
+{
+    ShaderGenerator& generator = context.getShaderGenerator();
+
+    for (auto& extension : _requiredExtensions)
+    {
+        generator.emitLine("#extension " + extension + " : enable", stage, false);
+    }
+}
+
 void GlslResourceBindingContext::emitUniformBlock(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage)
 {
     ShaderGenerator& generator = context.getShaderGenerator();

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -1,0 +1,45 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXGenGlsl/GlslResourceBindingContext.h>
+
+namespace MaterialX
+{
+
+//
+// GlslResourceBindingContext
+//
+GlslResourceBindingContext::GlslResourceBindingContext()
+{
+    _requiredExtensions.insert("GL_ARB_shading_language_420pack");
+}
+
+void GlslResourceBindingContext::emitUniformBlock(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage)
+{
+    ShaderGenerator& generator = context.getShaderGenerator();
+
+    generator.emitString("layout (binding=" + std::to_string(_hwBindLocation) + ") " + syntax->getUniformQualifier() + " " + uniforms.getName(), stage);
+    generator.emitScopeBegin(stage);
+    generator.emitVariableDeclarations(uniforms, EMPTY_STRING, Syntax::SEMICOLON, context, stage, false);
+    generator.emitScopeEnd(stage, true);
+    generator.emitLineBreak(stage);
+    _hwBindLocation++;
+}
+
+void GlslResourceBindingContext::emitSamplerBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage)
+{
+    ShaderGenerator& generator = context.getShaderGenerator();
+
+    for (size_t i = 0; i < uniforms.size(); ++i)
+    {
+        generator.emitString("layout (binding=" + std::to_string(_hwBindLocation) + ") " + syntax->getUniformQualifier() + " ", stage);
+        generator.emitVariableDeclaration(uniforms[i], EMPTY_STRING, context, stage, false);
+        generator.emitLineEnd(stage, true);
+        _hwBindLocation++;
+    }
+}
+
+
+}

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -23,8 +23,12 @@ class GlslResourceBindingContext : public HwResourceBindingContext
 {
 public:
 
-    // Constructor
     GlslResourceBindingContext();
+
+    static GlslResourceBindingContextPtr create() { return std::make_shared<GlslResourceBindingContext>(); }
+
+    // Emit directives for stage
+    void emitDirectives(GenContext& context, ShaderStage& stage) override;
 
     // Emit blocks with resource binding information
     void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) override
@@ -38,11 +42,6 @@ public:
         {
             emitUniformBlock(context, uniforms, syntax, stage);
         }
-    }
-
-    const StringSet& requiredExtensions() const override
-    {
-        return _requiredExtensions;
     }
 
     // Emits each sampler as a separate block

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -1,0 +1,66 @@
+//
+// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_GLSLRESOURCEBINDING_H
+#define MATERIALX_GLSLRESOURCEBINDING_H
+
+/// @file
+/// GLSL resource binding context
+
+#include <MaterialXGenShader/HwShaderGenerator.h>
+
+namespace MaterialX
+{
+
+/// Shared pointer to a GlslResourceBindingContext
+using GlslResourceBindingContextPtr = shared_ptr<class GlslResourceBindingContext>;
+
+/// @class GlslResourceBindingContext
+/// Class representing a resource binding for Glsl shader resources.
+class GlslResourceBindingContext : public HwResourceBindingContext
+{
+public:
+
+    // Constructor
+    GlslResourceBindingContext();
+
+    // Emit blocks with resource binding information
+    void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) override
+    {
+        const string uniformBlockName(uniforms.getName());
+        if (uniformBlockName == HW::SAMPLER_UNIFORMS)
+        {
+            emitSamplerBlocks(context, uniforms, syntax, stage);
+        }
+        else
+        {
+            emitUniformBlock(context, uniforms, syntax, stage);
+        }
+    }
+
+    const StringSet& requiredExtensions() const override
+    {
+        return _requiredExtensions;
+    }
+
+    // Emits each sampler as a separate block
+    void emitSamplerBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage);
+
+    // Emits all uniforms group as a block
+    void emitUniformBlock(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage);
+
+protected:
+
+    // List of required extensions
+    StringSet _requiredExtensions;
+
+    // Binding location
+    int _hwBindLocation = 0;
+
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -337,10 +337,10 @@ void GlslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& 
             }
             else
             {
-            emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage);
-            emitLineBreak(stage);
+                emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage);
+                emitLineBreak(stage);
+            }
         }
-    }
     }
 
     // Add vertex inputs
@@ -449,10 +449,10 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
             }
             else
             {
-            emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage);
-            emitLineBreak(stage);
+                emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage);
+                emitLineBreak(stage);
+            }
         }
-    }
     }
 
     bool lighting = graph.hasClassification(ShaderNode::Classification::SHADER|ShaderNode::Classification::SURFACE) ||

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -312,10 +312,7 @@ void GlslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& 
     emitLine("#version " + getVersion(), stage, false);
     if (resourceBindingCtx)
     {
-        for (auto& extension : resourceBindingCtx->requiredExtensions())
-        {
-            emitLine("#extension " + extension + " : enable", stage, false);
-        }
+        resourceBindingCtx->emitDirectives(context, stage);
     }
     emitLineBreak(stage);
 
@@ -413,10 +410,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitLine("#version " + getVersion(), stage, false);
     if (resourceBindingCtx)
     {
-        for (auto& extension : resourceBindingCtx->requiredExtensions())
-        {
-            emitLine("#extension " + extension + " : enable", stage, false);
-        }
+        resourceBindingCtx->emitDirectives(context, stage);
     }
     emitLineBreak(stage);
 

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -123,6 +123,7 @@ namespace HW
     const string VERTEX_DATA                      = "VertexData";
     const string PRIVATE_UNIFORMS                 = "PrivateUniforms";
     const string PUBLIC_UNIFORMS                  = "PublicUniforms";
+    const string SAMPLER_UNIFORMS                 = "SamplerUniforms";
     const string LIGHT_DATA                       = "LightData";
     const string PIXEL_OUTPUTS                    = "PixelOutputs";
     const string DIR_N                            = "N";
@@ -131,6 +132,7 @@ namespace HW
     const string ATTR_TRANSPARENT                 = "transparent";
     const string USER_DATA_CLOSURE_CONTEXT        = "udcc";
     const string USER_DATA_LIGHT_SHADERS          = "udls";
+    const string USER_DATA_BINDING_CONTEXT        = "udbinding";
 }
 
 namespace Stage
@@ -227,8 +229,18 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     // Create vertex stage.
     ShaderStagePtr vs = createStage(Stage::VERTEX, *shader);
     vs->createInputBlock(HW::VERTEX_INPUTS, "i_vs");
+
+    // Each Stage must have three types of uniform blocks:
+    // Private, Public and Sampler blocks
+    // Public uniforms are inputs that should be published in a user interface for user interaction,
+    // while private uniforms are internal variables needed by the system which should not be exposed in UI.
+    // So when creating these uniforms for a shader node, if the variable is user-facing it should go into the public block,
+    // and otherwise the private block.
+    // All texture based objects should be added to Sampler block
+
     vs->createUniformBlock(HW::PRIVATE_UNIFORMS, "u_prv");
     vs->createUniformBlock(HW::PUBLIC_UNIFORMS, "u_pub");
+    vs->createUniformBlock(HW::SAMPLER_UNIFORMS, "u_s");
 
     // Create required variables for vertex stage
     VariableBlock& vsInputs = vs->getInputBlock(HW::VERTEX_INPUTS);
@@ -240,8 +252,11 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     // Create pixel stage.
     ShaderStagePtr ps = createStage(Stage::PIXEL, *shader);
     VariableBlockPtr psOutputs = ps->createOutputBlock(HW::PIXEL_OUTPUTS, "o_ps");
+
+    // Create required Uniform blocks and any additonal blocks if needed.
     VariableBlockPtr psPrivateUniforms = ps->createUniformBlock(HW::PRIVATE_UNIFORMS, "u_prv");
     VariableBlockPtr psPublicUniforms = ps->createUniformBlock(HW::PUBLIC_UNIFORMS, "u_pub");
+    VariableBlockPtr psSamplerUniforms = ps->createUniformBlock(HW::SAMPLER_UNIFORMS, "u_s");
     VariableBlockPtr lightData = ps->createUniformBlock(HW::LIGHT_DATA, HW::T_LIGHT_DATA_INSTANCE);
     lightData->add(Type::INTEGER, "type");
 
@@ -251,7 +266,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     // Add uniforms for shadow map rendering.
     if (context.getOptions().hwShadowMap)
     {
-        psPrivateUniforms->add(Type::FILENAME, HW::T_SHADOW_MAP);
+        psSamplerUniforms->add(Type::FILENAME, HW::T_SHADOW_MAP);
         psPrivateUniforms->add(Type::MATRIX44, HW::T_SHADOW_MATRIX, Value::createValue(Matrix44::IDENTITY));
     }
 
@@ -260,7 +275,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     {
         addStageInput(HW::VERTEX_INPUTS, Type::VECTOR2, HW::T_IN_TEXCOORD + "_0", *vs);
         addStageConnector(HW::VERTEX_DATA, Type::VECTOR2, HW::T_TEXCOORD + "_0", *vs, *ps);
-        psPrivateUniforms->add(Type::FILENAME, HW::T_AMB_OCC_MAP);
+        psSamplerUniforms->add(Type::FILENAME, HW::T_AMB_OCC_MAP);
         psPrivateUniforms->add(Type::FLOAT, HW::T_AMB_OCC_GAIN, Value::createValue(1.0f));
     }
 
@@ -271,17 +286,17 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     {
         const Matrix44 yRotationPI = Matrix44::createScale(Vector3(-1, 1, -1));
         psPrivateUniforms->add(Type::MATRIX44, HW::T_ENV_MATRIX, Value::createValue(yRotationPI));
-        psPrivateUniforms->add(Type::FILENAME, HW::T_ENV_RADIANCE);
+        psSamplerUniforms->add(Type::FILENAME, HW::T_ENV_RADIANCE);
         psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_MIPS, Value::createValue<int>(1));
         psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_SAMPLES, Value::createValue<int>(16));
-        psPrivateUniforms->add(Type::FILENAME, HW::T_ENV_IRRADIANCE);
+        psSamplerUniforms->add(Type::FILENAME, HW::T_ENV_IRRADIANCE);
     }
 
     // Add uniforms for the directional albedo table.
     if (context.getOptions().hwDirectionalAlbedoMethod == DIRECTIONAL_ALBEDO_TABLE ||
         context.getOptions().hwWriteAlbedoTable)
     {
-        psPrivateUniforms->add(Type::FILENAME, HW::T_ALBEDO_TABLE);
+        psSamplerUniforms->add(Type::FILENAME, HW::T_ALBEDO_TABLE);
         psPrivateUniforms->add(Type::INTEGER, HW::T_ALBEDO_TABLE_SIZE, Value::createValue<int>(64));
     }
 
@@ -292,8 +307,15 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
         // and are editable by users.
         if (!inputSocket->getConnections().empty() && graph->isEditable(*inputSocket))
         {
+            if (inputSocket->getType() == Type::FILENAME)
+            {
+                psSamplerUniforms->add(inputSocket->getSelf());
+            }
+            else
+            {
             psPublicUniforms->add(inputSocket->getSelf());
         }
+    }
     }
 
     // Add the pixel stage output. This needs to be a color4 for rendering,
@@ -358,7 +380,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
                     if (!input->getConnection() && input->getType() == Type::FILENAME)
                     {
                         // Create the uniform using the filename type to make this uniform into a texture sampler.
-                        ShaderPort* filename = psPublicUniforms->add(Type::FILENAME, input->getVariable(), input->getValue());
+                        ShaderPort* filename = psSamplerUniforms->add(Type::FILENAME, input->getVariable(), input->getValue());
                         filename->setPath(input->getPath());
 
                         // Assing the uniform name to the input value

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -313,9 +313,9 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
             }
             else
             {
-            psPublicUniforms->add(inputSocket->getSelf());
+                psPublicUniforms->add(inputSocket->getSelf());
+            }
         }
-    }
     }
 
     // Add the pixel stage output. This needs to be a color4 for rendering,

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -190,6 +190,7 @@ namespace HW
     extern const string VERTEX_DATA;      // Connector block for data transfer from vertex stage to pixel stage.
     extern const string PRIVATE_UNIFORMS; // Uniform inputs set privately by application.
     extern const string PUBLIC_UNIFORMS;  // Uniform inputs visible in UI and set by user.
+    extern const string SAMPLER_UNIFORMS; // Uniform inputs for all sampler texture objects.
     extern const string LIGHT_DATA;       // Uniform inputs for light sources.
     extern const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
@@ -204,6 +205,7 @@ namespace HW
     /// User data names.
     extern const string USER_DATA_CLOSURE_CONTEXT;
     extern const string USER_DATA_LIGHT_SHADERS;
+    extern const string USER_DATA_BINDING_CONTEXT;
 }
 
 namespace Stage
@@ -215,6 +217,7 @@ namespace Stage
 class HwClosureContext;
 class HwLightShaders;
 class HwShaderGenerator;
+class HwResourceBindingContext;
 
 /// Shared pointer to a HwClosureContext
 using HwClosureContextPtr = shared_ptr<class HwClosureContext>;
@@ -222,6 +225,8 @@ using HwClosureContextPtr = shared_ptr<class HwClosureContext>;
 using HwLightShadersPtr = shared_ptr<class HwLightShaders>;
 /// Shared pointer to a HwShaderGenerator
 using HwShaderGeneratorPtr = shared_ptr<class HwShaderGenerator>;
+/// Shared pointer to a HwResourceBindingContext
+using HwResourceBindingContextPtr = shared_ptr<class HwResourceBindingContext>;
 
 /// @class HwClosureContext
 /// Class representing a context for closure evaluation on hardware targets.
@@ -387,6 +392,20 @@ protected:
     HwClosureContextPtr _defTransmission;
     HwClosureContextPtr _defIndirect;
     HwClosureContextPtr _defEmission;
+};
+
+/// @class HwResourceBinding
+/// Class representing a context for resource binding for hardware resources.
+class HwResourceBindingContext : public GenUserData
+{
+public:
+    virtual ~HwResourceBindingContext() {}
+
+    // Emit resource blocks with binding information
+    virtual void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) = 0;
+
+    // List of required extensions if any
+    virtual const StringSet& requiredExtensions() const = 0;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -401,11 +401,12 @@ class HwResourceBindingContext : public GenUserData
 public:
     virtual ~HwResourceBindingContext() {}
 
+    // Emit directives required for binding support 
+    virtual void emitDirectives(GenContext& context, ShaderStage& stage) = 0;
+
     // Emit resource blocks with binding information
     virtual void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) = 0;
 
-    // List of required extensions if any
-    virtual const StringSet& requiredExtensions() const = 0;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -15,6 +15,7 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXGenGlsl/GlslSyntax.h>
+#include <MaterialXGenGlsl/GlslResourceBindingContext.h>
 
 namespace mx = MaterialX;
 
@@ -121,6 +122,13 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
     REQUIRE_NOTHROW(mx::HwShaderGenerator::bindLightShader(*spotLightShader, 66, context));
 }
 
+// Add user data to context
+void GlslShaderGeneratorTester::addUserData(mx::GenContext& context)
+{
+    mx::GlslResourceBindingContextPtr bindCtx = std::make_shared<mx::GlslResourceBindingContext>();
+    context.pushUserData(mx::HW::USER_DATA_BINDING_CONTEXT, bindCtx);
+}
+
 static void generateGlslCode()
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
@@ -140,6 +148,14 @@ static void generateGlslCode()
     const mx::GenOptions genOptions;
     mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
+
+    // Test glsl 400 with uniform layout qualifier extensions
+    const mx::FilePath glsl42LogPath("genglsl_glsl420_layout_generate_test.txt");
+    writeShadersToDisk = true;
+    GlslShaderGeneratorTester testerglsl42(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, glsl42LogPath, writeShadersToDisk);
+    
+    // enable tester to use userdata
+    testerglsl42.validate(genOptions, optionsFilePath, true);
 }
 
 TEST_CASE("GenShader: GLSL Shader Generation", "[genglsl]")

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -125,8 +125,7 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
 // Add user data to context
 void GlslShaderGeneratorTester::addUserData(mx::GenContext& context)
 {
-    mx::GlslResourceBindingContextPtr bindCtx = std::make_shared<mx::GlslResourceBindingContext>();
-    context.pushUserData(mx::HW::USER_DATA_BINDING_CONTEXT, bindCtx);
+    context.pushUserData(mx::HW::USER_DATA_BINDING_CONTEXT, mx::GlslResourceBindingContext::create());
 }
 
 static void generateGlslCode()

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -150,7 +150,7 @@ static void generateGlslCode()
 
     // Test glsl 400 with uniform layout qualifier extensions
     const mx::FilePath glsl42LogPath("genglsl_glsl420_layout_generate_test.txt");
-    writeShadersToDisk = true;
+    writeShadersToDisk = false;
     GlslShaderGeneratorTester testerglsl42(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, glsl42LogPath, writeShadersToDisk);
     
     // enable tester to use userdata

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -47,6 +47,8 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
         loadLibrary(lightDir / mx::FilePath("light_rig_test_1.mtlx"), _dependLib);
     }
 
+    void addUserData(mx::GenContext& context) override;
+
   protected:
     void getImplementationWhiteList(mx::StringSet& whiteList) override
     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -20,6 +20,7 @@ namespace mx = MaterialX;
 
 namespace GenShaderUtil
 {
+    const std::string TEST_USER_DATA_SUFFIX = "_ud";
 
 namespace
 {
@@ -796,8 +797,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                     }
                     else if (_writeShadersToDisk && sourceCode.size())
                     {
-
-                        const std::string udsuffix(enableUserData ? "_ud" : "");
+                        const std::string udsuffix(enableUserData ? TEST_USER_DATA_SUFFIX : mx::EMPTY_STRING);
 
                         mx::FilePath path = element->getActiveSourceUri();
                         if (!path.isEmpty())

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -569,7 +569,7 @@ void ShaderGeneratorTester::registerLights(mx::DocumentPtr doc, const std::vecto
     context.getOptions().hwMaxActiveLightSources = lightSourceCount;
 }
 
-void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath)
+void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath, bool enableUserData)
 {
     // Start logging
     _logFile.open(_logFilePath);
@@ -691,6 +691,13 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
         findLights(doc, _lights);
         registerLights(doc, _lights, context);
 
+
+        // Add any userdata if required
+        if (enableUserData)
+        {
+            addUserData(context);
+        }
+
         // Find elements to render in the document
         std::vector<mx::TypedElementPtr> elements;
         try
@@ -789,6 +796,9 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                     }
                     else if (_writeShadersToDisk && sourceCode.size())
                     {
+
+                        const std::string udsuffix(enableUserData ? "_ud" : "");
+
                         mx::FilePath path = element->getActiveSourceUri();
                         if (!path.isEmpty())
                         {
@@ -828,7 +838,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                         {
                             for (size_t i=0; i<sourceCode.size(); ++i)
                             {
-                                const mx::FilePath filename = path / (elementName + "." + _testStages[i] + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage()));
+                                const mx::FilePath filename = path / (elementName + udsuffix + "." + _testStages[i] + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage()));
                                 sourceCodePaths.push_back(filename);
                                 std::ofstream file(filename.asString());
                                 file << sourceCode[i];

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -191,6 +191,9 @@ class ShaderGeneratorTester
     // Add unit system
     virtual void addUnitSystem();
 
+    // Add user data 
+    virtual void addUserData(mx::GenContext&) {}
+
     // Load in dependent libraries
     virtual void setupDependentLibraries();
 
@@ -210,7 +213,7 @@ class ShaderGeneratorTester
                               std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
 
     // Run test for source code generation
-    void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);
+    void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath, bool enableUserData = false);
 
     // Compile generated source code. Default implementation does nothing.
     virtual void compileSource(const std::vector<mx::FilePath>& /*sourceCodePaths*/) {};


### PR DESCRIPTION
This makes the MaterialX Codegen'ed GLSL shader more SPIR-V friendly and also Cross Compiler friendly. _However a side effect is that uniform initialization in the GLSL shader is not possible._

**Additional details:**
1. Separate and group uniforms:
The Hardware codegen will separate and group uniforms into three areas:
Private, Public and Sampler blocks
Public uniforms are inputs that should be published in a user interface for user interaction.
Private uniforms are internal variables needed by the system which should not be exposed in UI.
All texture based objects should be added to Sampler block

2. Emit uniform blocks with binding information
A new HwResourceBindingContext Interface and an implementation for `GlslResourceBindingContext 

`is added to allow GlslShaderGenerator to emit extended layout binding information where configured.

The configuration is `HwResourceBindingContext `is added to the Context by the caller as userdata called `udbinding (HW::USER_DATA_BINDING_CONTEXT)`

example shader code:
```
#version 400
#extension GL_ARB_shading_language_420pack : enable

#define M_PI 3.1415926535897932384626433832795
#define M_PI_INV 1.0/3.1415926535897932384626433832795
#define M_GOLDEN_RATIO 1.6180339887498948482045868343656
#define M_FLOAT_EPS 0.000001
#define MAX_LIGHT_SOURCES 9
#define DIRECTIONAL_ALBEDO_METHOD 0

#define BSDF vec3
#define EDF vec3
struct VDF { vec3 absorption; vec3 scattering; };
struct surfaceshader { vec3 color; vec3 transparency; };
struct volumeshader { VDF vdf; EDF edf; };
struct displacementshader { vec3 offset; float scale; };
struct lightshader { vec3 intensity; vec3 direction; };

// Uniform block: PrivateUniforms
layout (binding=1) uniform PrivateUniforms{
    mat4 u_envMatrix;
    int u_envRadianceMips;
    int u_envRadianceSamples;
    vec3 u_viewPosition;
    int u_numActiveLightSources;
};

// Uniform block: PublicUniforms
layout (binding=2) uniform PublicUniforms{
    float base;
    float diffuse_roughness;
    float specular;
...
    float GraphInstShader_rust_pow;
};

// Uniform block: SamplerUniforms
layout (binding=3) uniform sampler2D u_envRadiance;
layout (binding=4) uniform sampler2D u_envIrradiance;
layout (binding=5) uniform sampler2D node_image_float_23_file;
// Uniform block: LightData
layout (binding=12) uniform LightData{
    int type;
    vec3 direction;
    vec3 color;
    float intensity;
    vec3 position;
    float decay_rate;
    float inner_angle;
    float outer_angle;
    float exposure;
};

```