### PR TITLE
Add resource binding for structured uniforms.

### DIFF
--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -123,8 +123,10 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
         (((structSize + (baseAlignment - 1)) & ~(baseAlignment - 1)) - structSize) / 4;
 
     // Sort order from largest to smallest
-    std::sort(memberOrder.begin(), memberOrder.end(), std::greater<>());
-
+    std::sort(memberOrder.begin(), memberOrder.end(),
+        [](const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b) {
+            return a.first > b.first;
+        });
 
     // Emit the struct
     generator.emitLine("struct " + uniforms.getName(), stage, false);

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -49,7 +49,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     }
     if (hasValueUniforms)
     {
-        generator.emitLine("layout (binding=" + std::to_string(_hwBindLocation++) + ") " + 
+        generator.emitLine("layout (std140, binding=" + std::to_string(_hwBindLocation++) + ") " + 
                            syntax.getUniformQualifier() + " " + uniforms.getName() + "_" + stage.getName(), 
                            stage, false);
         generator.emitScopeBegin(stage);
@@ -80,4 +80,82 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     generator.emitLineBreak(stage);
 }
 
+void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& context,
+    const VariableBlock& uniforms, ShaderStage& stage, const std::string& structInstanceName,
+    const std::string& arraySuffix)
+{
+    ShaderGenerator& generator = context.getShaderGenerator();
+    const Syntax& syntax = generator.getSyntax();
+
+    // Glsl struct need to be aligned. We make a best effort to base align struct members and add
+    // padding if required
+    // https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_uniform_buffer_object.txt
+
+    const size_t baseAlignment = 16;
+    std::unordered_map<const TypeDesc*, size_t> alignmentMap({ { Type::FLOAT, baseAlignment / 4 },
+        { Type::INTEGER, baseAlignment / 4 }, { Type::BOOLEAN, baseAlignment / 4 },
+        { Type::COLOR2, baseAlignment }, { Type::COLOR3, baseAlignment },
+        { Type::COLOR4, baseAlignment }, { Type::VECTOR2, baseAlignment },
+        { Type::VECTOR3, baseAlignment }, { Type::VECTOR4, baseAlignment },
+        { Type::MATRIX33, baseAlignment * 4 }, { Type::MATRIX44, baseAlignment * 4 } });
+
+    //Get struct alignment and size
+    // alignment, uniform member index
+    vector<std::pair<size_t, size_t>> memberOrder;
+    size_t structSize = 0;
+    for (size_t i = 0; i < uniforms.size(); ++i)
+    {
+        auto it = alignmentMap.find(uniforms[i]->getType());
+        if (it == alignmentMap.end())
+        {
+            structSize += baseAlignment;
+            memberOrder.push_back(std::make_pair(baseAlignment, i));
+        }
+        else
+        {
+            structSize += it->second;
+            memberOrder.push_back(std::make_pair(it->second, i));
+        }
+    }
+
+    // Align up and determine number of padding floats to add
+    const size_t numPaddingfloats =
+        (((structSize + (baseAlignment - 1)) & ~(baseAlignment - 1)) - structSize) / 4;
+
+    // Sort order from largest to smallest
+    std::sort(memberOrder.begin(), memberOrder.end(), std::greater<>());
+
+
+    // Emit the struct
+    generator.emitLine("struct " + uniforms.getName(), stage, false);
+    generator.emitScopeBegin(stage);
+
+    for (size_t i = 0; i < uniforms.size(); ++i)
+    {
+        size_t variableIndex = memberOrder[i].second;
+        generator.emitLineBegin(stage);
+        generator.emitVariableDeclaration(
+            uniforms[variableIndex], EMPTY_STRING, context, stage, false);
+        generator.emitString(Syntax::SEMICOLON, stage);
+        generator.emitLineEnd(stage, false);
+    }
+
+    // Emit padding
+    for (size_t i = 0; i < numPaddingfloats; ++i)
+    {
+        generator.emitLine("float pad" + std::to_string(i), stage, true);
+    }
+    generator.emitScopeEnd(stage, true);
+
+
+    // emit the binding info
+    generator.emitLineBreak(stage);
+    generator.emitLine("layout (std140, binding=" + std::to_string(_hwBindLocation++) +
+        ") " + syntax.getUniformQualifier() + " " + uniforms.getName() + "_" +
+        stage.getName(),
+    stage, false);
+    generator.emitScopeBegin(stage);
+    generator.emitLine(uniforms.getName() + " " + structInstanceName + arraySuffix, stage);
+    generator.emitScopeEnd(stage, true);
+}
 }

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -36,6 +36,11 @@ public:
     // Emit uniforms with binding information
     void emitResourceBindings(GenContext& context, const VariableBlock& uniforms, ShaderStage& stage) override;
 
+    // Emit Structured uniforms with binding information and align members where possible
+    void emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms,
+        ShaderStage& stage, const std::string& structInstanceName,
+        const std::string& arraySuffix) override;
+
 protected:
     // List of required extensions
     StringSet _requiredExtensions;

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -434,7 +434,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     if (context.getOptions().hwMaxActiveLightSources > 0)
     {
         const unsigned int maxLights = std::max(1u, context.getOptions().hwMaxActiveLightSources);
-        emitLine("#define MAX_LIGHT_SOURCES " + std::to_string(maxLights), stage, false);
+        emitLine("#define " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + " " + std::to_string(maxLights), stage, false);
     }
     emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);
     emitLineBreak(stage);
@@ -478,12 +478,22 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     if (lighting && context.getOptions().hwMaxActiveLightSources > 0)
     {
         const VariableBlock& lightData = stage.getUniformBlock(HW::LIGHT_DATA);
-        emitLine("struct " + lightData.getName(), stage, false);
-        emitScopeBegin(stage);
-        emitVariableDeclarations(lightData, EMPTY_STRING, Syntax::SEMICOLON, context, stage, false);
-        emitScopeEnd(stage, true);
-        emitLineBreak(stage);
-        emitLine("uniform " + lightData.getName() + " " + lightData.getInstance() + "[MAX_LIGHT_SOURCES]", stage);
+        const string structArraySuffix = "[" + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + "]";
+        const string structName        = lightData.getInstance();
+        if (resourceBindingCtx)
+        {
+            resourceBindingCtx->emitStructuredResourceBindings(
+                context, lightData, stage, structName, structArraySuffix);
+        }
+        else
+        {
+            emitLine("struct " + lightData.getName(), stage, false);
+            emitScopeBegin(stage);
+            emitVariableDeclarations(lightData, EMPTY_STRING, Syntax::SEMICOLON, context, stage, false);
+            emitScopeEnd(stage, true);
+            emitLineBreak(stage);
+            emitLine("uniform " + lightData.getName() + " " + structName + structArraySuffix, stage);
+        }
         emitLineBreak(stage);
     }
 

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
@@ -39,7 +39,8 @@ void NumLightsNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext& co
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLine(NUM_LIGHTS_FUNC_SIGNATURE, stage, false);
         shadergen.emitScopeBegin(stage);
-        shadergen.emitLine("return min("+ HW::T_NUM_ACTIVE_LIGHT_SOURCES + ", MAX_LIGHT_SOURCES)", stage);
+        shadergen.emitLine("return min(" + HW::T_NUM_ACTIVE_LIGHT_SOURCES + ", " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + ") ",
+            stage);
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);
     END_SHADER_STAGE(shader, Stage::PIXEL)

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -119,6 +119,7 @@ namespace HW
     const string SHADOW_MATRIX                    = "u_shadowMatrix";
     const string VERTEX_DATA_INSTANCE             = "vd";
     const string LIGHT_DATA_INSTANCE              = "u_lightData";
+    const string LIGHT_DATA_MAX_LIGHT_SOURCES     = "MAX_LIGHT_SOURCES";
 
     const string VERTEX_INPUTS                    = "VertexInputs";
     const string VERTEX_DATA                      = "VertexData";

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -184,6 +184,7 @@ namespace HW
     extern const string SHADOW_MATRIX;
     extern const string VERTEX_DATA_INSTANCE;
     extern const string LIGHT_DATA_INSTANCE;
+    extern const string LIGHT_DATA_MAX_LIGHT_SOURCES;
 
     /// Variable blocks names.
     extern const string VERTEX_INPUTS;    // Geometric inputs for vertex stage.
@@ -408,6 +409,12 @@ public:
 
     // Emit uniforms with binding information
     virtual void emitResourceBindings(GenContext& context, const VariableBlock& uniforms, ShaderStage& stage) = 0;
+
+    // Emit struct uniforms with binding information
+    virtual void emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms,
+        ShaderStage& stage, const std::string& structInstanceName,
+        const std::string& arraySuffix = EMPTY_STRING) = 0;
+
 };
 
 } // namespace MaterialX


### PR DESCRIPTION
Update #584

Glsl shaders with Structured uniforms e.g. lightdata cannot be Cross Compiled to other targets.
The main issue is that members of the structures need to be aligned.
This can cause SPIRV exceptions such as:
SPIRV-Cross threw an exception: cbuffer ID 4559 (name: LightData_pixel), member index 0 (name: u_lightData) cannot be expressed with either HLSL packing layout or packoffset

Added a new HwResourceBindingContext::emitStructuredResourceBindings that can be used to generate struct with binding information.
It also tries to arrange the members so that they are aligned by adding padding as needed.

e.g.

```
struct LightData
{
    vec3 position;
    vec3 color;
    vec3 direction;
    float outer_angle;
    float inner_angle;
    float decay_rate;
    float intensity;
    int type;
    float pad0;
    float pad1;
    float pad2;
};

layout (std140, binding=20) uniform LightData_pixel
{
    LightData u_lightData[MAX_LIGHT_SOURCES];
};

```