### PR TITLE
Fix handling of included functions for convolution nodes

### DIFF
--- a/resources/Materials/TestSuite/stdlib/convolution/heighttonormal_in_nodegraph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/heighttonormal_in_nodegraph.mtlx
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<materialx version="1.37" xmlns:xi="http://www.w3.org/2001/XInclude">
+  <nodedef name="ND_MtlxShader" node="MtlxShader">
+    <output name="base_color_output" type="color3" />
+    <output name="normal_output" type="vector3" />
+  </nodedef>
+  <nodegraph name="Shader_graph" nodedef="ND_MtlxShader">
+    <constant name="node_color_0" type="color3">
+      <parameter name="value" type="color3" value=" 0.2, 0.2, 0.8" />
+    </constant>
+    <texcoord name="t1" type="vector2"/>
+    <multiply name="m1" type="vector2">
+      <input name="in1" type="vector2" nodename="t1"/>
+      <input name="in2" type="float" value="50"/>
+    </multiply>
+    <noise2d name="noise2d_float" type="float">
+      <input name="texcoord" type="vector2" nodename="m1"/>
+      <parameter name="amplitude" type="float" value="1.0" />
+    </noise2d>
+    <heighttonormal name="node_heighttonormal_2" type="vector3">
+      <input name="in" type="float" nodename="noise2d_float" />
+      <parameter name="scale" type="float" value="1.0" />
+    </heighttonormal>
+    <output name="base_color_output" type="color3" nodename="node_color_0" />
+    <output name="normal_output" type="vector3" nodename="node_heighttonormal_2" />
+  </nodegraph>
+  <MtlxShader name="GraphInst" type="multioutput" />
+  <output name="GraphInst_base_color_output" type="color3" nodename="GraphInst" output="base_color_output" />
+  <output name="GraphInst_normal_output" type="vector3" nodename="GraphInst" output="normal_output" />
+  <material name="heighttonormal_in_nodegraph">
+    <shaderref name="Shader" node="standard_surface">
+      <bindinput name="base" type="float" value="0.8" />
+      <bindinput name="base_color" type="color3" output="GraphInst_base_color_output" />
+      <bindinput name="normal" type="vector3" output="GraphInst_normal_output" />
+    </shaderref>
+  </material>
+</materialx>

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -504,13 +504,6 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitInclude("pbrlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_math.glsl", context, stage);
     emitLineBreak(stage);
 
-    // Emit texture sampling code
-    if (graph.hasClassification(ShaderNode::Classification::CONVOLUTION2D))
-    {
-        emitInclude("stdlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_sampling.glsl", context, stage);
-        emitLineBreak(stage);
-    }
-
     // Emit lighting and shadowing code
     if (lighting)
     {

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -101,6 +101,7 @@ const string GlslSyntax::INPUT_QUALIFIER = "in";
 const string GlslSyntax::OUTPUT_QUALIFIER = "out";
 const string GlslSyntax::UNIFORM_QUALIFIER = "uniform";
 const string GlslSyntax::CONSTANT_QUALIFIER = "const";
+const string GlslSyntax::SOURCE_FILE_EXTENSION = ".glsl";
 const StringVec GlslSyntax::VEC2_MEMBERS = { ".x", ".y" };
 const StringVec GlslSyntax::VEC3_MEMBERS = { ".x", ".y", ".z" };
 const StringVec GlslSyntax::VEC4_MEMBERS = { ".x", ".y", ".z", ".w" };

--- a/source/MaterialXGenGlsl/GlslSyntax.h
+++ b/source/MaterialXGenGlsl/GlslSyntax.h
@@ -26,6 +26,7 @@ class GlslSyntax : public Syntax
     const string& getOutputQualifier() const override { return OUTPUT_QUALIFIER; }
     const string& getConstantQualifier() const override { return CONSTANT_QUALIFIER; };
     const string& getUniformQualifier() const override { return UNIFORM_QUALIFIER; };
+    const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
 
     bool typeSupported(const TypeDesc* type) const override;
 
@@ -37,6 +38,7 @@ class GlslSyntax : public Syntax
     static const string OUTPUT_QUALIFIER;
     static const string UNIFORM_QUALIFIER;
     static const string CONSTANT_QUALIFIER;
+    static const string SOURCE_FILE_EXTENSION;
 
     static const StringVec VEC2_MEMBERS;
     static const StringVec VEC3_MEMBERS;

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -55,6 +55,16 @@ bool HeightToNormalNodeGlsl::acceptsInputType(const TypeDesc* type) const
     return (type == Type::FLOAT && type->isScalar());
 }
 
+void HeightToNormalNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
+{
+    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+        // Emit sampling functions
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        shadergen.emitInclude("stdlib/" + shadergen.getLanguage() + "/lib/mx_sampling.glsl", context, stage);
+        shadergen.emitLineBreak(stage);
+    END_SHADER_STAGE(shader, Stage::PIXEL)
+}
+
 void HeightToNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
@@ -17,6 +17,7 @@ class HeightToNormalNodeGlsl : public ConvolutionNode
   public:
     static ShaderNodeImplPtr create();
 
+    void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
     const string& getLanguage() const override;

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -224,11 +224,6 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     {
         emitLine(module, stage);
     }
-    if (graph.hasClassification(ShaderNode::Classification::CONVOLUTION2D))
-    {
-        // TODO: create a package with the convolution functions
-        // emitLine("import materialx::convolution::*", stage);
-    }
 
     // Add global constants and type definitions
     emitTypeDefinitions(context, stage);

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -180,6 +180,7 @@ public:
 
 const string MdlSyntax::CONST_QUALIFIER = "";
 const string MdlSyntax::UNIFORM_QUALIFIER = "uniform";
+const string MdlSyntax::SOURCE_FILE_EXTENSION = ".mdl";
 const StringVec MdlSyntax::VECTOR2_MEMBERS = { ".x", ".y" };
 const StringVec MdlSyntax::VECTOR3_MEMBERS = { ".x", ".y", ".z" };
 const StringVec MdlSyntax::VECTOR4_MEMBERS = { ".x", ".y", ".z", ".w" };

--- a/source/MaterialXGenMdl/MdlSyntax.h
+++ b/source/MaterialXGenMdl/MdlSyntax.h
@@ -30,6 +30,7 @@ public:
 
     const string& getConstantQualifier() const override { return CONST_QUALIFIER; };
     const string& getUniformQualifier() const override { return UNIFORM_QUALIFIER; };
+    const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
 
     string getSwizzledVariable(const string& srcName, const TypeDesc* srcType, const string& channels, const TypeDesc* dstType) const override;
 
@@ -41,6 +42,7 @@ public:
 
     static const string CONST_QUALIFIER;
     static const string UNIFORM_QUALIFIER;
+    static const string SOURCE_FILE_EXTENSION;
     static const StringVec VECTOR2_MEMBERS;
     static const StringVec VECTOR3_MEMBERS;
     static const StringVec VECTOR4_MEMBERS;

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
@@ -17,6 +17,7 @@ class BlurNodeMdl : public BlurNode
   public:
     static ShaderNodeImplPtr create();
 
+    void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   protected:

--- a/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
+++ b/source/MaterialXGenOgsFx/OgsFxShaderGenerator.cpp
@@ -304,14 +304,6 @@ void OgsFxShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& 
     emitInclude("pbrlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_math.glsl", context, stage);
     emitLineBreak(stage);
 
-    // Emit sampling code if needed
-    if (graph.hasClassification(ShaderNode::Classification::CONVOLUTION2D))
-    {
-        // Emit sampling functions
-        emitInclude("stdlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_sampling.glsl", context, stage);
-        emitLineBreak(stage);
-    }
-
     // Set the include file to use for uv transformations,
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)

--- a/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/source/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -151,14 +151,6 @@ ShaderPtr GlslFragmentGenerator::generate(const string& fragmentName, ElementPtr
         emitSpecularEnvironment(context, pixelStage);
     }
 
-    // Emit sampling code if needed
-    if (graph.hasClassification(ShaderNode::Classification::CONVOLUTION2D))
-    {
-        // Emit sampling functions
-        emitInclude("stdlib/" + GlslShaderGenerator::LANGUAGE + "/lib/mx_sampling.glsl", context, pixelStage);
-        emitLineBreak(pixelStage);
-    }
-
     // Set the include file to use for uv transformations,
     // depending on the vertical flip flag.
     _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "stdlib/" + GlslShaderGenerator::LANGUAGE +

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -216,14 +216,6 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     emitLine("#define GGX_DIRECTIONAL_ALBEDO_TABLE \"" + albedoTableFilePath + "\"", stage, false);
     emitLineBreak(stage);
 
-    // Emit sampling code if needed
-    if (graph.hasClassification(ShaderNode::Classification::CONVOLUTION2D))
-    {
-        // Emit sampling functions
-        emitInclude("stdlib/" + OslShaderGenerator::LANGUAGE + "/lib/mx_sampling.osl", context, stage);
-        emitLineBreak(stage);
-    }
-
     // Set the include file to use for uv transformations,
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -250,6 +250,7 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
 } // anonymous namespace
 
 const string OslSyntax::OUTPUT_QUALIFIER = "output";
+const string OslSyntax::SOURCE_FILE_EXTENSION = ".osl";
 const StringVec OslSyntax::VECTOR_MEMBERS  = { "[0]", "[1]", "[2]" };
 const StringVec OslSyntax::VECTOR2_MEMBERS = { ".x", ".y" };
 const StringVec OslSyntax::VECTOR4_MEMBERS = { ".x", ".y", ".z", ".w" };

--- a/source/MaterialXGenOsl/OslSyntax.h
+++ b/source/MaterialXGenOsl/OslSyntax.h
@@ -25,8 +25,10 @@ public:
 
     const string& getOutputQualifier() const override;
     const string& getConstantQualifier() const override { return EMPTY_STRING; };
+    const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
 
     static const string OUTPUT_QUALIFIER;
+    static const string SOURCE_FILE_EXTENSION;
     static const StringVec VECTOR_MEMBERS;
     static const StringVec VECTOR2_MEMBERS;
     static const StringVec VECTOR4_MEMBERS;

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -79,7 +79,7 @@ void BlurNode::emitFunctionDefinition(const ShaderNode&, GenContext& context, Sh
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         // Emit sampling functions
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-        shadergen.emitInclude("stdlib/" + shadergen.getLanguage() + "/lib/mx_sampling.glsl", context, stage);
+        shadergen.emitInclude("stdlib/" + shadergen.getLanguage() + "/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
         shadergen.emitLineBreak(stage);
     END_SHADER_STAGE(shader, Stage::PIXEL)
 }

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -74,6 +74,16 @@ void BlurNode::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& 
     }
 }
 
+void BlurNode::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
+{
+    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+        // Emit sampling functions
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        shadergen.emitInclude("stdlib/" + shadergen.getLanguage() + "/lib/mx_sampling.glsl", context, stage);
+        shadergen.emitLineBreak(stage);
+    END_SHADER_STAGE(shader, Stage::PIXEL)
+}
+
 void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)

--- a/source/MaterialXGenShader/Nodes/BlurNode.h
+++ b/source/MaterialXGenShader/Nodes/BlurNode.h
@@ -17,6 +17,7 @@ class BlurNode : public ConvolutionNode
   public:
     static ShaderNodeImplPtr create();
 
+    void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   protected:

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1021,12 +1021,6 @@ ShaderNode* ShaderGraph::createNode(const Node& node, GenContext& context)
     _nodeMap[name] = newNode;
     _nodeOrder.push_back(newNode.get());
 
-    // Check if the node is a convolution node and mark the graph as such.
-    if (newNode->hasClassification(Classification::CONVOLUTION2D))
-    {
-        _classification |= Classification::CONVOLUTION2D;
-    }
-
     // Check if any of the node inputs should be connected to the graph interface
     for (ValueElementPtr elem : node.getChildrenOfType<ValueElement>())
     {

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -121,7 +121,6 @@ const string ShaderNode::TEXTURE2D_GROUPNAME = "texture2d";
 const string ShaderNode::TEXTURE3D_GROUPNAME = "texture3d";
 const string ShaderNode::PROCEDURAL2D_GROUPNAME = "procedural2d";
 const string ShaderNode::PROCEDURAL3D_GROUPNAME = "procedural3d";
-const string ShaderNode::CONVOLUTION2D_GROUPNAME = "convolution2d";
 
 //
 // ShaderNode methods
@@ -229,10 +228,6 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
         else if (groupName == TEXTURE3D_GROUPNAME || groupName == PROCEDURAL3D_GROUPNAME)
         {
             groupClassification = Classification::SAMPLE3D;
-        }
-        else if (groupName == CONVOLUTION2D_GROUPNAME)
-        {
-            groupClassification = Classification::CONVOLUTION2D;
         }
     }
 

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -355,7 +355,6 @@ class ShaderNode
         // Types based on nodegroup
         static const uint32_t SAMPLE2D      = 1 << 17; /// Can be sampled in 2D (uv space)
         static const uint32_t SAMPLE3D      = 1 << 18; /// Can be sampled in 3D (position)
-        static const uint32_t CONVOLUTION2D = 1 << 19; /// Performs a convolution in 2D (uv space)
     };
 
     /// @struct ScopeInfo
@@ -400,7 +399,6 @@ class ShaderNode
     static const string TEXTURE3D_GROUPNAME;
     static const string PROCEDURAL2D_GROUPNAME;
     static const string PROCEDURAL3D_GROUPNAME;
-    static const string CONVOLUTION2D_GROUPNAME;
 
   public:
     /// Constructor.

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -148,6 +148,9 @@ class Syntax
     /// Return the characters used to end a multi line comments block.
     virtual const string& getEndMultiLineComment() const { return END_MULTI_LINE_COMMENT; };
 
+    /// Return the file extension used for source code files in this language.
+    virtual const string& getSourceFileExtension() const = 0;
+
     /// Return the array suffix to use for declaring an array type.
     virtual string getArrayTypeSuffix(const TypeDesc*, const Value&) const { return EMPTY_STRING; };
 

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -257,6 +257,11 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                 WARN("Failed to load in file: " + filename.asString() + "See: " + docValidLogFilename + " for details.");
             }
 
+            // For each new file clear the implementation cache.
+            // Since the new file might contain implementations with names
+            // colliding with implementations in previous test cases.
+            context.clearNodeImplementations();
+
             doc->importLibrary(dependLib, &copyOptions);
             ioTimer.endTimer();
 


### PR DESCRIPTION
Fix a bug triggered with using heighttonormal inside a nodegraph implementation (convolution classification was not tracked).

Instead of tracking the convolution classification, and emitting needed include files in the pixel stage, each convolution node is now responsible for emitting its own include files, if needed.