### PR TITLE
Fix regressions with layout bindings.

### DIFF
--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -16,6 +16,12 @@ GlslResourceBindingContext::GlslResourceBindingContext()
     _requiredExtensions.insert("GL_ARB_shading_language_420pack");
 }
 
+void GlslResourceBindingContext::initialize()
+{
+    // Reset bind location counter.
+    _hwBindLocation = 0;
+}
+
 void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage& stage)
 {
     ShaderGenerator& generator = context.getShaderGenerator();
@@ -26,30 +32,52 @@ void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage
     }
 }
 
-void GlslResourceBindingContext::emitUniformBlock(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage)
+void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const VariableBlock& uniforms, ShaderStage& stage)
 {
     ShaderGenerator& generator = context.getShaderGenerator();
+    const Syntax& syntax = generator.getSyntax();
 
-    generator.emitString("layout (binding=" + std::to_string(_hwBindLocation) + ") " + syntax->getUniformQualifier() + " " + uniforms.getName(), stage);
-    generator.emitScopeBegin(stage);
-    generator.emitVariableDeclarations(uniforms, EMPTY_STRING, Syntax::SEMICOLON, context, stage, false);
-    generator.emitScopeEnd(stage, true);
-    generator.emitLineBreak(stage);
-    _hwBindLocation++;
-}
-
-void GlslResourceBindingContext::emitSamplerBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage)
-{
-    ShaderGenerator& generator = context.getShaderGenerator();
-
-    for (size_t i = 0; i < uniforms.size(); ++i)
+    // First, emit all value uniforms in a block with single layout binding
+    bool hasValueUniforms = false;
+    for (auto uniform : uniforms.getVariableOrder())
     {
-        generator.emitString("layout (binding=" + std::to_string(_hwBindLocation) + ") " + syntax->getUniformQualifier() + " ", stage);
-        generator.emitVariableDeclaration(uniforms[i], EMPTY_STRING, context, stage, false);
-        generator.emitLineEnd(stage, true);
-        _hwBindLocation++;
+        if (uniform->getType() != Type::FILENAME)
+        {
+            hasValueUniforms = true;
+            break;
+        }
     }
-}
+    if (hasValueUniforms)
+    {
+        generator.emitLine("layout (binding=" + std::to_string(_hwBindLocation++) + ") " + 
+                           syntax.getUniformQualifier() + " " + uniforms.getName() + "_" + stage.getName(), 
+                           stage, false);
+        generator.emitScopeBegin(stage);
+        for (auto uniform : uniforms.getVariableOrder())
+        {
+            if (uniform->getType() != Type::FILENAME)
+            {
+                generator.emitLineBegin(stage);
+                generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);
+                generator.emitString(Syntax::SEMICOLON, stage);
+                generator.emitLineEnd(stage, false);
+            }
+        }
+        generator.emitScopeEnd(stage, true);
+    }
 
+    // Second, emit all sampler uniforms as separate uniforms with separate layout bindings
+    for (auto uniform : uniforms.getVariableOrder())
+    {
+        if (uniform->getType() == Type::FILENAME)
+        {
+            generator.emitString("layout (binding=" + std::to_string(_hwBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
+            generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);
+            generator.emitLineEnd(stage, true);
+        }
+    }
+
+    generator.emitLineBreak(stage);
+}
 
 }

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -27,37 +27,21 @@ public:
 
     static GlslResourceBindingContextPtr create() { return std::make_shared<GlslResourceBindingContext>(); }
 
+    // Initialize the context before generation starts.
+    void initialize() override;
+
     // Emit directives for stage
     void emitDirectives(GenContext& context, ShaderStage& stage) override;
 
-    // Emit blocks with resource binding information
-    void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) override
-    {
-        const string uniformBlockName(uniforms.getName());
-        if (uniformBlockName == HW::SAMPLER_UNIFORMS)
-        {
-            emitSamplerBlocks(context, uniforms, syntax, stage);
-        }
-        else
-        {
-            emitUniformBlock(context, uniforms, syntax, stage);
-        }
-    }
-
-    // Emits each sampler as a separate block
-    void emitSamplerBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage);
-
-    // Emits all uniforms group as a block
-    void emitUniformBlock(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage);
+    // Emit uniforms with binding information
+    void emitResourceBindings(GenContext& context, const VariableBlock& uniforms, ShaderStage& stage) override;
 
 protected:
-
     // List of required extensions
     StringSet _requiredExtensions;
 
     // Binding location
-    int _hwBindLocation = 0;
-
+    size_t _hwBindLocation = 0;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -293,6 +293,13 @@ ShaderPtr GlslShaderGenerator::generate(const string& name, ElementPtr element, 
     // any scientific notation which isn't supported by all OpenGL targets.
     ScopedFloatFormatting fmt(Value::FloatFormatFixed);
 
+    // Make sure we initialize/reset the binding context before generation.
+    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    if (resourceBindingCtx)
+    {
+        resourceBindingCtx->initialize();
+    }
+
     // Emit code for vertex shader stage
     ShaderStage& vs = shader->getStage(Stage::VERTEX);
     emitVertexStage(shader->getGraph(), context, vs);
@@ -308,8 +315,7 @@ ShaderPtr GlslShaderGenerator::generate(const string& name, ElementPtr element, 
 
 void GlslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const
 {
-    HwResourceBindingContextPtr resourceBindingCtx =
-        context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
 
     // Add directives
     emitLine("#version " + getVersion(), stage, false);
@@ -336,7 +342,7 @@ void GlslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& 
             emitComment("Uniform block: " + uniforms.getName(), stage);
             if (resourceBindingCtx)
             {
-                resourceBindingCtx->emitResourceBindingBlocks(context, uniforms, _syntax, stage);
+                resourceBindingCtx->emitResourceBindings(context, uniforms, stage);
             }
             else
             {
@@ -405,9 +411,7 @@ void GlslShaderGenerator::emitSpecularEnvironment(GenContext& context, ShaderSta
 
 void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const
 {
-
-    HwResourceBindingContextPtr resourceBindingCtx =
-        context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
 
     // Add directives
     emitLine("#version " + getVersion(), stage, false);
@@ -448,7 +452,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
             emitComment("Uniform block: " + uniforms.getName(), stage);
             if (resourceBindingCtx)
             {
-                resourceBindingCtx->emitResourceBindingBlocks(context, uniforms, _syntax, stage);
+                resourceBindingCtx->emitResourceBindings(context, uniforms, stage);
             }
             else
             {

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -190,7 +190,6 @@ namespace HW
     extern const string VERTEX_DATA;      // Connector block for data transfer from vertex stage to pixel stage.
     extern const string PRIVATE_UNIFORMS; // Uniform inputs set privately by application.
     extern const string PUBLIC_UNIFORMS;  // Uniform inputs visible in UI and set by user.
-    extern const string SAMPLER_UNIFORMS; // Uniform inputs for all sampler texture objects.
     extern const string LIGHT_DATA;       // Uniform inputs for light sources.
     extern const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
@@ -401,12 +400,14 @@ class HwResourceBindingContext : public GenUserData
 public:
     virtual ~HwResourceBindingContext() {}
 
+    // Initialize the context before generation starts.
+    virtual void initialize() = 0;
+
     // Emit directives required for binding support 
     virtual void emitDirectives(GenContext& context, ShaderStage& stage) = 0;
 
-    // Emit resource blocks with binding information
-    virtual void emitResourceBindingBlocks(GenContext& context, const VariableBlock& uniforms, SyntaxPtr syntax, ShaderStage& stage) = 0;
-
+    // Emit uniforms with binding information
+    virtual void emitResourceBindings(GenContext& context, const VariableBlock& uniforms, ShaderStage& stage) = 0;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -122,12 +122,6 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
     REQUIRE_NOTHROW(mx::HwShaderGenerator::bindLightShader(*spotLightShader, 66, context));
 }
 
-// Add user data to context
-void GlslShaderGeneratorTester::addUserData(mx::GenContext& context)
-{
-    context.pushUserData(mx::HW::USER_DATA_BINDING_CONTEXT, mx::GlslResourceBindingContext::create());
-}
-
 static void generateGlslCode(bool generateLayout = false)
 {
     const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
@@ -147,7 +141,14 @@ static void generateGlslCode(bool generateLayout = false)
     const mx::FilePath logPath(generateLayout ? "genglsl_glsl420_layout_generate_test.txt" : "genglsl_glsl400_generate_test.txt");
 
     GlslShaderGeneratorTester tester(mx::GlslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
-    tester.validate(genOptions, optionsFilePath, generateLayout);
+
+    if (generateLayout)
+    {
+        // Set binding context to handle resource binding layouts
+        tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, mx::GlslResourceBindingContext::create());
+    }
+
+    tester.validate(genOptions, optionsFilePath);
 }
 
 TEST_CASE("GenShader: GLSL Shader Generation", "[genglsl]")

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -47,8 +47,6 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
         loadLibrary(lightDir / mx::FilePath("light_rig_test_1.mtlx"), _dependLib);
     }
 
-    void addUserData(mx::GenContext& context) override;
-
   protected:
     void getImplementationWhiteList(mx::StringSet& whiteList) override
     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -192,7 +192,10 @@ class ShaderGeneratorTester
     virtual void addUnitSystem();
 
     // Add user data 
-    virtual void addUserData(mx::GenContext&) {}
+    void addUserData(const std::string& name, mx::GenUserDataPtr data)
+    {
+        _userData[name] = data;
+    }
 
     // Load in dependent libraries
     virtual void setupDependentLibraries();
@@ -213,7 +216,7 @@ class ShaderGeneratorTester
                               std::ostream& log, mx::StringVec testStages, mx::StringVec& sourceCode);
 
     // Run test for source code generation
-    void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath, bool enableUserData = false);
+    void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);
 
     // Compile generated source code. Default implementation does nothing.
     virtual void compileSource(const std::vector<mx::FilePath>& /*sourceCodePaths*/) {};
@@ -256,6 +259,7 @@ class ShaderGeneratorTester
     std::vector<mx::NodePtr> _lights;
     std::unordered_map<std::string, unsigned int> _lightIdentifierMap;
 
+    std::unordered_map<std::string, mx::GenUserDataPtr> _userData;
     mx::StringSet _usedImplementations;
 };
 

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -32,7 +32,5 @@ void bindPyGlslResourceBindingContext(py::module &mod)
         .def_static("create", &mx::GlslResourceBindingContext::create)
         .def(py::init<>())
         .def("emitDirectives", &mx::GlslResourceBindingContext::emitDirectives)
-        .def("emitResourceBindingBlocks", &mx::GlslResourceBindingContext::emitResourceBindingBlocks)
-        .def("emitSamplerBlocks", &mx::GlslResourceBindingContext::emitSamplerBlocks)
-        .def("emitUniformBlock", &mx::GlslResourceBindingContext::emitUniformBlock);
+        .def("emitResourceBindings", &mx::GlslResourceBindingContext::emitResourceBindings);
 }

--- a/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
@@ -22,7 +22,6 @@ void bindPyHwShaderGenerator(py::module& mod)
     mod.attr("HW_VERTEX_DATA") = mx::HW::VERTEX_DATA;
     mod.attr("HW_PRIVATE_UNIFORMS") = mx::HW::PRIVATE_UNIFORMS;
     mod.attr("HW_PUBLIC_UNIFORMS") = mx::HW::PUBLIC_UNIFORMS;
-    mod.attr("HW_SAMPLER_UNIFORMS") = mx::HW::SAMPLER_UNIFORMS;
     mod.attr("HW_LIGHT_DATA") = mx::HW::LIGHT_DATA;
     mod.attr("HW_PIXEL_OUTPUTS") = mx::HW::PIXEL_OUTPUTS;
     mod.attr("HW_ATTR_TRANSPARENT") =  mx::HW::ATTR_TRANSPARENT;
@@ -34,10 +33,9 @@ void bindPyHwShaderGenerator(py::module& mod)
         .def("unbindLightShaders", &mx::HwShaderGenerator::unbindLightShaders);
 }
 
-
 void bindPyHwResourceBindingContext(py::module& mod)
 {
     py::class_<mx::HwResourceBindingContext, mx::GenUserData, mx::HwResourceBindingContextPtr>(mod, "HwResourceBindingContext")
         .def("emitDirectives", &mx::HwResourceBindingContext::emitDirectives)
-        .def("emitResourceBindingBlocks", &mx::HwResourceBindingContext::emitResourceBindingBlocks);
+        .def("emitResourceBindings", &mx::HwResourceBindingContext::emitResourceBindings);
 }


### PR DESCRIPTION
This change list fixes the regression with MaterialXView not binding any image textures. Change done is mainly to remove the explicit "sampler" variable block. Instead of keeping a separate block for sampler uniforms the split is handled when the uniforms are emitted.

Also addressed is an issue with generated uniform block names being the same in vertex vs pixel stages, causing compile errors. Fixed by appending the stage name to the uniform block name.

One remaining issue is how to handle binding layout for the LightData uniform block, this was not addressed in the previous PR (#896) and the LightData uniform struct is emitted without a layout directive. To be discussed further.

The following code is now emitted if a binding context is used:

```
#version 400
#extension GL_ARB_shading_language_420pack : enable

...

// Uniform block: PrivateUniforms
layout (binding=1) uniform PrivateUniforms_pixel
{
    mat4 u_envMatrix;
    int u_envRadianceMips;
    int u_envRadianceSamples;
    vec3 u_viewPosition;
    int u_numActiveLightSources;
};
layout (binding=2) uniform sampler2D u_envRadiance;
layout (binding=3) uniform sampler2D u_envIrradiance;

// Uniform block: PublicUniforms
layout (binding=4) uniform PublicUniforms_pixel
{
    float base;
    vec3 base_color;
    float metalness;
   ...
};

struct LightData
{
    int type;
    vec3 direction;
    vec3 color;
    float intensity;
   ...
};

uniform LightData u_lightData[MAX_LIGHT_SOURCES];

in VertexData
{
    vec3 normalWorld;
    vec3 tangentWorld;
    vec3 positionWorld;
} vd;

// Pixel shader outputs
out vec4 out1;

...
```