### PR TITLE
Fix crash when calling setNodeLayout on an empty nodegraph.

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -33,7 +33,8 @@ namespace
     // Lists of known metadata which are handled explicitly by import/export.
     static const RtTokenSet nodedefMetadata     = { RtToken("name"), RtToken("type"), RtToken("node") };
     static const RtTokenSet attrMetadata        = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("channels") };
-    static const RtTokenSet inputMetadata       = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("channels"), RtToken("nodegraph") };
+    static const RtTokenSet inputMetadata       = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("channels"), 
+                                                    RtToken("nodegraph"), RtToken("interfacename") };
     static const RtTokenSet nodeMetadata        = { RtToken("name"), RtToken("type"), RtToken("node") };
     static const RtTokenSet nodegraphMetadata   = { RtToken("name") };
     static const RtTokenSet genericMetadata     = { RtToken("name"), RtToken("kind") };

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -179,7 +179,7 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
     // Switch to the new order.
     p->_attrOrder = newAttrOrder;
 
-    // Assing uifolder metadata.
+    // Assign uifolder metadata.
     for (RtAttribute input : getInputs())
     {
         auto it = layout.uifolder.find(input.getName());

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -149,14 +149,13 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
     PvtDataHandleVec newAttrOrder;
     for (const RtToken& name : layout.order)
     {
-        PvtInput* input = p->getInput(name);
-        if (!input)
-        {
-            throw ExceptionRuntimeError("No input found with name '" + name.str() + "'");
-        }
         if (!processed.count(name))
         {
-            newAttrOrder.push_back(input->hnd());
+            PvtInput* input = p->getInput(name);
+            if (input)
+            {
+                newAttrOrder.push_back(input->hnd());
+            }
             processed.insert(name);
         }
     }
@@ -174,7 +173,7 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
     // Make sure all attributes where moved.
     if (processed.size() != p->_attrOrder.size())
     {
-        throw ExceptionRuntimeError("Faild setting new node layout for '" + getName().str() + "'");
+        throw ExceptionRuntimeError("Failed setting new node layout for '" + getName().str() + "'. Some attributes where not processed.");
     }
 
     // Switch to the new order.

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -170,7 +170,7 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
         }
     }
 
-    // Make sure all attributes where moved.
+    // Make sure all attributes were moved.
     if (newAttrOrder.size() != p->_attrOrder.size())
     {
         throw ExceptionRuntimeError("Failed setting new node layout for '" + getName().str() + "'. Changing the attribute count is not allowed.");

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -171,9 +171,9 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
     }
 
     // Make sure all attributes where moved.
-    if (processed.size() != p->_attrOrder.size())
+    if (newAttrOrder.size() != p->_attrOrder.size())
     {
-        throw ExceptionRuntimeError("Failed setting new node layout for '" + getName().str() + "'. Some attributes where not processed.");
+        throw ExceptionRuntimeError("Failed setting new node layout for '" + getName().str() + "'. Changing the attribute count is not allowed.");
     }
 
     // Switch to the new order.


### PR DESCRIPTION
- Fix crash when calling setNodeLayout on an empty nodegraph.
- Fix ignore saving of interfacename as metadata.
