### PR TITLE
Fix issue with RtGeneric prim schema.

### DIFF
--- a/source/MaterialXRuntime/RtGeneric.cpp
+++ b/source/MaterialXRuntime/RtGeneric.cpp
@@ -14,6 +14,7 @@ namespace
 {
     static const RtToken KIND("kind");
     static const RtToken GENERIC1("generic1");
+    static const RtToken UNKNOWN("unknown");
 }
 
 DEFINE_TYPED_SCHEMA(RtGeneric, "generic");
@@ -37,12 +38,22 @@ RtPrim RtGeneric::createPrim(const RtToken& typeName, const RtToken& name, RtPri
 const RtToken& RtGeneric::getKind() const
 {
     RtTypedValue* v = prim()->getMetadata(KIND);
-    return v->getValue().asToken();
+    return v && v->getType() == RtType::TOKEN ? v->getValue().asToken() : UNKNOWN;
 }
 
-void RtGeneric::setKind(const RtToken& kind) const
+void RtGeneric::setKind(const RtToken& kind)
 {
-    RtTypedValue* v = prim()->getMetadata(KIND);
+    PvtPrim* p = prim();
+    RtTypedValue* v = p->getMetadata(KIND);
+    if (!v)
+    {
+        v = p->addMetadata(KIND, RtType::TOKEN);
+    }
+    else if (v->getType() != RtType::TOKEN)
+    {
+        p->removeMetadata(KIND);
+        v = p->addMetadata(KIND, RtType::TOKEN);
+    }
     v->getValue().asToken() = kind;
 }
 

--- a/source/MaterialXRuntime/RtGeneric.h
+++ b/source/MaterialXRuntime/RtGeneric.h
@@ -30,7 +30,7 @@ public:
 
     /// Set the kind for this generic prim,
     /// giving its custom typename.
-    void setKind(const RtToken& kind) const;
+    void setKind(const RtToken& kind);
 };
 
 }


### PR DESCRIPTION
Fix possible crash bug if a generic prim schema (RtGeneric) is attached to a prim that was not created as a generic prim.
