### PR TITLE
Test and upgrade updates

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -14,6 +14,11 @@ try:
 except Exception:
     DIFF_ENABLED = False
 
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
+
 def createDiff(image1Path, image2Path, imageDiffPath):
     try:
         image1 = Image.open(image1Path).convert('RGB')
@@ -66,7 +71,7 @@ def main(args=None):
         if len(glslFiles) > 0 or len(oslFiles) > 0:
             fh.write("<h2>" + subdir + ":</h2><br>\n")
             fh.write("<table>\n")
-            for glslFile, oslFile in itertools.zip_longest(glslFiles, oslFiles):
+            for glslFile, oslFile in zip_longest(glslFiles, oslFiles):
                 fullGlslPath = os.path.join(subdir, glslFile) if glslFile else None
                 fullOslPath = os.path.join(subdir, oslFile) if glslFile else None
                 if glslFile and oslFile and DIFF_ENABLED and args.CREATE_DIFF:
@@ -75,20 +80,20 @@ def main(args=None):
                 else:
                     diffPath = None
                 fh.write("    <tr>\n")
-                if glslFile:
+                if fullGlslPath:
                     fh.write("        <td class='td_image'><img src='" + fullGlslPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' loading='lazy' style='background-color:black;'/></td>\n")
-                if oslFile:
+                if fullOslPath:
                     fh.write("        <td class='td_image'><img src='" + fullOslPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' loading='lazy' style='background-color:black;'/></td>\n")
                 if diffPath:
                     fh.write("        <td class='td_image'><img src='" + diffPath + "' height='" + str(args.imagewidth) + "' width='" + str(args.imagewidth) + "' loading='lazy' style='background-color:black;'/></td>\n")
                 fh.write("    </tr>\n")
                 fh.write("    <tr>\n")
-                if glslFile:
+                if fullGlslPath:
                     if args.ENABLE_TIMESTAMPS:
                         fh.write("        <td align='center'><p>" + glslFile + "</p>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullGlslPath))) + ")</td>\n")
                     else:
                         fh.write("        <td align='center'>" + glslFile + "</td>\n")
-                if oslFile:
+                if fullOslPath:
                     if args.ENABLE_TIMESTAMPS:
                         fh.write("        <td align='center'><p>" + oslFile + "</p>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullOslPath))) + ")</td>\n")
                     else:

--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -68,7 +68,7 @@ def main(args=None):
             print ("Number of glsl files " + str(len(glslFiles)) + " does not match number of osl files " +  str(len(oslFiles)) + " in dir: " + subdir)
             print ("GLSL list: " + str(glslFiles))
             print ("OSL files: " + str(oslFiles))
-        if len(glslFiles) > 0 or len(oslFiles) > 0:
+        if len(glslFiles) > 0 and len(oslFiles) > 0:
             fh.write("<h2>" + subdir + ":</h2><br>\n")
             fh.write("<table>\n")
             for glslFile, oslFile in zip_longest(glslFiles, oslFiles):

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -99,7 +99,7 @@
       <parameter name="applyFutureUpdates" type="boolean" value="true" />
       
       <!-- Wedge rendering options -->
-      <parameter name="wedgeFiles" type="string" value="conductor.mtlx" />
+      <parameter name="wedgeFiles" type="string" value="" />
       <parameter name="wedgeParameters" type="string" value="test_conductor/roughness1/roughness" />
       <parameter name="wedgeRangeMin" type="floatarray" value="0.0" />
       <parameter name="wedgeRangeMax" type="floatarray" value="1.0" />

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -99,11 +99,11 @@
       <parameter name="applyFutureUpdates" type="boolean" value="true" />
       
       <!-- Wedge rendering options -->
-      <parameter name="wedgeFiles" type="string" value="wedge_conductor.mtlx" />
-      <parameter name="wedgeParameters" type="string" value="test_conductor/roughness1/roughness" />
-      <parameter name="wedgeRangeMin" type="floatarray" value="0.0" />
-      <parameter name="wedgeRangeMax" type="floatarray" value="1.0" />
-      <parameter name="wedgeSteps" type="integerarray" value="8" />
+      <parameter name="wedgeFiles" type="string" value="wedge_conductor.mtlx,wedge_conductor.mtlx" />
+      <parameter name="wedgeParameters" type="string" value="test_conductor/roughness1/roughness,test_conductor/roughness1/anisotropy" />
+      <parameter name="wedgeRangeMin" type="floatarray" value="0.0, 0.3" />
+      <parameter name="wedgeRangeMax" type="floatarray" value="1.0, 0.9" />
+      <parameter name="wedgeSteps" type="integerarray" value="4, 3" />
 
    </nodedef>
 </materialx>

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -99,7 +99,7 @@
       <parameter name="applyFutureUpdates" type="boolean" value="true" />
       
       <!-- Wedge rendering options -->
-      <parameter name="wedgeFiles" type="string" value="" />
+      <parameter name="wedgeFiles" type="string" value="wedge_conductor.mtlx" />
       <parameter name="wedgeParameters" type="string" value="test_conductor/roughness1/roughness" />
       <parameter name="wedgeRangeMin" type="floatarray" value="0.0" />
       <parameter name="wedgeRangeMax" type="floatarray" value="1.0" />

--- a/resources/Materials/TestSuite/pbrlib/bsdf/wedge_conductor.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/wedge_conductor.mtlx
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<materialx version="1.37">
+  <nodegraph name="test_conductor">
+    <roughness_anisotropy name="roughness1" type="vector2">
+      <input name="roughness" type="float" value="0.2" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </roughness_anisotropy>
+    <conductor_brdf name="conductor_brdf1" type="BSDF">
+      <input name="reflectivity" type="color3" value="1, 1, 1"/>
+      <input name="edge_color" type="color3" value="1, 1, 1"/>
+      <input name="roughness" type="vector2" nodename="roughness1" />
+    </conductor_brdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="conductor_brdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+</materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -6,6 +6,7 @@
 #include <MaterialXCore/Document.h>
 
 #include <MaterialXCore/Util.h>
+#include <MaterialXCore/MaterialNode.h>
 
 #include <mutex>
 
@@ -29,139 +30,6 @@ template<class T> shared_ptr<T> updateChildSubclass(ElementPtr parent, ElementPt
     parent->setChildIndex(childName, childIndex);
     newChild->copyContentFrom(origChild);
     return newChild;
-}
-
-bool convertMaterialsToNodes(DocumentPtr doc)
-{
-    bool modified = false;
-
-    vector<MaterialPtr> materials = doc->getMaterials();
-    for (auto m : materials)
-    {
-        // See if a node of this name has already been created.
-        // Should not occur otherwise there are duplicate existing
-        // Material elements.
-        string materialName = m->getName();
-        if (doc->getNode(materialName))
-        {
-            throw Exception("Material node already exists: " + materialName);
-        }
-
-        // Create a temporary name for the material element
-        // so the new node can reuse the existing name.
-        string validName = doc->createValidChildName(materialName + "1");
-        m->setName(validName);
-
-        // Create a new material node
-        NodePtr materialNode = nullptr;
-
-        ShaderRefPtr sr;
-        // Only include the shader refs explicitly specified on the material instance
-        vector<ShaderRefPtr> srs = m->getShaderRefs();
-        for (size_t i = 0; i < srs.size(); i++)
-        {
-            sr = srs[i];
-
-            // See if shader has been created already.
-            // Should not occur as the shaderref is a uniquely named
-            // child of a uniquely named material element, but the two combined
-            // may have been used for another node instance which not a shader node.
-            string shaderNodeName = materialName + "_" + sr->getName();
-            NodePtr existingShaderNode = doc->getNode(shaderNodeName);
-            if (existingShaderNode)
-            {
-                const string& existingType = existingShaderNode->getType();
-                if (existingType == VOLUME_SHADER_TYPE_STRING ||
-                    existingType == SURFACE_SHADER_TYPE_STRING ||
-                    existingType == DISPLACEMENT_SHADER_TYPE_STRING)
-                {
-                    throw Exception("Shader node already exists: " + shaderNodeName);
-                }
-                else
-                {
-                    shaderNodeName = doc->createValidChildName(shaderNodeName);
-                }
-            }
-
-            modified = true;
-
-            // Find the shader type if defined
-            string shaderNodeType = SURFACE_SHADER_TYPE_STRING;
-            NodeDefPtr nodeDef = sr->getNodeDef();
-            if (nodeDef)
-            {
-                shaderNodeType = nodeDef->getType();
-            }
-
-            // Add in a new shader node
-            const string shaderNodeCategory = sr->getNodeString();
-            NodePtr shaderNode = doc->addNode(shaderNodeCategory, shaderNodeName, shaderNodeType);
-            shaderNode->setSourceUri(sr->getSourceUri());
-
-            for (auto valueElement : sr->getChildrenOfType<ValueElement>())
-            {
-                ElementPtr portChild = nullptr;
-
-                // Copy over bindinputs as inputs, and bindparams as params
-                if (valueElement->isA<BindInput>())
-                {
-                    portChild = shaderNode->addInput(valueElement->getName(), valueElement->getType());
-                }
-                else if (valueElement->isA<BindParam>())
-                {
-                    portChild = shaderNode->addInput(valueElement->getName(), valueElement->getType());
-                }
-                if (portChild)
-                {
-                    // Copy over attributes.
-                    // Note: We preserve inputs which have nodegraph connections,
-                    // as well as top level output connections.
-                    portChild->copyContentFrom(valueElement);
-                }
-            }
-
-            // Copy over any bindtokens as tokens
-            for (auto bt : sr->getBindTokens())
-            {
-                TokenPtr token = shaderNode->addToken(bt->getName());
-                token->copyContentFrom(bt);
-            }
-
-            // Create a new material node if not already created and
-            // add a reference from the material node to the new shader node
-            if (!materialNode)
-            {
-                // Set the type of material based on current assumption that
-                // surfaceshaders + displacementshaders result in a surfacematerial
-                // while a volumeshader means a volumematerial needs to be created.
-                string materialNodeCategory =
-                    (shaderNodeType != VOLUME_SHADER_TYPE_STRING) ? SURFACE_MATERIAL_NODE_STRING
-                    : VOLUME_MATERIAL_NODE_STRING;
-                materialNode = doc->addNode(materialNodeCategory, materialName, MATERIAL_TYPE_STRING);
-                materialNode->setSourceUri(m->getSourceUri());
-                // Note: Inheritance does not get transfered to the node we do
-                // not perform the following:
-                //      - materialNode->setInheritString(m->getInheritString());
-            }
-            // Create input to replace each shaderref. Use shaderref name as unique
-            // input name.
-            InputPtr shaderInput = materialNode->addInput(shaderNodeType, shaderNodeType);
-            shaderInput->setNodeName(shaderNode->getName());
-            // Make sure to copy over any target and version information from the shaderref.
-            if (!sr->getTarget().empty())
-            {
-                shaderInput->setTarget(sr->getTarget());
-            }
-            if (!sr->getVersionString().empty())
-            {
-                shaderInput->setVersionString(sr->getVersionString());
-            }
-        }
-
-        // Remove existing material element
-        doc->removeChild(m->getName());
-    }
-    return modified;
 }
 
 } // anonymous namespace

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -615,7 +615,7 @@ class Document : public GraphElement
     /// the library version.
     /// @param applyFutureUpdates Apply updates that test prototype functionality
     ///    for future versions of MaterialX
-    void upgradeVersion(bool applyFutureUpdates = false);
+    void upgradeVersion(bool applyFutureUpdates = true);
 
     /// @}
     /// @name Color Management System

--- a/source/MaterialXCore/MaterialNode.cpp
+++ b/source/MaterialXCore/MaterialNode.cpp
@@ -7,6 +7,139 @@
 
 namespace MaterialX
 {
+bool convertMaterialsToNodes(DocumentPtr doc)
+{
+    bool modified = false;
+
+    vector<MaterialPtr> materials = doc->getMaterials();
+    for (auto m : materials)
+    {
+        // See if a node of this name has already been created.
+        // Should not occur otherwise there are duplicate existing
+        // Material elements.
+        string materialName = m->getName();
+        if (doc->getNode(materialName))
+        {
+            throw Exception("Material node already exists: " + materialName);
+        }
+
+        // Create a temporary name for the material element
+        // so the new node can reuse the existing name.
+        string validName = doc->createValidChildName(materialName + "1");
+        m->setName(validName);
+
+        // Create a new material node
+        NodePtr materialNode = nullptr;
+
+        ShaderRefPtr sr;
+        // Only include the shader refs explicitly specified on the material instance
+        vector<ShaderRefPtr> srs = m->getShaderRefs();
+        for (size_t i = 0; i < srs.size(); i++)
+        {
+            sr = srs[i];
+
+            // See if shader has been created already.
+            // Should not occur as the shaderref is a uniquely named
+            // child of a uniquely named material element, but the two combined
+            // may have been used for another node instance which not a shader node.
+            string shaderNodeName = materialName + "_" + sr->getName();
+            NodePtr existingShaderNode = doc->getNode(shaderNodeName);
+            if (existingShaderNode)
+            {
+                const string& existingType = existingShaderNode->getType();
+                if (existingType == VOLUME_SHADER_TYPE_STRING ||
+                    existingType == SURFACE_SHADER_TYPE_STRING ||
+                    existingType == DISPLACEMENT_SHADER_TYPE_STRING)
+                {
+                    throw Exception("Shader node already exists: " + shaderNodeName);
+                }
+                else
+                {
+                    shaderNodeName = doc->createValidChildName(shaderNodeName);
+                }
+            }
+
+            modified = true;
+
+            // Find the shader type if defined
+            string shaderNodeType = SURFACE_SHADER_TYPE_STRING;
+            NodeDefPtr nodeDef = sr->getNodeDef();
+            if (nodeDef)
+            {
+                shaderNodeType = nodeDef->getType();
+            }
+
+            // Add in a new shader node
+            const string shaderNodeCategory = sr->getNodeString();
+            NodePtr shaderNode = doc->addNode(shaderNodeCategory, shaderNodeName, shaderNodeType);
+            shaderNode->setSourceUri(sr->getSourceUri());
+
+            for (auto valueElement : sr->getChildrenOfType<ValueElement>())
+            {
+                ElementPtr portChild = nullptr;
+
+                // Copy over bindinputs as inputs, and bindparams as params
+                if (valueElement->isA<BindInput>())
+                {
+                    portChild = shaderNode->addInput(valueElement->getName(), valueElement->getType());
+                }
+                else if (valueElement->isA<BindParam>())
+                {
+                    portChild = shaderNode->addInput(valueElement->getName(), valueElement->getType());
+                }
+                if (portChild)
+                {
+                    // Copy over attributes.
+                    // Note: We preserve inputs which have nodegraph connections,
+                    // as well as top level output connections.
+                    portChild->copyContentFrom(valueElement);
+                }
+            }
+
+            // Copy over any bindtokens as tokens
+            for (auto bt : sr->getBindTokens())
+            {
+                TokenPtr token = shaderNode->addToken(bt->getName());
+                token->copyContentFrom(bt);
+            }
+
+            // Create a new material node if not already created and
+            // add a reference from the material node to the new shader node
+            if (!materialNode)
+            {
+                // Set the type of material based on current assumption that
+                // surfaceshaders + displacementshaders result in a surfacematerial
+                // while a volumeshader means a volumematerial needs to be created.
+                string materialNodeCategory =
+                    (shaderNodeType != VOLUME_SHADER_TYPE_STRING) ? SURFACE_MATERIAL_NODE_STRING
+                    : VOLUME_MATERIAL_NODE_STRING;
+                materialNode = doc->addNode(materialNodeCategory, materialName, MATERIAL_TYPE_STRING);
+                materialNode->setSourceUri(m->getSourceUri());
+                // Note: Inheritance does not get transfered to the node we do
+                // not perform the following:
+                //      - materialNode->setInheritString(m->getInheritString());
+            }
+            // Create input to replace each shaderref. Use shaderref name as unique
+            // input name.
+            InputPtr shaderInput = materialNode->addInput(shaderNodeType, shaderNodeType);
+            shaderInput->setNodeName(shaderNode->getName());
+            // Make sure to copy over any target and version information from the shaderref.
+            if (!sr->getTarget().empty())
+            {
+                shaderInput->setTarget(sr->getTarget());
+            }
+            if (!sr->getVersionString().empty())
+            {
+                shaderInput->setVersionString(sr->getVersionString());
+            }
+        }
+
+        // Remove existing material element
+        doc->removeChild(m->getName());
+    }
+    return modified;
+}
+
 
 std::unordered_set<NodePtr> getShaderNodes(const NodePtr& materialNode, const string& nodeType, const string& target)
 {

--- a/source/MaterialXCore/MaterialNode.h
+++ b/source/MaterialXCore/MaterialNode.h
@@ -20,6 +20,11 @@
 namespace MaterialX
 {
 
+/// Convert usage of Material Elements to Material nodes
+/// @param doc Document to convert
+/// @return If any conversion occurred.
+bool convertMaterialsToNodes(DocumentPtr doc);
+
 /// Return a vector of all nodes connected to a Material node's inputs. The default behavior
 /// is to return connected surface shader nodes.
 /// @param materialNode Node to examine.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -242,7 +242,7 @@ void documentFromXml(DocumentPtr doc,
 
 XmlReadOptions::XmlReadOptions() :
     readXIncludeFunction(readFromXmlFile),
-    applyFutureUpdates(false)
+    applyFutureUpdates(true)
 {
 }
 

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -230,7 +230,7 @@ void documentFromXml(DocumentPtr doc,
         elementFromXml(xmlRoot, doc, readOptions);
     }
 
-    bool applyFutureUpdates = readOptions ? readOptions->applyFutureUpdates : false;
+    bool applyFutureUpdates = readOptions ? readOptions->applyFutureUpdates : true;
     doc->upgradeVersion(applyFutureUpdates);
 }
 

--- a/source/MaterialXTest/MaterialXCore/Observer.cpp
+++ b/source/MaterialXTest/MaterialXCore/Observer.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Observer", "[observer]")
             REQUIRE(_beginUpdateCount == 4);
             REQUIRE(_endUpdateCount == 4);
             REQUIRE(_addElementCount == 12);
-            REQUIRE(_setAttributeCount == 16);
+            REQUIRE(_setAttributeCount == 17);
             REQUIRE(_removeElementCount == 4);
             REQUIRE(_removeAttributeCount == 0);
             REQUIRE(_copyContentCount == 0);

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -996,6 +996,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     MaterialX::DocumentPtr doc = MaterialX::createDocument();
     try {
         mx::XmlReadOptions readOptions;
+        readOptions.applyFutureUpdates = true;
         MaterialX::readFromXmlFile(doc, optionFile, mx::FileSearchPath(), &readOptions);
 
         MaterialX::NodeDefPtr optionDefs = doc->getNodeDef(RENDER_TEST_OPTIONS_STRING);

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -1115,7 +1115,12 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
 
                     else if (name == WEDGE_FILES)
                     {
-                        wedgeFiles = mx::splitString(p->getValueString(), ",");
+                        wedgeFiles.clear();
+                        mx::StringVec fileList = mx::splitString(p->getValueString(), ",");
+                        if (!fileList.empty())
+                        {
+                            wedgeFiles.insert(fileList.begin(), fileList.end());
+                        }
                     }
                     else if (name == WEDGE_PARAMETERS)
                     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -1115,12 +1115,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
 
                     else if (name == WEDGE_FILES)
                     {
-                        wedgeFiles.clear();
-                        mx::StringVec fileList = mx::splitString(p->getValueString(), ",");
-                        if (!fileList.empty())
-                        {
-                            wedgeFiles.insert(fileList.begin(), fileList.end());
-                        }
+                        wedgeFiles = mx::splitString(p->getValueString(), ",");
                     }
                     else if (name == WEDGE_PARAMETERS)
                     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -142,7 +142,7 @@ class TestSuiteOptions
     mx::FileSearchPath externalTestPaths;
 
     // Wedge parameters
-    mx::StringVec wedgeFiles;
+    mx::StringSet wedgeFiles;
     mx::StringVec wedgeParameters;
     mx::FloatVec wedgeRangeMin;
     mx::FloatVec wedgeRangeMax;

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -142,7 +142,7 @@ class TestSuiteOptions
     mx::FileSearchPath externalTestPaths;
 
     // Wedge parameters
-    mx::StringSet wedgeFiles;
+    mx::StringVec wedgeFiles;
     mx::StringVec wedgeParameters;
     mx::FloatVec wedgeRangeMin;
     mx::FloatVec wedgeRangeMax;

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -368,11 +368,8 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                             const mx::FloatVec& wedgeRangeMax = options.wedgeRangeMax;
                             const mx::IntVec& wedgeSteps = options.wedgeSteps;
                             const mx::StringVec& wedgeFiles = options.wedgeFiles;
-                            mx::StringSet wedgeFileSet;
-                            if (!wedgeFiles.empty())
-                            {
-                                wedgeFileSet.insert(wedgeFiles.begin(), wedgeFiles.end());
-                            }
+                            mx::StringSet wedgeFileSet(wedgeFiles.begin(), wedgeFiles.end());
+
                             bool performWedge = (!wedgeFiles.empty()) &&
                                 wedgeFileSet.count(file) &&
                                 wedgeFiles.size() == wedgeParameters.size() &&

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -121,7 +121,6 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     if (!runTest(options))
     {
         log << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
-        std::cout  << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
         return false;
     }
 

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -121,6 +121,7 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
     if (!runTest(options))
     {
         log << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
+        std::cout  << "Language / target: " << _languageTargetString << " not set to run. Skip test." << std::endl;
         return false;
     }
 
@@ -363,12 +364,13 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                                 usedImpls.insert(nodeGraphImpl ? nodeGraphImpl->getName() : impl->getName());
                             }
 
-                            const mx::StringVec& wedgeFiles = options.wedgeFiles;
+                            const mx::StringSet& wedgeFiles = options.wedgeFiles;
                             const mx::StringVec& wedgeParameters = options.wedgeParameters;
                             const mx::FloatVec& wedgeRangeMin = options.wedgeRangeMin;
                             const mx::FloatVec& wedgeRangeMax = options.wedgeRangeMax;
                             const mx::IntVec& wedgeSteps = options.wedgeSteps;
                             bool performWedge = (!wedgeFiles.empty()) &&
+                                wedgeFiles.count(file) &&
                                 wedgeFiles.size() == wedgeParameters.size() &&
                                 wedgeFiles.size() == wedgeRangeMin.size() &&
                                 wedgeFiles.size() == wedgeRangeMax.size() &&
@@ -383,12 +385,6 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                                 mx::ImageVec imageVec;
                                 for (size_t f = 0; f < wedgeFiles.size(); f++)
                                 {
-                                    const std::string& wedgeFile = wedgeFiles[f];
-                                    if (wedgeFile != file)
-                                    {
-                                        continue;
-                                    }
-
                                     // Make this a utility
                                     std::string parameterPath = wedgeParameters[f];
                                     mx::ElementPtr uniformElement = doc->getDescendant(parameterPath);

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -363,13 +363,18 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                                 usedImpls.insert(nodeGraphImpl ? nodeGraphImpl->getName() : impl->getName());
                             }
 
-                            const mx::StringSet& wedgeFiles = options.wedgeFiles;
                             const mx::StringVec& wedgeParameters = options.wedgeParameters;
                             const mx::FloatVec& wedgeRangeMin = options.wedgeRangeMin;
                             const mx::FloatVec& wedgeRangeMax = options.wedgeRangeMax;
                             const mx::IntVec& wedgeSteps = options.wedgeSteps;
+                            const mx::StringVec& wedgeFiles = options.wedgeFiles;
+                            mx::StringSet wedgeFileSet;
+                            if (!wedgeFiles.empty())
+                            {
+                                wedgeFileSet.insert(wedgeFiles.begin(), wedgeFiles.end());
+                            }
                             bool performWedge = (!wedgeFiles.empty()) &&
-                                wedgeFiles.count(file) &&
+                                wedgeFileSet.count(file) &&
                                 wedgeFiles.size() == wedgeParameters.size() &&
                                 wedgeFiles.size() == wedgeRangeMin.size() &&
                                 wedgeFiles.size() == wedgeRangeMax.size() &&
@@ -381,9 +386,16 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                             }
                             else
                             {
-                                mx::ImageVec imageVec;
                                 for (size_t f = 0; f < wedgeFiles.size(); f++)
                                 {
+                                    mx::ImageVec imageVec;
+
+                                    const std::string& wedgeFile = wedgeFiles[f];
+                                    if (wedgeFile != file)
+                                    {
+                                        continue;
+                                    }
+
                                     // Make this a utility
                                     std::string parameterPath = wedgeParameters[f];
                                     mx::ElementPtr uniformElement = doc->getDescendant(parameterPath);

--- a/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
@@ -77,6 +77,7 @@ void bindPyMaterial(py::module& mod)
         .def("getReferencedOutputs", &mx::ShaderRef::getReferencedOutputs)
         .def_readonly_static("CATEGORY", &mx::ShaderRef::CATEGORY);
 
+    mod.def("convertMaterialsToNodes", &mx::convertMaterialsToNodes);
     mod.def("getShaderNodes", &mx::getShaderNodes);
     mod.def("getGeometryBindings", &mx::getGeometryBindings);
 


### PR DESCRIPTION
Update #632.
Update #966 

- Change the default to apply upgrades. The onus is on integrators to set a read option to not upgrade to the latest. 
   - Note that this does not affect material node upgrade only the "latest" which is parameter->input upgrade.
- Prep / separate out material node upgrade. TBD where to put parameter->input upgrade.
- Fix up test display script to allow usage of on izip_longest (already in ILM 1.38 branch).
- Turn off wedge rendering by default.
