### PR TITLE
Separate Binding Location for uniforms and samplers.

### DIFF
--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -11,7 +11,10 @@ namespace MaterialX
 //
 // GlslResourceBindingContext
 //
-GlslResourceBindingContext::GlslResourceBindingContext()
+GlslResourceBindingContext::GlslResourceBindingContext(
+    size_t uniformBindingLocation, size_t samplerBindingLocation) :
+    _hwInitUniformBindLocation(uniformBindingLocation),
+    _hwInitSamplerBindLocation(samplerBindingLocation)
 {
     _requiredExtensions.insert("GL_ARB_shading_language_420pack");
 }
@@ -19,7 +22,10 @@ GlslResourceBindingContext::GlslResourceBindingContext()
 void GlslResourceBindingContext::initialize()
 {
     // Reset bind location counter.
-    _hwBindLocation = 0;
+    _hwUniformBindLocation = _hwInitUniformBindLocation;
+
+    // Reset sampler bind location counter.
+    _hwSamplerBindLocation = _hwInitSamplerBindLocation;
 }
 
 void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage& stage)
@@ -49,7 +55,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     }
     if (hasValueUniforms)
     {
-        generator.emitLine("layout (std140, binding=" + std::to_string(_hwBindLocation++) + ") " + 
+        generator.emitLine("layout (std140, binding=" + std::to_string(_hwUniformBindLocation++) + ") " + 
                            syntax.getUniformQualifier() + " " + uniforms.getName() + "_" + stage.getName(), 
                            stage, false);
         generator.emitScopeBegin(stage);
@@ -71,7 +77,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     {
         if (uniform->getType() == Type::FILENAME)
         {
-            generator.emitString("layout (binding=" + std::to_string(_hwBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
+            generator.emitString("layout (binding=" + std::to_string(_hwSamplerBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
             generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);
             generator.emitLineEnd(stage, true);
         }
@@ -152,7 +158,7 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
 
     // emit the binding info
     generator.emitLineBreak(stage);
-    generator.emitLine("layout (std140, binding=" + std::to_string(_hwBindLocation++) +
+    generator.emitLine("layout (std140, binding=" + std::to_string(_hwUniformBindLocation++) +
         ") " + syntax.getUniformQualifier() + " " + uniforms.getName() + "_" +
         stage.getName(),
     stage, false);

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -23,9 +23,14 @@ class GlslResourceBindingContext : public HwResourceBindingContext
 {
 public:
 
-    GlslResourceBindingContext();
+    GlslResourceBindingContext(size_t uniformBindingLocation, size_t samplerBindingLocation);
 
-    static GlslResourceBindingContextPtr create() { return std::make_shared<GlslResourceBindingContext>(); }
+    static GlslResourceBindingContextPtr create(
+        size_t uniformBindingLocation=0, size_t samplerBindingLocation=0)
+    {
+        return std::make_shared<GlslResourceBindingContext>(
+            uniformBindingLocation, samplerBindingLocation);
+    }
 
     // Initialize the context before generation starts.
     void initialize() override;
@@ -45,8 +50,18 @@ protected:
     // List of required extensions
     StringSet _requiredExtensions;
 
-    // Binding location
-    size_t _hwBindLocation = 0;
+    // Binding location for Uniform Blocks
+    size_t _hwUniformBindLocation = 0;
+
+    // Initial value of uniform binding location
+    size_t _hwInitUniformBindLocation = 0;
+
+    // Binding location for Sampler Blocks
+    size_t _hwSamplerBindLocation = 0;
+
+    // Initial value of sampler binding location
+    size_t _hwInitSamplerBindLocation = 0;
+
 };
 
 } // namespace MaterialX

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -30,7 +30,7 @@ void bindPyGlslResourceBindingContext(py::module &mod)
 {
     py::class_<mx::GlslResourceBindingContext, mx::HwResourceBindingContext, mx::GlslResourceBindingContextPtr>(mod, "GlslResourceBindingContext")
         .def_static("create", &mx::GlslResourceBindingContext::create)
-        .def(py::init<>())
+        .def(py::init<size_t, size_t>())
         .def("emitDirectives", &mx::GlslResourceBindingContext::emitDirectives)
         .def("emitResourceBindings", &mx::GlslResourceBindingContext::emitResourceBindings);
 }


### PR DESCRIPTION
All binding locations are contiguous at the moment. This separates them for Uniforms (b# registers) and Samplers (t# registers)
Also added ability to set initial value