### PR TITLE
LOOKDEVX-235 : Nodegraph version support (part 2).

### DIFF
--- a/libraries/adsk/adsklib/colorcorrect.mtlx
+++ b/libraries/adsk/adsklib/colorcorrect.mtlx
@@ -1,116 +1,119 @@
 <?xml version="1.0"?>
 <materialx version="1.38" xmlns:xi="http://www.w3.org/2001/XInclude">
- <nodedef name="ND_colorcorrect" node="colorcorrect" nodegroup="adjustment" 
-          version="1.0" isdefaultversion="true" namespace="adsk">
-    <parameter name="color" type="color3" value="0.5, 0.5, 0.5" />
-    <parameter name="alpha" type="float" value="1" />
-    <input name="HSV" type="vector3" value="0, 1, 1" />
-    <input name="color_gain" type="color3" value="1, 1, 1" />
-    <input name="alpha_gain" type="float" value="1" />
-    <input name="color_offset" type="color3" value="0, 0, 0" />
-    <input name="alpha_offset" type="float" value="0" />
-    <input name="color_gamma" type="color3" value="1 1, 1" />
-    <input name="alpha_gamma" type="float" value="1" />
-    <input name="unpremultiply_input" type="boolean" value="false" />
-    <input name="premultiply_input" type="boolean" value="false" />
-    <parameter name="clamp_color" type="boolean" value="false" />
-    <input name="min_color" type="color3" value="0, 0, 0" />
-    <input name="max_color" type="color3" value="1, 1, 1" />
-    <parameter name="clamp_alpha" type="boolean" value="false" />
-    <input name="min_alpha" type="float" value="0" />
-    <input name="max_alpha" type="float" value="1" />
-    <output name="outColor" type="color3" />
-    <output name="outAlpha" type="float" />
-  </nodedef>
-  <nodegraph name="NG_colorcorrect" nodedef="adsk:ND_colorcorrect" namespace="adsk">
-    <range name="AlphaClampAndGamma" type="float">
-      <input name="in" type="float" nodename="AlphaOffset" />
-      <input name="gamma" type="float" value="1" interfacename="alpha_gamma" />
-      <parameter name="doclamp" type="boolean" value="false" interfacename="clamp_alpha" />
-      <input name="inlow" type="float" value="0.0" interfacename="min_alpha" />
-      <input name="inhigh" type="float" value="1.0" interfacename="max_alpha" />
-      <input name="outlow" type="float" value="0.0" interfacename="min_alpha" />
-      <input name="outhigh" type="float" value="1.0" interfacename="max_alpha"/>
-    </range>
-    <multiply name="AlphaGain" type="float">
-      <input name="in1" type="float" nodename="extractAlphaForGain" />
-      <input name="in2" type="float" value="1.0" interfacename="alpha_gain" />
-    </multiply>
-    <add name="AlphaOffset" type="float">
-      <input name="in1" type="float" nodename="AlphaGain" />
-      <input name="in2" type="float" value="0.0" interfacename="alpha_offset" />
-    </add>
-    <range name="ColorClampAndGamma" type="color3">
-      <input name="in" type="color3" nodename="ColorOffset" />
-      <input name="gamma" type="color3" value="1, 1, 1" interfacename="color_gamma" />
-      <input name="inlow" type="color3" value="0.0, 0.0, 0.0" interfacename="min_color" />
-      <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" interfacename="max_color" />
-      <input name="outlow" type="color3" value="0.0, 0.0, 0.0" interfacename="min_color" />
-      <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" interfacename="max_color" />
-      <parameter name="doclamp" type="boolean" value="false" interfacename="clamp_color" />
-    </range>
-    <multiply name="ColorGain" type="color3">
-      <input name="in1" type="color3" nodename="HSV_adjust" />
-      <input name="in2" type="color3" value="1.0, 1.0, 1.0" interfacename="color_gain" />
-    </multiply>
-    <add name="ColorOffset" type="color3">
-      <input name="in1" type="color3" nodename="ColorGain" />
-      <input name="in2" type="color3" value="0.0, 0.0, 0.0" interfacename="color_offset" />
-    </add>
-    <combine2 name="CombineColorAlpha" type="color4">
-      <input name="in1" type="color3" nodename="ColorClampAndGamma" />
-      <input name="in2" type="float" nodename="AlphaClampAndGamma" />
-    </combine2>
-    <hsvadjust name="HSV_adjust" type="color3">
-      <input name="in" type="color3" nodename="extractColorForHsv" />
-      <input name="amount" type="vector3" value="0.0, 1.0, 1.0" interfacename="HSV" />
-    </hsvadjust>
-    <premult name="premultiplyColor" type="color4">
-      <input name="in" type="color4" nodename="combineInput" />
-    </premult>
-    <ifequal name="if_premultiply_condition" type="color4">
-      <input name="value2" type="boolean" value="true" />
-      <input name="in1" type="color4" nodename="premultiplyColor" />
-      <input name="in2" type="color4" nodename="combineInput" />
-      <input name="value1" type="boolean" value="false" interfacename="premultiply_input" />
-    </ifequal>
-    <unpremult name="unpremultiply" type="color4">
-      <input name="in" type="color4" nodename="CombineColorAlpha" />
-    </unpremult>
-    <ifequal name="if_unpremultiply_condition" type="color4">
-      <input name="value2" type="boolean" value="true" />
-      <input name="in1" type="color4" nodename="unpremultiply" />
-      <input name="in2" type="color4" nodename="CombineColorAlpha" />
-      <input name="value1" type="boolean" value="false" interfacename="unpremultiply_input" />
-    </ifequal>
-    <swizzle name="outputColor" type="color3">
-      <input name="in" type="color4" nodename="if_unpremultiply_condition" />
-      <parameter name="channels" type="string" value="rgb" />
-    </swizzle>
-    <swizzle name="outputAlpha" type="float">
-      <input name="in" type="color4" nodename="if_unpremultiply_condition" />
-      <parameter name="channels" type="string" value="a" />
-    </swizzle>
-    <swizzle name="extractColorForHsv" type="color3">
-      <input name="in" type="color4" nodename="if_premultiply_condition" />
-      <parameter name="channels" type="string" value="rgb" />
-    </swizzle>
-    <swizzle name="extractAlphaForGain" type="float">
-      <input name="in" type="color4" nodename="if_premultiply_condition" />
-      <parameter name="channels" type="string" value="a" />
-    </swizzle>
-    <constant name="inputColor" type="color3">
-      <parameter name="value" type="color3" value="0.5, 0.5, 0.5" interfacename="color" />
-    </constant>
-    <constant name="inputAlpha" type="float">
-      <parameter name="value" type="float" value="1" interfacename="alpha" />
-    </constant>
-    <combine2 name="combineInput" type="color4">
-      <input name="in1" type="color3" nodename="inputColor" />
-      <input name="in2" type="float" nodename="inputAlpha" />
-    </combine2>
-    <output name="outColor" type="color3" nodename="outputColor" />
-    <output name="outAlpha" type="float" nodename="outputAlpha" />
-  </nodegraph>
-  
+
+   <!-- Sample color correct interface. Versioned and namespaced -->
+   <nodedef name="ND_colorcorrect" node="colorcorrect" nodegroup="adjustment" version="1.0" isdefaultversion="true" namespace="adsk">
+      <parameter name="color" type="color3" value="0.5, 0.5, 0.5" />
+      <parameter name="alpha" type="float" value="1" />
+      <input name="HSV" type="vector3" value="0, 1, 1" />
+      <input name="color_gain" type="color3" value="1, 1, 1" />
+      <input name="alpha_gain" type="float" value="1" />
+      <input name="color_offset" type="color3" value="0, 0, 0" />
+      <input name="alpha_offset" type="float" value="0" />
+      <input name="color_gamma" type="color3" value="1 1, 1" />
+      <input name="alpha_gamma" type="float" value="1" />
+      <input name="unpremultiply_input" type="boolean" value="false" />
+      <input name="premultiply_input" type="boolean" value="false" />
+      <parameter name="clamp_color" type="boolean" value="false" />
+      <input name="min_color" type="color3" value="0, 0, 0" />
+      <input name="max_color" type="color3" value="1, 1, 1" />
+      <parameter name="clamp_alpha" type="boolean" value="false" />
+      <input name="min_alpha" type="float" value="0" />
+      <input name="max_alpha" type="float" value="1" />
+      <output name="outColor" type="color3" />
+      <output name="outAlpha" type="float" />
+   </nodedef>
+
+   <!-- Sample color correct implementation. Versioned and namespaced -->
+   <nodegraph name="NG_colorcorrect" nodedef="adsk:ND_colorcorrect" namespace="adsk" version="1.0">
+      <range name="AlphaClampAndGamma" type="float">
+         <input name="in" type="float" nodename="AlphaOffset" />
+         <input name="gamma" type="float" value="1" interfacename="alpha_gamma" />
+         <parameter name="doclamp" type="boolean" value="false" interfacename="clamp_alpha" />
+         <input name="inlow" type="float" value="0.0" interfacename="min_alpha" />
+         <input name="inhigh" type="float" value="1.0" interfacename="max_alpha" />
+         <input name="outlow" type="float" value="0.0" interfacename="min_alpha" />
+         <input name="outhigh" type="float" value="1.0" interfacename="max_alpha"/>
+      </range>
+      <multiply name="AlphaGain" type="float">
+         <input name="in1" type="float" nodename="extractAlphaForGain" />
+         <input name="in2" type="float" value="1.0" interfacename="alpha_gain" />
+      </multiply>
+      <add name="AlphaOffset" type="float">
+         <input name="in1" type="float" nodename="AlphaGain" />
+         <input name="in2" type="float" value="0.0" interfacename="alpha_offset" />
+      </add>
+      <range name="ColorClampAndGamma" type="color3">
+         <input name="in" type="color3" nodename="ColorOffset" />
+         <input name="gamma" type="color3" value="1, 1, 1" interfacename="color_gamma" />
+         <input name="inlow" type="color3" value="0.0, 0.0, 0.0" interfacename="min_color" />
+         <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" interfacename="max_color" />
+         <input name="outlow" type="color3" value="0.0, 0.0, 0.0" interfacename="min_color" />
+         <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" interfacename="max_color" />
+         <parameter name="doclamp" type="boolean" value="false" interfacename="clamp_color" />
+      </range>
+      <multiply name="ColorGain" type="color3">
+         <input name="in1" type="color3" nodename="HSV_adjust" />
+         <input name="in2" type="color3" value="1.0, 1.0, 1.0" interfacename="color_gain" />
+      </multiply>
+      <add name="ColorOffset" type="color3">
+         <input name="in1" type="color3" nodename="ColorGain" />
+         <input name="in2" type="color3" value="0.0, 0.0, 0.0" interfacename="color_offset" />
+      </add>
+      <combine2 name="CombineColorAlpha" type="color4">
+         <input name="in1" type="color3" nodename="ColorClampAndGamma" />
+         <input name="in2" type="float" nodename="AlphaClampAndGamma" />
+      </combine2>
+      <hsvadjust name="HSV_adjust" type="color3">
+         <input name="in" type="color3" nodename="extractColorForHsv" />
+         <input name="amount" type="vector3" value="0.0, 1.0, 1.0" interfacename="HSV" />
+      </hsvadjust>
+      <premult name="premultiplyColor" type="color4">
+         <input name="in" type="color4" nodename="combineInput" />
+      </premult>
+      <ifequal name="if_premultiply_condition" type="color4">
+         <input name="value2" type="boolean" value="true" />
+         <input name="in1" type="color4" nodename="premultiplyColor" />
+         <input name="in2" type="color4" nodename="combineInput" />
+         <input name="value1" type="boolean" value="false" interfacename="premultiply_input" />
+      </ifequal>
+      <unpremult name="unpremultiply" type="color4">
+         <input name="in" type="color4" nodename="CombineColorAlpha" />
+      </unpremult>
+      <ifequal name="if_unpremultiply_condition" type="color4">
+         <input name="value2" type="boolean" value="true" />
+         <input name="in1" type="color4" nodename="unpremultiply" />
+         <input name="in2" type="color4" nodename="CombineColorAlpha" />
+         <input name="value1" type="boolean" value="false" interfacename="unpremultiply_input" />
+      </ifequal>
+      <swizzle name="outputColor" type="color3">
+         <input name="in" type="color4" nodename="if_unpremultiply_condition" />
+         <parameter name="channels" type="string" value="rgb" />
+      </swizzle>
+      <swizzle name="outputAlpha" type="float">
+         <input name="in" type="color4" nodename="if_unpremultiply_condition" />
+         <parameter name="channels" type="string" value="a" />
+      </swizzle>
+      <swizzle name="extractColorForHsv" type="color3">
+         <input name="in" type="color4" nodename="if_premultiply_condition" />
+         <parameter name="channels" type="string" value="rgb" />
+      </swizzle>
+      <swizzle name="extractAlphaForGain" type="float">
+         <input name="in" type="color4" nodename="if_premultiply_condition" />
+         <parameter name="channels" type="string" value="a" />
+      </swizzle>
+      <constant name="inputColor" type="color3">
+         <parameter name="value" type="color3" value="0.5, 0.5, 0.5" interfacename="color" />
+      </constant>
+      <constant name="inputAlpha" type="float">
+         <parameter name="value" type="float" value="1" interfacename="alpha" />
+      </constant>
+      <combine2 name="combineInput" type="color4">
+         <input name="in1" type="color3" nodename="inputColor" />
+         <input name="in2" type="float" nodename="inputAlpha" />
+      </combine2>
+      <output name="outColor" type="color3" nodename="outputColor" />
+      <output name="outAlpha" type="float" nodename="outputAlpha" />
+   </nodegraph>
+
 </materialx>

--- a/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
+++ b/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
-  <nodedef name="ND_parque_03_material" node="parque_03_material" nodegroup="material">
+   <!-- Sample parquet material interface. Versioned and namespaced -->
+   <nodedef name="ND_parque_03_material" node="parque_03_material" nodegroup="material" version="1.0" isdefaultversion="true" namespace="adsk">
     <output name="out" type="material" value="" />
   </nodedef>
-  <nodegraph name="NG_parque_03_material1" nodedef="ND_parque_03_material">
+
+   <!-- Sample parquet material implemtnation. Versioned and namespaced -->
+   <nodegraph name="NG_parque_03_material1" nodedef="adsk:ND_parque_03_material" version="1.0" namespace="adsk">
     <displacement name="parque_03_displacement_shader" type="displacementshader" />
     <surfacematerial name="parquet_03_material" type="material">
       <input name="surfaceshader" type="surfaceshader" nodename="parquet_03_surface_shader" />

--- a/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
+++ b/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
    <!-- Sample parquet material interface. Versioned and namespaced -->
-   <nodedef name="ND_parque_03_material" node="parque_03_material" nodegroup="material" version="1.0" isdefaultversion="true" namespace="adsk">
+   <nodedef name="ND_parquet_03_material" node="parquet_03_material" nodegroup="material" version="1.0" isdefaultversion="true" namespace="adsk">
     <output name="out" type="material" value="" />
   </nodedef>
 
    <!-- Sample parquet material implemtnation. Versioned and namespaced -->
-   <nodegraph name="NG_parque_03_material1" nodedef="adsk:ND_parque_03_material" version="1.0" namespace="adsk">
-    <displacement name="parque_03_displacement_shader" type="displacementshader" />
+   <nodegraph name="NG_parquet_03_material1" nodedef="adsk:ND_parquet_03_material" version="1.0" namespace="adsk">
+    <displacement name="parquet_03_displacement_shader" type="displacementshader" />
     <surfacematerial name="parquet_03_material" type="material">
       <input name="surfaceshader" type="surfaceshader" nodename="parquet_03_surface_shader" />
-      <input name="displacementshader" type="displacementshader" nodename="parque_03_displacement_shader" />
+      <input name="displacementshader" type="displacementshader" nodename="parquet_03_displacement_shader" />
     </surfacematerial>
     <parquet_03 name="parquet_03_surface_shader" type="surfaceshader" />
     <output name="out" type="material" nodename="parquet_03_material" />

--- a/libraries/adsk/shaders/wood/parquet_3/ND_parquet_03_shader.mtlx
+++ b/libraries/adsk/shaders/wood/parquet_3/ND_parquet_03_shader.mtlx
@@ -1,53 +1,56 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodedef name="ND_parquet_03_shader" node="parquet_03" nodegroup="Shaders" version="1.0" isdefaultversion="true">
-    <output name="surfaceshader" type="surfaceshader"/>
-  </nodedef>
-  <nodegraph name="NG_parquet_03_shader" nodedef="ND_parquet_03_shader">
-    <constant name="colorCorrect_diffuse" type="color3">
-      <parameter name="value" type="color3" value="1.12, 0.99, 0.63" />
-    </constant>
-    <extract name="extract_color3_1" type="float">
-      <input name="in" type="color3" nodename="remap_color3_1" />
-    </extract>
-    <multiply name="multiply_color" type="color3">
-      <input name="in1" type="color3" nodename="multiply_difuse" />
-      <input name="in2" type="color3" nodename="colorCorrect_diffuse" />
-    </multiply>
-    <multiply name="multiply_difuse" type="color3">
-      <input name="in1" type="color3" nodename="parquet_03_basecolor" />
-      <input name="in2" type="color3" value="1.1, 1.1, 1.1" />
-    </multiply>
-    <normalmap name="normalmap_1" type="vector3">
-      <input name="in" type="vector3" nodename="parquet_03_normal" />
-    </normalmap>
-    <image name="parquet_03_basecolor" type="color3">
-      <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_basecolor_2k_acescg.exr" />
-    </image>
-    <image name="parquet_03_normal" type="vector3">
-      <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_normal_2k_raw.exr" />
-    </image>
-    <image name="parquet_03_roughness" type="color3">
-      <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_roughness_2k_raw.exr" />
-    </image>
-    <standard_surface name="parquete_03_sts" type="surfaceshader">
-      <input name="base_color" type="color3" nodename="saturate_color" />
-      <input name="diffuse_roughness" type="float" value="1" />
-      <input name="specular_roughness" type="float" value="0.5" />
-      <input name="coat" type="float" value="1" />
-      <input name="coat_roughness" type="float" nodename="extract_color3_1" />
-      <input name="normal" type="vector3" nodename="normalmap_1" />
-    </standard_surface>
-    <remap name="remap_color3_1" type="color3">
-      <input name="in" type="color3" nodename="parquet_03_roughness" />
-      <input name="inhigh" type="color3" value="0.1, 0.1, 0.1" />
-      <input name="outhigh" type="color3" value="0.6, 0.6, 0.6" />
-    </remap>
-    <saturate name="saturate_color" type="color3">
-      <input name="in" type="color3" nodename="multiply_color" />
-      <input name="amount" type="float" value="0.9" />
-      <parameter name="lumacoeffs" type="color3" value="1, 1, 1" />
-    </saturate>
-    <output name="surfaceshader" type="surfaceshader" nodename="parquete_03_sts" />
-  </nodegraph>
+   <!-- Sample parquet shader interface. Versioned and namespaced -->
+   <nodedef name="ND_parquet_03_shader" node="parquet_03" nodegroup="shader" version="1.0" isdefaultversion="true" namespace="adsk">
+      <output name="surfaceshader" type="surfaceshader"/>
+   </nodedef>
+
+   <!-- Sample parquet shader implementation. Versioned and namespaced -->
+   <nodegraph name="NG_parquet_03_shader" nodedef="adsk:ND_parquet_03_shader" version="1.0" namespace="adsk">
+      <constant name="colorCorrect_diffuse" type="color3">
+         <parameter name="value" type="color3" value="1.12, 0.99, 0.63" />
+      </constant>
+      <extract name="extract_color3_1" type="float">
+         <input name="in" type="color3" nodename="remap_color3_1" />
+      </extract>
+      <multiply name="multiply_color" type="color3">
+         <input name="in1" type="color3" nodename="multiply_difuse" />
+         <input name="in2" type="color3" nodename="colorCorrect_diffuse" />
+      </multiply>
+      <multiply name="multiply_difuse" type="color3">
+         <input name="in1" type="color3" nodename="parquet_03_basecolor" />
+         <input name="in2" type="color3" value="1.1, 1.1, 1.1" />
+      </multiply>
+      <normalmap name="normalmap_1" type="vector3">
+         <input name="in" type="vector3" nodename="parquet_03_normal" />
+      </normalmap>
+      <image name="parquet_03_basecolor" type="color3">
+         <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_basecolor_2k_acescg.exr" />
+      </image>
+      <image name="parquet_03_normal" type="vector3">
+         <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_normal_2k_raw.exr" />
+      </image>
+      <image name="parquet_03_roughness" type="color3">
+         <parameter name="file" type="filename" value="adsk/textures/parquet_03/2k/parquet_03_roughness_2k_raw.exr" />
+      </image>
+      <standard_surface name="parquete_03_sts" type="surfaceshader">
+         <input name="base_color" type="color3" nodename="saturate_color" />
+         <input name="diffuse_roughness" type="float" value="1" />
+         <input name="specular_roughness" type="float" value="0.5" />
+         <input name="coat" type="float" value="1" />
+         <input name="coat_roughness" type="float" nodename="extract_color3_1" />
+         <input name="normal" type="vector3" nodename="normalmap_1" />
+      </standard_surface>
+      <remap name="remap_color3_1" type="color3">
+         <input name="in" type="color3" nodename="parquet_03_roughness" />
+         <input name="inhigh" type="color3" value="0.1, 0.1, 0.1" />
+         <input name="outhigh" type="color3" value="0.6, 0.6, 0.6" />
+      </remap>
+      <saturate name="saturate_color" type="color3">
+         <input name="in" type="color3" nodename="multiply_color" />
+         <input name="amount" type="float" value="0.9" />
+         <parameter name="lumacoeffs" type="color3" value="1, 1, 1" />
+      </saturate>
+      <output name="surfaceshader" type="surfaceshader" nodename="parquete_03_sts" />
+   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/adsklib/adsk_shaders.mtlx
+++ b/resources/Materials/TestSuite/adsklib/adsk_shaders.mtlx
@@ -2,7 +2,7 @@
 <materialx version="1.38">
    <!-- Test graph for parquet shader / material and colorcorrect -->
    <nodegraph name="parquet_instance_nodegraph" type="multioutput">
-      <adsk:parque_03_material name="parque_03_material" type="material" version="1.0"/>
+      <adsk:parquet_03_material name="parquet_03_material" type="material" version="1.0"/>
       <adsk:parquet_03 name="parquet_03" type="surfaceshader" version="1.0" />
       <adsk:colorcorrect name="colorcorrect" type="multioutput" version="1.0">
          <parameter name="color" type="color3" value="1, 0.5, 0.5" />
@@ -11,7 +11,7 @@
       </adsk:colorcorrect>
       <output name="parquet_out" type="surfaceshader" nodename="parquet_03" />
       <output name="colorcorrect_out" type="color3" nodename="colorcorrect" output="outColor" />
-      <output name="parquet_material_out" type="material" nodename="parque_03_material" />
+      <output name="parquet_material_out" type="material" nodename="parquet_03_material" />
    </nodegraph>
 
 </materialx>

--- a/resources/Materials/TestSuite/adsklib/adsk_shaders.mtlx
+++ b/resources/Materials/TestSuite/adsklib/adsk_shaders.mtlx
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="nodegraph1" type="surfaceshader">
-    <parquet_03 name="parquet_03" type="surfaceshader" version="1.0"/>
-    <adsk:colorcorrect name="adsk_colorcorrect" type="multioutput" version="1.0">
-       <parameter name="color" type="color3" value="1.0, 0.0, 1.0" />
-       <parameter name="alpha" type="float" value="1.0" />
-       <output name="outColor" type="color3" />
-      <output name="outAlpha" type="float" />
-    </adsk:colorcorrect>
-    <output name="parquet_out" type="surfaceshader" nodename="parquet_03" />
-    <output name="colorcorrect_out" type="color3" nodename="adsk_colorcorrect" output="outColor" />
-  </nodegraph>
+   <!-- Test graph for parquet shader / material and colorcorrect -->
+   <nodegraph name="parquet_instance_nodegraph" type="multioutput">
+      <adsk:parque_03_material name="parque_03_material" type="material" version="1.0"/>
+      <adsk:parquet_03 name="parquet_03" type="surfaceshader" version="1.0" />
+      <adsk:colorcorrect name="colorcorrect" type="multioutput" version="1.0">
+         <parameter name="color" type="color3" value="1, 0.5, 0.5" />
+         <output name="outColor" type="color3" />
+         <output name="outAlpha" type="float" />
+      </adsk:colorcorrect>
+      <output name="parquet_out" type="surfaceshader" nodename="parquet_03" />
+      <output name="colorcorrect_out" type="color3" nodename="colorcorrect" output="outColor" />
+      <output name="parquet_material_out" type="material" nodename="parque_03_material" />
+   </nodegraph>
+
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/version/my_add_versioned.mtlx
+++ b/resources/Materials/TestSuite/stdlib/version/my_add_versioned.mtlx
@@ -6,7 +6,7 @@
       <input name="v1_in2" type="color3" value="0, 1, 0" uiname="Input 2. Version 1"/>
       <output name="out" type="color3" value="0, 0, 0" />
    </nodedef>
-   <nodegraph name="NG_version1" nodedef="ND_my_add">
+   <nodegraph name="NG_version1" nodedef="ND_my_add" version="1.0">
       <add name="add" type="color3">
          <input name="in1" type="color3" interfacename="v1_in1" />
          <input name="in2" type="color3" interfacename="v1_in2" />
@@ -20,7 +20,7 @@
       <input name="v2_in2" type="color3" value="0, 1, 1" uiname="Input 2. Version 2"/>
       <output name="out" type="color3" value="0, 0, 0" />
    </nodedef>
-   <nodegraph name="NG_version2" nodedef="ND_my_add2">
+   <nodegraph name="NG_version2" nodedef="ND_my_add2" version="2.0">
       <add name="add" type="color3">
          <input name="in1" type="color3" interfacename="v2_in1" />
          <input name="in2" type="color3" interfacename="v2_in2" />
@@ -32,15 +32,15 @@
    <nodegraph name="my_add_graph">
       <my_add name="my_add_v1" type="color3" version="1.0">
          <input name="v1_in1" type="color3" value="1, 0, 0.5" />
-         <input name="v1_in2" type="color3" value="0, 1, 0.5" />
+         <input name="v1_in2" type="color3" value="0, 0.0, 0.5" />
       </my_add>
       <output name="out" type="color3" nodename="my_add_v1" />
    </nodegraph>
 
-   <!-- Explicitly choose version 1.0 -->
+   <!-- Explicitly choose version 2.0 -->
    <nodegraph name="my_add_graph2">
       <my_add name="my_add_v2" type="color3" version="2.0" >
-         <input name="v2_in1" type="color3" value="1, 0, 0.5" />
+         <input name="v2_in1" type="color3" value="0.0, 0, 0.5" />
          <input name="v2_in2" type="color3" value="0.5, 1, 1" />
       </my_add>
       <output name="out" type="color3" nodename="my_add_v2" />

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -86,7 +86,8 @@ InterfaceElementPtr NodeDef::getImplementation(const string& target, const strin
     for (InterfaceElementPtr interface : interfaces)
     {
         if (interface->isA<Implementation>() ||
-            !targetStringsMatch(interface->getTarget(), target))
+            !targetStringsMatch(interface->getTarget(), target) ||
+            !isVersionCompatible(interface))
         {
             continue;
         }

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -111,12 +111,8 @@ void RtNodeDef::setIsDefaultVersion(bool isDefault)
 bool RtNodeDef::isVersionCompatible(const RtToken& version) const
 {
     // Test if either the version matches or if no version passed in if this is the default version.
-    if (version == getVersion() ||
-        (version.str().empty() && getIsDefaultVersion()))
-    {
-        return true;
-    }
-    return false;
+    return ((version == getVersion()) ||
+            (version.str().empty() && getIsDefaultVersion()));
 }
 
 

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -112,7 +112,7 @@ bool RtNodeDef::isVersionCompatible(const RtToken& version) const
 {
     // Test if either the version matches or if no version passed in if this is the default version.
     if (version == getVersion() ||
-        version.str().empty() && getIsDefaultVersion())
+        (version.str().empty() && getIsDefaultVersion()))
     {
         return true;
     }

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -108,6 +108,18 @@ void RtNodeDef::setIsDefaultVersion(bool isDefault)
     v->getValue().asBool() = isDefault;
 }
 
+bool RtNodeDef::isVersionCompatible(const RtToken& version) const
+{
+    // Test if either the version matches or if no version passed in if this is the default version.
+    if (version == getVersion() ||
+        version.str().empty() && getIsDefaultVersion())
+    {
+        return true;
+    }
+    return false;
+}
+
+
 RtInput RtNodeDef::createInput(const RtToken& name, const RtToken& type, uint32_t flags)
 {
     return prim()->createInput(name, type, flags)->hnd();

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -54,10 +54,10 @@ public:
     /// Set the version for this nodedef.
     void setVersion(const RtToken& version);
 
-    /// Is the version of this graph compatible with the version passed in
+    /// Is the version for this definition compatible with the version passed in
     bool isVersionCompatible(const RtToken& version) const;
 
-    /// Return the version for this nodedef.
+    /// Return if this definition is the default version.
     bool getIsDefaultVersion() const;
 
     /// Set the version for this nodedef.

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -54,6 +54,9 @@ public:
     /// Set the version for this nodedef.
     void setVersion(const RtToken& version);
 
+    /// Is the version of this graph compatible with the version passed in
+    bool isVersionCompatible(const RtToken& version) const;
+
     /// Return the version for this nodedef.
     bool getIsDefaultVersion() const;
 

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -18,6 +18,7 @@ namespace
     static const RtToken SOCKETS("_nodegraph_internal_sockets");
     static const RtToken NODEGRAPH1("nodegraph1");
     static const RtToken NODEDEF("nodedef");
+    static const RtToken VERSION("version");
 }
 
 DEFINE_TYPED_SCHEMA(RtNodeGraph, "node:nodegraph");
@@ -133,6 +134,18 @@ RtPrimIterator RtNodeGraph::getNodes() const
 {
     RtSchemaPredicate<RtNode> predicate;
     return RtPrimIterator(hnd(), predicate);
+}
+
+const RtToken& RtNodeGraph::getVersion() const
+{
+    RtTypedValue* v = prim()->getMetadata(VERSION);
+    return v ? v->getValue().asToken() : EMPTY_TOKEN;
+}
+
+void RtNodeGraph::setVersion(const RtToken& value)
+{
+    RtTypedValue* v = prim()->addMetadata(VERSION, RtType::TOKEN);
+    v->getValue().asToken() = value;
 }
 
 const RtToken& RtNodeGraph::getDefinition() const

--- a/source/MaterialXRuntime/RtNodeGraph.h
+++ b/source/MaterialXRuntime/RtNodeGraph.h
@@ -61,11 +61,11 @@ public:
     /// Return an iterator over the nodes in the graph.
     RtPrimIterator getNodes() const;
 
-    /// Return any associated version string.	
+    /// Return the version for this nodeegraph.
     const RtToken& getVersion() const;
 
-    /// Set the associated version string.	
-    void setVersion(const RtToken& value);
+    /// Set the version for this nodegraph.
+    void setVersion(const RtToken& version);
 
     /// Return any associated definition name.
     const RtToken& getDefinition() const;

--- a/source/MaterialXRuntime/RtNodeGraph.h
+++ b/source/MaterialXRuntime/RtNodeGraph.h
@@ -61,6 +61,12 @@ public:
     /// Return an iterator over the nodes in the graph.
     RtPrimIterator getNodes() const;
 
+    /// Return any associated version string.	
+    const RtToken& getVersion() const;
+
+    /// Set the associated version string.	
+    void setVersion(const RtToken& value);
+
     /// Return any associated definition name.
     const RtToken& getDefinition() const;
 

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -144,12 +144,16 @@ void RtStage::restorePrim(const RtPath& parentPath, const RtPrim& prim)
 RtPrim RtStage::getImplementation(const RtNodeDef& definition) const
 {
     const RtToken& nodeDefName = definition.getName();
+    const RtToken& nodeDefVersion = definition.getVersion();
 
     RtSchemaPredicate<RtNodeGraph> filter;
     for (RtPrim child : _cast(_ptr)->getRootPrim()->getChildren(filter))
     {
         RtNodeGraph nodeGraph(child);
-        if (nodeGraph.getDefinition() == nodeDefName)
+        // Check if there is a definition name match and
+        // if the versions are compatible.
+        if (nodeGraph.getDefinition() == nodeDefName &&
+            definition.isVersionCompatible(nodeGraph.getVersion())
         {
             PvtPrim* graphPrim = PvtObject::ptr<PvtPrim>(child);
             return RtPrim(graphPrim->hnd());
@@ -190,6 +194,8 @@ RtPrim RtStage::createNodeDef(RtNodeGraph& nodeGraph,
     if (version != EMPTY_TOKEN)
     {
         nodedef.setVersion(version);
+        nodeGraph.setVersion(version);
+
         // If a version is specified, set if it is the default version
         if (isDefaultVersion)
         {

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -144,7 +144,6 @@ void RtStage::restorePrim(const RtPath& parentPath, const RtPrim& prim)
 RtPrim RtStage::getImplementation(const RtNodeDef& definition) const
 {
     const RtToken& nodeDefName = definition.getName();
-    const RtToken& nodeDefVersion = definition.getVersion();
 
     RtSchemaPredicate<RtNodeGraph> filter;
     for (RtPrim child : _cast(_ptr)->getRootPrim()->getChildren(filter))
@@ -153,7 +152,7 @@ RtPrim RtStage::getImplementation(const RtNodeDef& definition) const
         // Check if there is a definition name match and
         // if the versions are compatible.
         if (nodeGraph.getDefinition() == nodeDefName &&
-            definition.isVersionCompatible(nodeGraph.getVersion())
+            definition.isVersionCompatible(nodeGraph.getVersion()))
         {
             PvtPrim* graphPrim = PvtObject::ptr<PvtPrim>(child);
             return RtPrim(graphPrim->hnd());

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -206,9 +206,10 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
 
     registerLights(dependLib, options, context);
 
-    // Map to replace "/" in Element path names with "_".
+    // Map to replace "/" in Element path and ":" in namespaced names with "_".
     mx::StringMap pathMap;
     pathMap["/"] = "_";
+    pathMap[":"] = "_";
 
     RenderUtil::AdditiveScopedTimer validateTimer(profileTimes.validateTime, "Global validation time");
     RenderUtil::AdditiveScopedTimer renderableSearchTimer(profileTimes.renderableSearchTime, "Global renderable search time");

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -793,8 +793,9 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     mx::RtPrim addgraphPrim = stage->createNodeDef(graph1, ND_ADDGRAPH, ADDGRAPH, ADDGRAPH_VERSION, isDefaultVersion, MATH_GROUP);
     mx::RtNodeDef addgraphDef(addgraphPrim);    
 
-    REQUIRE(addgraphDef.isMasterPrim());
     REQUIRE(graph1.getDefinition() == ND_ADDGRAPH);
+    REQUIRE(graph1.getVersion() == ADDGRAPH_VERSION);
+    REQUIRE(addgraphDef.isMasterPrim());
     REQUIRE(addgraphDef.numInputs() == 2);
     REQUIRE(addgraphDef.numOutputs() == 1);
     REQUIRE(addgraphDef.getOutput().getName() == OUT);

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -807,18 +807,41 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     addgraphDef.setTarget(ADDGRAPH_TARGET);
     REQUIRE(addgraphDef.getTarget() == ADDGRAPH_TARGET);
 
-    // Check instance creation. Metadata like version should be copied
-    // but not target or node.
+    // Check implementation search based on nodegraph.
+    mx::RtPrim addGraphImpl = stage->getImplementation(addgraphDef);
+    // Exact version check
+    {
+        REQUIRE(addGraphImpl.getPath() == graph1.getPath());
+    }
+    // Bad version check
+    {
+        graph1.setVersion(mx::RtToken("badVersion")); 
+        addGraphImpl = stage->getImplementation(addgraphDef);
+        REQUIRE_FALSE(addGraphImpl.isValid());
+        graph1.setVersion(ADDGRAPH_VERSION);
+    }
+
+    // Check instance creation:
     mx::RtPrim agPrim = stage->createPrim("addgraph1", ND_ADDGRAPH);
     REQUIRE(agPrim.isValid());
     mx::RtNode agNode(agPrim);
-    mx::RtTypedValue* agVersion = agNode.getMetadata(mx::RtNodeDef::VERSION);
-    REQUIRE(agVersion->getValueString() == ADDGRAPH_VERSION);
-    mx::RtTypedValue* agTarget= agNode.getMetadata(mx::RtNodeDef::TARGET);
-    REQUIRE(!agTarget);
-    mx::RtTypedValue* agNodeValue = agNode.getMetadata(mx::RtNodeDef::NODE);
-    REQUIRE(!agNodeValue);
+    {
+        // 1. Metadata like version should be copiedbut not target or node.
+        mx::RtTypedValue* agVersion = agNode.getMetadata(mx::RtNodeDef::VERSION);
+        REQUIRE(agVersion->getValueString() == ADDGRAPH_VERSION);
+        mx::RtTypedValue* agTarget = agNode.getMetadata(mx::RtNodeDef::TARGET);
+        REQUIRE(!agTarget);
+        mx::RtTypedValue* agNodeValue = agNode.getMetadata(mx::RtNodeDef::NODE);
+        REQUIRE(!agNodeValue);
+    }
 
+    // 2. The assocaited nodedef can be found.
+    {
+        mx::RtPrim agNodeDefinition = agNode.getNodeDef();
+        REQUIRE(agNodeDefinition.getPath() == addgraphDef.getPath());
+    }
+
+    // Check export to MTLX document:
     mx::RtFileIo stageIo(stage);
     mx::RtTokenVec names;
     names.push_back(ND_ADDGRAPH);
@@ -826,64 +849,76 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
 
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, "ND_addgraph.mtlx");
+    doc->validate();
     mx::NodeDefPtr nodeDef = doc->getNodeDef(ND_ADDGRAPH.str());
-    REQUIRE(nodeDef);
-    REQUIRE(nodeDef->getVersionString() == ADDGRAPH_VERSION.str());
-    REQUIRE(nodeDef->getTarget() == ADDGRAPH_TARGET.str());
-    std::vector<mx::InputPtr> inputs = nodeDef->getInputs();
-    bool inputCheck = 
-        (inputs.size() == 2) &&
-        (inputs[0]->getName() == "a") &&
-        (inputs[0]->getType() == "float") &&
-        (inputs[0]->getValueString() == "0.3") &&
-        (inputs[1]->getName() == "b") &&
-        (inputs[1]->getType() == "float") &&
-        (inputs[1]->getValueString() == "0.1");
-    REQUIRE(inputCheck);
-    mx::OutputPtr out = nodeDef->getOutput("out");
-    bool outputCheck = out && 
-        (out->getName() == "out") &&
-        (out->getType() == "float") &&
-        (out->getValueString() == "0");
-    REQUIRE(outputCheck);
-    mx::NodeGraphPtr nodeGraph = doc->getNodeGraph(NG_ADDGRAPH.str());
-    REQUIRE((nodeGraph && nodeGraph->getOutputs().size() == 1));
-    for (mx::TreeIterator it = nodeGraph->traverseTree().begin(); it != mx::TreeIterator::end(); ++it)
     {
-        mx::ValueElementPtr input = it.getElement()->asA<mx::ValueElement>();
-        if (input)
+        // 1. Check nodedef
+        REQUIRE(nodeDef);
+        REQUIRE(nodeDef->getVersionString() == ADDGRAPH_VERSION.str());
+        REQUIRE(nodeDef->getTarget() == ADDGRAPH_TARGET.str());
+        std::vector<mx::InputPtr> inputs = nodeDef->getInputs();
+        bool inputCheck =
+            (inputs.size() == 2) &&
+            (inputs[0]->getName() == "a") &&
+            (inputs[0]->getType() == "float") &&
+            (inputs[0]->getValueString() == "0.3") &&
+            (inputs[1]->getName() == "b") &&
+            (inputs[1]->getType() == "float") &&
+            (inputs[1]->getValueString() == "0.1");
+        REQUIRE(inputCheck);
+        mx::OutputPtr out = nodeDef->getOutput("out");
+        bool outputCheck = out &&
+            (out->getName() == "out") &&
+            (out->getType() == "float") &&
+            (out->getValueString() == "0");
+        REQUIRE(outputCheck);
+    }
+
+    // 2. Check the nodegraph for the nodedef
+    {
+        mx::InterfaceElementPtr inter = nodeDef->getImplementation();
+        mx::NodeGraphPtr nodeGraph = inter->asA<mx::NodeGraph>();
+        REQUIRE((nodeGraph && nodeGraph->getOutputs().size() == 1));
+        for (mx::TreeIterator it = nodeGraph->traverseTree().begin(); it != mx::TreeIterator::end(); ++it)
         {
-            if (input->getName() == "in1" && input->getAttribute("nodename").empty())
+            mx::ValueElementPtr input = it.getElement()->asA<mx::ValueElement>();
+            if (input)
             {
-                REQUIRE((input->getInterfaceName() == "a"));
-            }
-            else if (input->getName() == "in2")
-            {
-                if (input->getParent())
+                if (input->getName() == "in1" && input->getAttribute("nodename").empty())
                 {
-                    bool interfaceNameMatched = true;
-                    if (input->getParent()->getName() == "add2")
-                        interfaceNameMatched = (input->getInterfaceName() == "a");
-                    else
-                        interfaceNameMatched = (input->getInterfaceName() == "b");
-                    REQUIRE(interfaceNameMatched);
+                    REQUIRE((input->getInterfaceName() == "a"));
+                }
+                else if (input->getName() == "in2")
+                {
+                    if (input->getParent())
+                    {
+                        bool interfaceNameMatched = true;
+                        if (input->getParent()->getName() == "add2")
+                            interfaceNameMatched = (input->getInterfaceName() == "a");
+                        else
+                            interfaceNameMatched = (input->getInterfaceName() == "b");
+                        REQUIRE(interfaceNameMatched);
+                    }
                 }
             }
         }
     }
 
-    // Check instance creation
-    stageIo.write("addgraph_example.mtlx");
-    doc = mx::createDocument();
-    mx::readFromXmlFile(doc, "addgraph_example.mtlx");
-    mx::ElementPtr agInstance = doc->getChild("addgraph1");
-    REQUIRE(agInstance);
-    bool instanceVersionSaved = agInstance->getAttribute(mx::RtNodeDef::VERSION.str()) == ADDGRAPH_VERSION;
-    REQUIRE(instanceVersionSaved);
-    bool instanceTargetNotSaved = agInstance->getAttribute(mx::RtNodeDef::TARGET.str()) == mx::EMPTY_STRING;
-    REQUIRE(instanceTargetNotSaved);
-    bool instanceNodeNotSaved = agInstance->getAttribute(mx::RtNodeDef::NODE.str()) == mx::EMPTY_STRING;
-    REQUIRE(instanceNodeNotSaved);
+    // 3. Check instance creation
+    {
+        stageIo.write("addgraph_example.mtlx");
+        doc = mx::createDocument();
+        mx::readFromXmlFile(doc, "addgraph_example.mtlx");
+        doc->validate();
+        mx::ElementPtr agInstance = doc->getChild("addgraph1");
+        REQUIRE(agInstance);
+        bool instanceVersionSaved = agInstance->getAttribute(mx::RtNodeDef::VERSION.str()) == ADDGRAPH_VERSION;
+        REQUIRE(instanceVersionSaved);
+        bool instanceTargetNotSaved = agInstance->getAttribute(mx::RtNodeDef::TARGET.str()) == mx::EMPTY_STRING;
+        REQUIRE(instanceTargetNotSaved);
+        bool instanceNodeNotSaved = agInstance->getAttribute(mx::RtNodeDef::NODE.str()) == mx::EMPTY_STRING;
+        REQUIRE(instanceNodeNotSaved);
+    }
 }
 
 TEST_CASE("Runtime: FileIo", "[runtime]")


### PR DESCRIPTION
Update #852 
- Add back in version check between nodedef and nodegraph implementation to allow for different implemenation versions per definition.
- Add in supporting code to ensure and check for compatible version support for RtNodeGraph/RtNodeDef.
  - Add back in version setting for RtNodeGraph when publishing an RtNodeGraph.
  - Add in version "compatibility" check when looking for an implementation (RtNodeGraph) for an RtNodeDef.
- Namespace and version parquet shader and material
- Add back in versioning for nodegraphs implementation on colorcorrect.
- Replace namespace characters for shadername used for render unit tests.
- Update unit tests.
