### PR TITLE
LOOKDEVX-290 : Change to not write inputsockets on file write.

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -389,6 +389,14 @@ namespace
                             const RtToken inputType(elem->getType());
                             RtInput input = schema.createInput(socketName, inputType);
                             socket = schema.getInputSocket(input.getName());
+
+                            // Set the input value
+                            const string& valueStr = elem->getValueString();
+                            if (!valueStr.empty())
+                            {
+                                const RtToken portType(elem->getType());
+                                RtValue::fromString(portType, valueStr, input.getValue());
+                            }
                         }
 
                         RtInput input(findInputOrThrow(inputName, node)->hnd());
@@ -784,9 +792,10 @@ namespace
                                 valueElem->setInterfaceName(source.getName());
                             }
                         }
-                        else
+                        const string& inputValueString = input.getValueString(); 
+                        if (!inputValueString.empty())
                         {
-                            valueElem->setValueString(input.getValueString());
+                            valueElem->setValueString(inputValueString);
                         }
                     }
                     else
@@ -797,8 +806,13 @@ namespace
                             RtOutput source = input.getConnection();
                             if (source.isSocket())
                             {
-                                // This is a connection to the internal socket of a graph
+                                // This is a connection to the internal socket of a graph                                
                                 valueElem->setInterfaceName(source.getName());
+                                const string& inputValueString = input.getValueString();
+                                if (!inputValueString.empty())
+                                {
+                                    valueElem->setValueString(inputValueString);
+                                }
                             }
                             else
                             {
@@ -925,7 +939,7 @@ namespace
 
         RtNodeGraph nodegraph(src->hnd());
 
-        if (!writeOptions || writeOptions->writeNodeGraphInputs)
+        if (writeOptions && writeOptions->writeNodeGraphInputs)
         {
             // Write inputs/parameters.
             RtObjTypePredicate<RtInput> inputsFilter;
@@ -1165,6 +1179,10 @@ namespace
             {
                 writeNodeGraph(prim, doc, writeOptions);
             }
+            else if (typeName == RtBackdrop::typeName())
+            {
+                //writeBackdrop(prim, doc)
+            }
             else if (typeName != RtLook::typeName() &&
                      typeName != RtLookGroup::typeName() &&
                      typeName != RtMaterialAssign::typeName() &&
@@ -1277,7 +1295,7 @@ RtReadOptions::RtReadOptions() :
 
 RtWriteOptions::RtWriteOptions() :
     writeIncludes(true),
-    writeNodeGraphInputs(true),
+    writeNodeGraphInputs(false),
     writeFilter(nullptr),
     materialWriteOp(NONE),
     desiredMajorVersion(MATERIALX_MAJOR_VERSION),

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -59,7 +59,7 @@ class RtWriteOptions
     /// includes rather than explicit data.  Defaults to true.
     bool writeIncludes;
 
-    // If true, writes out nodegraph inputs
+    // If true, writes out nodegraph inputs. Default value is false.
     bool writeNodeGraphInputs;
 
     /// Filter function type used for filtering objects during write.


### PR DESCRIPTION
- Set writeNodeGraphInputs to false by default to not write out inputsockets. as nodegraph <inputs>
- Always write inputs on nodes even when connected to inputsockets.
- Update read to set inputsocket values based on the corresponding nodegraph node input value.
 