### PR TITLE
Fix MaterialX for VS2019 16.7 release

### DIFF
--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <iterator>
 
 namespace MaterialX
 {


### PR DESCRIPTION
With the latest VS2019 16.7 release, MaterialX fails to build (with e……rrors below).

Looks like this is caused by the internal changes from vs2019 16.6 to 16.7 release.
MaterialX\source\MaterialXCore\Element.cpp(753,32): error C2039: 'inserter': is not a member of 'std'