### PR TITLE
LOOKDEVX-235 : Output port and Rt File I/O fixes for nodedef

### DIFF
--- a/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
+++ b/libraries/adsk/materials/wood/parquet_3/ND_parquet_03_material.mtlx
@@ -12,7 +12,7 @@
       <input name="surfaceshader" type="surfaceshader" nodename="parquet_03_surface_shader" />
       <input name="displacementshader" type="displacementshader" nodename="parquet_03_displacement_shader" />
     </surfacematerial>
-    <parquet_03 name="parquet_03_surface_shader" type="surfaceshader" />
+    <adsk:parquet_03 name="parquet_03_surface_shader" type="surfaceshader" />
     <output name="out" type="material" nodename="parquet_03_material" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1160,16 +1160,6 @@ namespace
         }
     }
 
-    void writeUnitDefinitions(DocumentPtr doc)
-    {
-        RtApi& api = RtApi::get();
-        UnitConverterRegistryPtr unitDefinitions = api.getUnitDefinitions();
-        if (unitDefinitions)
-        {
-            unitDefinitions->write(doc);
-        }
-    }
-
     void writeMasterPrim(DocumentPtr document, PvtStage* stage, PvtPrim* prim, const RtWriteOptions* writeOptions)
     {
         if (!prim || prim->isDisposed())

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -89,7 +89,7 @@ namespace
 
     PvtOutput* findOutputOrThrow(const RtToken& name, PvtPrim* prim)
     {
-        PvtOutput* output = prim->getOutput(name);
+        PvtOutput* output = name.str().empty() ? prim->getOutput() : prim->getOutput(name);
         if (!output)
         {
             throw ExceptionRuntimeError("Node '" + prim->getName().str() + "' has no output named '" + name.str() + "'");
@@ -188,7 +188,7 @@ namespace
                             outputName = output.getName();
                         }
                     }
-                    PvtOutput* output = findOutputOrThrow(outputName != EMPTY_TOKEN ? outputName : PvtAttribute::DEFAULT_OUTPUT_NAME, connectedNode);
+                    PvtOutput* output = findOutputOrThrow(outputName, connectedNode);
                     output->connect(input);
                 }
             }
@@ -262,10 +262,12 @@ namespace
         for (RtPrim masterPrim : RtApi::get().getMasterPrims(nodedefFilter))
         {
             RtNodeDef candidate(masterPrim);
-            if (candidate.getNode() == nodeName &&
-                matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
+            if (candidate.getNamespacedNode() == nodeName)
             {
-                return candidate.getName();
+                if (matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
+                {
+                    return candidate.getName();
+                }
             }
         }
 
@@ -396,7 +398,7 @@ namespace
                 PvtPrim* connectedNode = findPrimOrThrow(RtToken(connectedNodeName), nodegraph, mapper);
 
                 const RtToken outputName(elem->getOutputString());
-                RtOutput output(findOutputOrThrow(outputName != EMPTY_TOKEN ? outputName : PvtAttribute::DEFAULT_OUTPUT_NAME, connectedNode)->hnd());
+                RtOutput output(findOutputOrThrow(outputName, connectedNode)->hnd());
                 output.connect(socket);
             }
         }

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -262,12 +262,10 @@ namespace
         for (RtPrim masterPrim : RtApi::get().getMasterPrims(nodedefFilter))
         {
             RtNodeDef candidate(masterPrim);
-            if (candidate.getNamespacedNode() == nodeName)
+            if (candidate.getNode() == nodeName && 
+                matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
             {
-                if (matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
-                {
-                    return candidate.getName();
-                }
+                return candidate.getName();
             }
         }
 

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -262,7 +262,7 @@ namespace
         for (RtPrim masterPrim : RtApi::get().getMasterPrims(nodedefFilter))
         {
             RtNodeDef candidate(masterPrim);
-            if (candidate.getNode() == nodeName && 
+            if (candidate.getNamespacedNode() == nodeName && 
                 matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
             {
                 return candidate.getName();

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1233,8 +1233,7 @@ namespace
 RtReadOptions::RtReadOptions() :
     readFilter(nullptr),
     readLookInformation(false),
-    applyFutureUpdates(true),
-    validateDocument(true)
+    applyFutureUpdates(true)
 {
 }
 
@@ -1262,30 +1261,8 @@ void RtFileIo::read(const FilePath& documentPath, const FileSearchPath& searchPa
         }
         readFromXmlFile(document, documentPath, searchPaths, &xmlReadOptions);
 
-        bool validateDocument = readOptions ? readOptions->validateDocument : true;
-        if (validateDocument)
-        {
-            string errorMessage;
-            DocumentPtr validationDocument = createDocument();
-            writeUnitDefinitions(validationDocument);
-            CopyOptions cops;
-            cops.skipConflictingElements = true;
-            validationDocument->copyContentFrom(document, &cops);
-            if (validationDocument->validate(&errorMessage))
-            {
-                PvtStage* stage = PvtStage::ptr(_stage);
-                readDocument(document, stage, readOptions);
-            }
-            else
-            {
-                throw ExceptionRuntimeError("Failed validation: " + errorMessage);
-            }
-        }
-        else
-        {
-            PvtStage* stage = PvtStage::ptr(_stage);
-            readDocument(document, stage, readOptions);
-        }
+        PvtStage* stage = PvtStage::ptr(_stage);
+        readDocument(document, stage, readOptions);
     }
     catch (Exception& e)
     {
@@ -1307,30 +1284,8 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* readOptions)
         }
         readFromXmlStream(document, stream, &xmlReadOptions);
 
-        bool validateDocument = readOptions ? readOptions->validateDocument : true;
-        if (validateDocument)
-        {
-            string errorMessage;
-            DocumentPtr validationDocument = createDocument();
-            writeUnitDefinitions(validationDocument);
-            CopyOptions cops;
-            cops.skipConflictingElements = true;
-            validationDocument->copyContentFrom(document, &cops);
-            if (validationDocument->validate(&errorMessage))
-            {
-                PvtStage* stage = PvtStage::ptr(_stage);
-                readDocument(document, stage, readOptions);
-            }
-            else
-            {
-                throw ExceptionRuntimeError("Failed validation: " + errorMessage);
-            }
-        }
-        else
-        {
-            PvtStage* stage = PvtStage::ptr(_stage);
-            readDocument(document, stage, readOptions);
-        }
+        PvtStage* stage = PvtStage::ptr(_stage);
+        readDocument(document, stage, readOptions);
     }
     catch (Exception& e)
     {

--- a/source/MaterialXRuntime/RtFileIo.h
+++ b/source/MaterialXRuntime/RtFileIo.h
@@ -39,9 +39,6 @@ class RtReadOptions
 
     /// Apply the latest MaterialX feature updates. The default value is true.
     bool applyFutureUpdates;
-
-    /// Validate MaterialX documents read. The default is true.
-    bool validateDocument;
 };
     
 /// @class RtWriteOptions

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -1080,10 +1080,17 @@ TEST_CASE("Runtime: namespaced definitions", "[runtime]")
 {
     mx::RtScopedApiHandle api;
 
-    mx::FilePath filePath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    mx::FilePathVec filePathVec = filePath.getSubDirectories();
+    mx::FilePath librariesPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
+    mx::FilePathVec rootPaths;
+    rootPaths.push_back(librariesPath);
+    mx::FileSearchPath searchPath(librariesPath);
+    mx::FilePathVec childFolders;
+    mx::getSubdirectories(rootPaths, searchPath, childFolders);
+    for (const auto& childFolder : childFolders)
+    {
+        searchPath.append(childFolder);
+    }
     api->setSearchPath(searchPath);
-    api->loadLibrary(STDLIB);
     api->loadLibrary(STDLIB);
     api->loadLibrary(PBRLIB);
     api->loadLibrary(BXDFLIB);
@@ -1099,7 +1106,10 @@ TEST_CASE("Runtime: namespaced definitions", "[runtime]")
         "adsklib");
 
     mx::RtFileIo fileIo(defaultStage);
-    fileIo.read("adsk_shaders.mtlx", adskTestPath);
+
+    mx::RtReadOptions options;
+    options.validateDocument = false;
+    fileIo.read("adsk_shaders.mtlx", adskTestPath, &options);
 }
 
 TEST_CASE("Runtime: Conflict resolution", "[runtime]")

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -1025,36 +1025,6 @@ TEST_CASE("Runtime: FileIo", "[runtime]")
     }
 }
 
-TEST_CASE("Runtime: FileIo no validatioon", "[runtime]")
-{
-    mx::RtScopedApiHandle api;
-
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    api->setSearchPath(searchPath);
-    api->loadLibrary(STDLIB);
-    api->loadLibrary(PBRLIB);
-
-    mx::FileSearchPath bxdfPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries") / mx::FilePath("bxdf"));
-    mx::RtReadOptions options;
-    options.validateDocument = false;
-
-    mx::RtStagePtr stage = api->createStage(MAIN);
-    mx::RtFileIo fileIo(stage);
-    REQUIRE_THROWS(fileIo.read("standard_surface.mtlx", bxdfPath));
-    REQUIRE_NOTHROW(fileIo.read("standard_surface.mtlx", bxdfPath, &options));
-
-    mx::DocumentPtr doc = mx::createDocument();
-    mx::readFromXmlFile(doc, "standard_surface.mtlx", bxdfPath);
-    std::stringstream stream;
-    mx::writeToXmlStream(doc, stream);
-    stage = api->createStage(MAIN);
-    mx::RtFileIo fileIo2(stage);
-    REQUIRE_THROWS(fileIo2.read(stream));
-    std::stringstream stream2;
-    mx::writeToXmlStream(doc, stream2);
-    REQUIRE_NOTHROW(fileIo2.read(stream2, &options));
-}
-
 TEST_CASE("Runtime: DefaultLook", "[runtime]")
 {
     mx::RtScopedApiHandle api;
@@ -1076,7 +1046,7 @@ TEST_CASE("Runtime: DefaultLook", "[runtime]")
     fileIo.read("emptyLook.mtlx", lookSearchPath);
 }
 
-TEST_CASE("Runtime: namespaced definitions", "[runtime]")
+TEST_CASE("Runtime: Namespaced definitions", "[runtime]")
 {
     mx::RtScopedApiHandle api;
 
@@ -1107,9 +1077,7 @@ TEST_CASE("Runtime: namespaced definitions", "[runtime]")
 
     mx::RtFileIo fileIo(defaultStage);
 
-    mx::RtReadOptions options;
-    options.validateDocument = false;
-    fileIo.read("adsk_shaders.mtlx", adskTestPath, &options);
+    fileIo.read("adsk_shaders.mtlx", adskTestPath);
 }
 
 TEST_CASE("Runtime: Conflict resolution", "[runtime]")

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -75,6 +75,7 @@ namespace
     const mx::RtToken STDLIB("stdlib");
     const mx::RtToken PBRLIB("pbrlib");
     const mx::RtToken BXDFLIB("bxdf");
+    const mx::RtToken ADSKLIB("adsk");
 
     bool compareFiles(const mx::FilePath& filename1, const mx::FilePath& filename2)
     {
@@ -1073,6 +1074,32 @@ TEST_CASE("Runtime: DefaultLook", "[runtime]")
     mx::RtFileIo fileIo(defaultStage);
     fileIo.read("defaultLook.mtlx", lookSearchPath);
     fileIo.read("emptyLook.mtlx", lookSearchPath);
+}
+
+TEST_CASE("Runtime: namespaced definitions", "[runtime]")
+{
+    mx::RtScopedApiHandle api;
+
+    mx::FilePath filePath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    mx::FilePathVec filePathVec = filePath.getSubDirectories();
+    api->setSearchPath(searchPath);
+    api->loadLibrary(STDLIB);
+    api->loadLibrary(STDLIB);
+    api->loadLibrary(PBRLIB);
+    api->loadLibrary(BXDFLIB);
+    api->loadLibrary(ADSKLIB);
+
+    mx::RtStagePtr defaultStage = api->createStage(mx::RtToken("defaultStage"));
+    defaultStage->addReference(api->getLibrary());
+
+    mx::FileSearchPath adskTestPath(mx::FilePath::getCurrentPath() /
+        "resources" /
+        "Materials" / 
+        "TestSuite" / 
+        "adsklib");
+
+    mx::RtFileIo fileIo(defaultStage);
+    fileIo.read("adsk_shaders.mtlx", adskTestPath);
 }
 
 TEST_CASE("Runtime: Conflict resolution", "[runtime]")


### PR DESCRIPTION
1. Make the validation check in RtFileIO for nodedefs consider namespace (same as done for write).
2. Fix to remove hard-coded "out" check if output connections so graphs with different output names load properly.
3. Fix missing namespace in unit test file.
4. Add new Runtime test to read in unit test (3.) to test RtFile nodedef validation and connection fixes (1, 2).
5. Remove the older MTLX level validation as definition checking is sufficiently done at the Runtime level.

The definition errors without this would be:
```
- Could not read file: adsk_shaders.mtlx. 
Error: No matching nodedef was found for node 'colorcorrect'
```
when it should have looked for `adsk:colorcorrect` and
```
Error: "Node 'NG_parquet_03_shader` no output named 'out'  
```
which is an incorrect error as this graph has an single output called `surfaceshader`.

This is the result at the top level:
![image](https://user-images.githubusercontent.com/14275104/88322613-fa30b400-ccee-11ea-941b-cadafdb82be1.png)
and corresponding graphs which will load in properly after the fixes:
![image](https://user-images.githubusercontent.com/14275104/88322520-d40b1400-ccee-11ea-82d6-b2d095a2a63f.png)
![image](https://user-images.githubusercontent.com/14275104/88322546-dec5a900-ccee-11ea-977e-0328956875d7.png)
![image](https://user-images.githubusercontent.com/14275104/88322577-e7b67a80-ccee-11ea-87a8-63fc4c33e423.png)
