### PR TITLE
Correctly renames inputs, outputs, and nodes that have duplicate names.

### DIFF
--- a/source/MaterialXRuntime/Private/PvtPrim.cpp
+++ b/source/MaterialXRuntime/Private/PvtPrim.cpp
@@ -185,19 +185,26 @@ void PvtPrim::removeAttribute(const RtToken& name)
     }
 }
 
+void PvtPrim::setAttributeName(const RtToken& name, const RtToken& newName)
+{
+    PvtAttribute* attr = getAttribute(name);
+    if (attr)
+    {
+        attr->setName(newName);
+        _attrMap[newName] = attr->hnd();
+        _attrMap.erase(name);
+    }
+    else
+    {
+        throw ExceptionRuntimeError("Unable to set attribute name. Attribute named: " + name.str() + " does not exist.");
+    }
+}
 
 RtToken PvtPrim::renameAttribute(const RtToken& name, const RtToken& newName)
 {
     RtToken uniqueNewName = makeUniqueChildName(newName);
-    PvtAttribute* attr = getAttribute(name);
-    if (attr)
-    {
-        attr->setName(uniqueNewName);
-        _attrMap[uniqueNewName] = attr->hnd();
-        _attrMap.erase(name);
-        return uniqueNewName;
-    }
-    return EMPTY_TOKEN;
+    setAttributeName(name, uniqueNewName);
+    return uniqueNewName;
 }
 
 RtAttrIterator PvtPrim::getAttributes(RtObjectPredicate predicate) const

--- a/source/MaterialXRuntime/Private/PvtPrim.h
+++ b/source/MaterialXRuntime/Private/PvtPrim.h
@@ -118,6 +118,7 @@ public:
 
     void removeAttribute(const RtToken& name);
 
+    void setAttributeName(const RtToken& name, const RtToken& newName);
     RtToken renameAttribute(const RtToken& name, const RtToken& newName);
 
     PvtAttribute* getAttribute(const RtToken& name) const

--- a/source/MaterialXRuntime/Private/PvtPrim.h
+++ b/source/MaterialXRuntime/Private/PvtPrim.h
@@ -118,7 +118,7 @@ public:
 
     void removeAttribute(const RtToken& name);
 
-    void renameAttribute(const RtToken& name, const RtToken& newName);
+    RtToken renameAttribute(const RtToken& name, const RtToken& newName);
 
     PvtAttribute* getAttribute(const RtToken& name) const
     {

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -70,12 +70,7 @@ RtToken RtNodeGraph::renameInput(const RtToken& name, const RtToken& newName)
     }
     PvtPrim* socket = prim()->getChild(SOCKETS);
     RtToken newPrimAttrName = prim()->renameAttribute(name, newName);
-    RtToken newSocketAttrName = socket->renameAttribute(name, newPrimAttrName);
-    if (newSocketAttrName != newPrimAttrName)
-    {
-        throw ExceptionRuntimeError("Renamed socket name does not match renamed prim name");
-    }
- 
+    socket->setAttributeName(name, newPrimAttrName);
     return newPrimAttrName;
 }
 
@@ -108,12 +103,7 @@ RtToken RtNodeGraph::renameOutput(const RtToken& name, const RtToken& newName)
     }
     PvtPrim* socket = prim()->getChild(SOCKETS);
     RtToken newPrimAttrName = prim()->renameAttribute(name, newName);
-    RtToken newSocketAttrName = socket->renameAttribute(name, newPrimAttrName);
-    if (newSocketAttrName != newPrimAttrName)
-    {
-        throw ExceptionRuntimeError("Renamed socket name does not match renamed prim name");
-    }
- 
+    socket->setAttributeName(name, newPrimAttrName);
     return newPrimAttrName;
 }
 

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -44,8 +44,9 @@ RtPrim RtNodeGraph::createPrim(const RtToken& typeName, const RtToken& name, RtP
 RtInput RtNodeGraph::createInput(const RtToken& name, const RtToken& type, uint32_t flags)
 {
     PvtPrim* socket = prim()->getChild(SOCKETS);
-    socket->createOutput(name, type, flags | RtAttrFlag::SOCKET);
-    return prim()->createInput(name, type, flags)->hnd();
+    RtInput input = prim()->createInput(name, type, flags)->hnd();
+    socket->createOutput(input.getName(), type, flags | RtAttrFlag::SOCKET);
+    return input;
 }
 
 void RtNodeGraph::removeInput(const RtToken& name)
@@ -60,7 +61,7 @@ void RtNodeGraph::removeInput(const RtToken& name)
     prim()->removeAttribute(name);
 }
 
-void RtNodeGraph::renameInput(const RtToken& name, const RtToken& newName)
+RtToken RtNodeGraph::renameInput(const RtToken& name, const RtToken& newName)
 {
     PvtInput* input = prim()->getInput(name);
     if (!(input && input->isA<PvtInput>()))
@@ -68,15 +69,22 @@ void RtNodeGraph::renameInput(const RtToken& name, const RtToken& newName)
         throw ExceptionRuntimeError("No input found with name '" + name.str() + "'");
     }
     PvtPrim* socket = prim()->getChild(SOCKETS);
-    socket->renameAttribute(name, newName);
-    prim()->renameAttribute(name, newName);
+    RtToken newPrimAttrName = prim()->renameAttribute(name, newName);
+    RtToken newSocketAttrName = socket->renameAttribute(name, newPrimAttrName);
+    if (newSocketAttrName != newPrimAttrName)
+    {
+        throw ExceptionRuntimeError("Renamed socket name does not match renamed prim name");
+    }
+ 
+    return newPrimAttrName;
 }
 
 RtOutput RtNodeGraph::createOutput(const RtToken& name, const RtToken& type, uint32_t flags)
 {
     PvtPrim* socket = prim()->getChild(SOCKETS);
-    socket->createInput(name, type, flags | RtAttrFlag::SOCKET);
-    return prim()->createOutput(name, type, flags)->hnd();
+    RtOutput output = prim()->createOutput(name, type, flags)->hnd();
+    socket->createInput(output.getName(), type, flags | RtAttrFlag::SOCKET);
+    return output;
 }
 
 void RtNodeGraph::removeOutput(const RtToken& name)
@@ -91,7 +99,7 @@ void RtNodeGraph::removeOutput(const RtToken& name)
     prim()->removeAttribute(name);
 }
 
-void RtNodeGraph::renameOutput(const RtToken& name, const RtToken& newName)
+RtToken RtNodeGraph::renameOutput(const RtToken& name, const RtToken& newName)
 {
     PvtOutput* output = prim()->getOutput(name);
     if (!(output && output->isA<PvtOutput>()))
@@ -99,8 +107,14 @@ void RtNodeGraph::renameOutput(const RtToken& name, const RtToken& newName)
         throw ExceptionRuntimeError("No output found with name '" + name.str() + "'");
     }
     PvtPrim* socket = prim()->getChild(SOCKETS);
-    socket->renameAttribute(name, newName);
-    prim()->renameAttribute(name, newName);
+    RtToken newPrimAttrName = prim()->renameAttribute(name, newName);
+    RtToken newSocketAttrName = socket->renameAttribute(name, newPrimAttrName);
+    if (newSocketAttrName != newPrimAttrName)
+    {
+        throw ExceptionRuntimeError("Renamed socket name does not match renamed prim name");
+    }
+ 
+    return newPrimAttrName;
 }
 
 RtOutput RtNodeGraph::getInputSocket(const RtToken& name) const

--- a/source/MaterialXRuntime/RtNodeGraph.h
+++ b/source/MaterialXRuntime/RtNodeGraph.h
@@ -31,8 +31,10 @@ public:
     /// Remove an input attribute from the graph.
     void removeInput(const RtToken& name);
 
-    /// Rename an input attribute in the graph.
-    void renameInput(const RtToken& name, const RtToken& newName);
+    /// Rename an input attribute in the graph. Return the actual new name which may not
+    /// match the provided newName as it may already exist as a child node, input or output
+    /// name.
+    RtToken renameInput(const RtToken& name, const RtToken& newName);
 
     /// Add an output attribute to the graph.
     RtOutput createOutput(const RtToken& name, const RtToken& type, uint32_t flags = 0);
@@ -40,8 +42,10 @@ public:
     /// Remove an output attribute from the graph.
     void removeOutput(const RtToken& name);
 
-    /// Rename an output attribute in the graph.
-    void renameOutput(const RtToken& name, const RtToken& newName);
+    /// Rename an output attribute in the graph. Return the actual new name which may not
+    /// match the provided newName as it may already exist as a child node, input or output
+    /// name.
+    RtToken renameOutput(const RtToken& name, const RtToken& newName);
 
     /// Return the internal socket that corresponds
     /// to the named input attribute.

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -2431,4 +2431,71 @@ TEST_CASE("Runtime: logging", "[runtime]")
     REQUIRE("Info: Test" == logger->result);
 }
 
+TEST_CASE("Runtime: duplicate name", "[runtime]")
+{
+    mx::RtScopedApiHandle api;
+
+    mx::RtStagePtr stage = api->createStage(ROOT);
+
+    // Create a new nodedef for an add node.
+    mx::RtNodeDef addFloat = stage->createPrim("/ND_add_float", mx::RtNodeDef::typeName());
+    addFloat.setNode(ADD);
+    addFloat.createInput(IN1, mx::RtType::FLOAT);
+    addFloat.createInput(IN2, mx::RtType::FLOAT);
+    addFloat.createOutput(OUT, mx::RtType::FLOAT);
+    addFloat.registerMasterPrim();
+
+    // Create a nodegraph object.
+    mx::RtNodeGraph graph1 = stage->createPrim("/graph1", mx::RtNodeGraph::typeName());
+    REQUIRE(graph1.isValid());
+
+    // Create add node in the graph.
+    mx::RtNode add1Node = stage->createPrim("/graph1/add1", addFloat.getName());
+    REQUIRE(graph1.getNode(add1Node.getName()));
+
+    // Add an interface to the graph.
+    mx::RtInput Ainput = graph1.createInput(A, mx::RtType::FLOAT);
+    graph1.createOutput(OUT, mx::RtType::FLOAT);
+    REQUIRE(graph1.getPrim().getAttribute(A));
+    REQUIRE(graph1.getPrim().getAttribute(OUT));
+    REQUIRE(graph1.getInput(A));
+    REQUIRE(graph1.getOutput(OUT));
+    REQUIRE(graph1.getInputSocket(A));
+    REQUIRE(graph1.getOutputSocket(OUT));
+
+    mx::RtToken add1("add1");
+    mx::RtToken add2("add2");
+    mx::RtToken add3("add3");
+    mx::RtToken add4("add4");
+    mx::RtToken add5("add5");
+
+    // Test renaming the input to the name of the node
+    graph1.renameInput(A, add1);
+    REQUIRE(!graph1.getInput(A));
+    REQUIRE(!graph1.getInputSocket(A));
+    REQUIRE(!graph1.getInput(add1));
+    REQUIRE(!graph1.getInputSocket(add1));
+    REQUIRE(graph1.getInput(add2));
+    REQUIRE(graph1.getInputSocket(add2));
+
+    // Test renaming the output to the name of the node
+    graph1.renameOutput(OUT, add1);
+    REQUIRE(!graph1.getOutput(OUT));
+    REQUIRE(!graph1.getOutputSocket(OUT));
+    REQUIRE(!graph1.getOutput(add1));
+    REQUIRE(!graph1.getOutputSocket(add1));
+    REQUIRE(graph1.getOutput(add3));
+    REQUIRE(graph1.getOutputSocket(add3));
+
+    // Add an interface to the graph with the same name as the add node.
+    mx::RtInput input2 = graph1.createInput(add1, mx::RtType::FLOAT);
+    REQUIRE(graph1.getInput(add4));
+    REQUIRE(graph1.getInputSocket(add4));
+
+    // Add an output to the graph with the same name as the add node.
+    mx::RtOutput output2 = graph1.createOutput(add1, mx::RtType::FLOAT);
+    REQUIRE(graph1.getOutput(add5));
+    REQUIRE(graph1.getOutputSocket(add5));
+}
+
 #endif // MATERIALX_BUILD_RUNTIME

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -2469,33 +2469,68 @@ TEST_CASE("Runtime: duplicate name", "[runtime]")
     mx::RtToken add4("add4");
     mx::RtToken add5("add5");
 
+    auto duplicateCount = [graph1](const mx::RtToken& name)
+    {
+        unsigned int count = 0;
+        for (auto inputIttr = graph1.getInputs(); !inputIttr.isDone(); ++inputIttr)
+        {
+            auto input = *inputIttr;
+            if (input.getName() == name)
+            {
+                count++;
+            }
+        }
+        for (auto outputIttr = graph1.getOutputs(); !outputIttr.isDone(); ++outputIttr)
+        {
+            auto output = *outputIttr;
+            if (output.getName() == name)
+            {
+                count++;
+            }
+        }
+        for (auto nodeIttr = graph1.getNodes(); !nodeIttr.isDone(); ++nodeIttr)
+        {
+            auto node = *nodeIttr;
+            if (node.getName() == name)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    };
+
     // Test renaming the input to the name of the node
-    graph1.renameInput(A, add1);
+    REQUIRE(graph1.renameInput(A, add1) == add2);
     REQUIRE(!graph1.getInput(A));
     REQUIRE(!graph1.getInputSocket(A));
     REQUIRE(!graph1.getInput(add1));
     REQUIRE(!graph1.getInputSocket(add1));
     REQUIRE(graph1.getInput(add2));
     REQUIRE(graph1.getInputSocket(add2));
+    REQUIRE(duplicateCount(add2) == 1);
 
     // Test renaming the output to the name of the node
-    graph1.renameOutput(OUT, add1);
+    REQUIRE(graph1.renameOutput(OUT, add1) == add3);
     REQUIRE(!graph1.getOutput(OUT));
     REQUIRE(!graph1.getOutputSocket(OUT));
     REQUIRE(!graph1.getOutput(add1));
     REQUIRE(!graph1.getOutputSocket(add1));
     REQUIRE(graph1.getOutput(add3));
     REQUIRE(graph1.getOutputSocket(add3));
+    REQUIRE(duplicateCount(add3) == 1);
 
     // Add an interface to the graph with the same name as the add node.
     mx::RtInput input2 = graph1.createInput(add1, mx::RtType::FLOAT);
     REQUIRE(graph1.getInput(add4));
     REQUIRE(graph1.getInputSocket(add4));
+    REQUIRE(duplicateCount(add4) == 1);
 
     // Add an output to the graph with the same name as the add node.
     mx::RtOutput output2 = graph1.createOutput(add1, mx::RtType::FLOAT);
     REQUIRE(graph1.getOutput(add5));
     REQUIRE(graph1.getOutputSocket(add5));
+    REQUIRE(duplicateCount(add5) == 1);
 }
 
 #endif // MATERIALX_BUILD_RUNTIME


### PR DESCRIPTION
This was a bigger change then I was hoping for, please take a look and let me know if you have any concerns. It seems to make things work on the LookdevX-side (separate review after this one assuming this is ok).