### PR TITLE
Update RtRuntime MTLX node save to support namespacing support

### DIFF
--- a/resources/Materials/TestSuite/stdlib/definition/surfacematerial_definition.mtlx
+++ b/resources/Materials/TestSuite/stdlib/definition/surfacematerial_definition.mtlx
@@ -28,7 +28,7 @@
    <nodedef name="ND_myshader" node="myshader" nodegroup="shader" target="mytarget" version="1.3" isdefaultversion="true">
       <output name="surfaceshader" type="surfaceshader"/>
    </nodedef>
-   <nodegraph name="NG_myshader" nodedef="ND_myshader" target="mytarget" version="1.3">
+   <nodegraph name="NG_myshader" nodedef="ND_myshader" version="1.3"> <!-- target="mytarget" fails here ! -->
       <standard_surface name="my_surface_shader" type="surfaceshader" >
          <input name="base_color" type="color3" value="0.264575,1.0,1.0" />
       </standard_surface>
@@ -38,5 +38,6 @@
    <mymaterial name="mymaterial_instance" type="material"></mymaterial>
    <output type="material" nodename="mymaterial_instance" />
    <myshader name="myshader_instance" type="surfaceshader"></myshader>
+   <output type="surfaceshader" nodename="myshader_instance" />
 
 </materialx>

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -768,7 +768,7 @@ namespace
             outputType = attr.getType();
         }
 
-        NodePtr destNode = dest->addNode(nodedef.getNode(), node.getName(), numOutputs > 1 ? "multioutput" : outputType);
+        NodePtr destNode = dest->addNode(nodedef.getNamespacedNode(), node.getName(), numOutputs > 1 ? "multioutput" : outputType);
 
         for (RtAttribute attrDef : nodedef.getPrim().getAttributes())
         {

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -18,6 +18,7 @@ RtToken RtNodeDef::INHERIT("inherit");
 RtToken RtNodeDef::TARGET("target");
 RtToken RtNodeDef::VERSION("version");
 RtToken RtNodeDef::IS_DEFAULT_VERSION("isdefaultversion");
+RtToken RtNodeDef::NAMESPACE("namespace");
 
 DEFINE_TYPED_SCHEMA(RtNodeDef, "nodedef");
 
@@ -41,6 +42,19 @@ const RtToken& RtNodeDef::getNode() const
     RtTypedValue* v = prim()->getMetadata(NODE);
     return v ? v->getValue().asToken() : EMPTY_TOKEN;
 }
+
+const RtToken& RtNodeDef::getNamespacedNode() const
+{
+    const RtToken& nodeToken = getNode();
+    string nodeString = nodeToken.c_str();
+    string namespaceString = getNamespace().c_str();;
+    if (!namespaceString.empty())
+    {
+        return RtToken(namespaceString + NAME_PREFIX_SEPARATOR + nodeString);
+    }
+    return nodeToken;
+}
+
 
 void RtNodeDef::setNode(const RtToken& node)
 {
@@ -107,6 +121,19 @@ void RtNodeDef::setIsDefaultVersion(bool isDefault)
     RtTypedValue* v = prim()->addMetadata(IS_DEFAULT_VERSION, RtType::BOOLEAN);
     v->getValue().asBool() = isDefault;
 }
+
+const RtToken& RtNodeDef::getNamespace() const
+{
+    RtTypedValue* v = prim()->getMetadata(NAMESPACE);
+    return v ? v->getValue().asToken() : EMPTY_TOKEN;
+}
+
+void RtNodeDef::setNamespace(const RtToken& space)
+{
+    RtTypedValue* v = prim()->addMetadata(NAMESPACE, RtType::TOKEN);
+    v->getValue().asToken() = space;
+}
+
 
 RtInput RtNodeDef::createInput(const RtToken& name, const RtToken& type, uint32_t flags)
 {

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -43,7 +43,7 @@ const RtToken& RtNodeDef::getNode() const
     return v ? v->getValue().asToken() : EMPTY_TOKEN;
 }
 
-const RtToken& RtNodeDef::getNamespacedNode() const
+RtToken RtNodeDef::getNamespacedNode() const
 {
     const RtToken& nodeToken = getNode();
     string nodeString = nodeToken.c_str();

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -28,7 +28,7 @@ public:
     const RtToken& getNode() const;
 
     /// Return the namespaced node for this nodedef.
-    const RtToken& getNamespacedNode() const;
+    RtToken getNamespacedNode() const;
 
     /// Set the node for this nodedef.
     void setNode(const RtToken& node);

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -27,6 +27,9 @@ public:
     /// Return the node for this nodedef.
     const RtToken& getNode() const;
 
+    /// Return the namespaced node for this nodedef.
+    const RtToken& getNamespacedNode() const;
+
     /// Set the node for this nodedef.
     void setNode(const RtToken& node);
 
@@ -59,6 +62,12 @@ public:
 
     /// Set the version for this nodedef.
     void setIsDefaultVersion(bool isDefault);
+
+    /// Return the namespacefor this nodedef.
+    const RtToken& getNamespace() const;
+
+    /// Set the namespacefor this nodedef.
+    void setNamespace(const RtToken& space);
 
     /// Add an input attribute to the interface.
     RtInput createInput(const RtToken& name, const RtToken& type, uint32_t flags = 0);
@@ -111,6 +120,7 @@ public:
     static RtToken TARGET;
     static RtToken VERSION;
     static RtToken IS_DEFAULT_VERSION;
+    static RtToken NAMESPACE;
 };
 
 }


### PR DESCRIPTION
Fix save to MTLX so that a fullly namespaced node name is used when creating a new node in the Document.
