### PR TITLE
Change generic metadata to use string instead of token

### DIFF
--- a/source/MaterialXRuntime/Private/PvtApi.cpp
+++ b/source/MaterialXRuntime/Private/PvtApi.cpp
@@ -100,7 +100,7 @@ RtToken PvtApi::makeUniqueName(const RtToken& name) const
         }
         // Iterate until there is no other stage with the resulting name.
         do {
-            newName = baseName + std::to_string(i++);
+            newName = RtToken(baseName + std::to_string(i++));
             otherStage = getStage(newName);
         } while (otherStage);
     }

--- a/source/MaterialXRuntime/Private/PvtNameResolver.cpp
+++ b/source/MaterialXRuntime/Private/PvtNameResolver.cpp
@@ -150,7 +150,7 @@ RtToken PvtNameResolverRegistry::resolveIdentifier(const RtToken& valueToResolve
     RtToken type(GEOMNAME_TYPE_STRING);
     if (elementType == RtNameResolverInfo::ElementType::FILENAME_TYPE)
     {
-        type = FILENAME_TYPE_STRING;
+        type = RtToken(FILENAME_TYPE_STRING);
     }
     
     RtToken result = valueToResolve;
@@ -165,7 +165,7 @@ RtToken PvtNameResolverRegistry::resolveIdentifier(const RtToken& valueToResolve
                     PvtUserStringResolverPtr resolverPtr = std::dynamic_pointer_cast<PvtUserStringResolver>(resolverPair.second->getToMaterialXResolver());
                     if (resolverPtr)
                     {
-                        result = resolverPtr->resolve(result, type);
+                        result = RtToken(resolverPtr->resolve(result, type));
                     }
                 }
             }
@@ -176,7 +176,7 @@ RtToken PvtNameResolverRegistry::resolveIdentifier(const RtToken& valueToResolve
                     PvtUserStringResolverPtr resolverPtr = std::dynamic_pointer_cast<PvtUserStringResolver>(resolverPair.second->getFromMaterialXResolver());
                     if (resolverPtr)
                     {
-                        result = resolverPtr->resolve(result, type);
+                        result = RtToken(resolverPtr->resolve(result, type));
                     }
                 }
             }

--- a/source/MaterialXRuntime/Private/PvtPrim.cpp
+++ b/source/MaterialXRuntime/Private/PvtPrim.cpp
@@ -245,7 +245,7 @@ RtToken PvtPrim::makeUniqueChildName(const RtToken& name) const
         }
         // Iterate until there is no other child with the resulting name.
         do {
-            newName = baseName + std::to_string(i++);
+            newName = RtToken(baseName + std::to_string(i++));
             otherChild = getChild(newName);
 	    otherAttr = getAttribute(newName);
         } while (otherChild || otherAttr);

--- a/source/MaterialXRuntime/Private/PvtTypeDef.cpp
+++ b/source/MaterialXRuntime/Private/PvtTypeDef.cpp
@@ -293,7 +293,7 @@ template<> void fromStringValue<string>(const string& str, RtValue& dest)
 }
 template<> void fromStringValue<RtToken>(const string& str, RtValue& dest)
 {
-    dest.asToken() = str;
+    dest.asToken() = RtToken(str);
 }
 void fromStringNoneValue(const string&, RtValue& dest)
 {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -116,7 +116,7 @@ namespace
             {
                 // Store all generic metadata as strings.
                 RtTypedValue* md = dest->addMetadata(mdName, RtType::STRING);
-                md->getValue().asToken() = src->getAttribute(name);
+                md->getValue().asString() = src->getAttribute(name);
             }
         }
     }

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -35,9 +35,9 @@ namespace
     static const RtTokenSet attrMetadata        = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("channels") };
     static const RtTokenSet inputMetadata       = { RtToken("name"), RtToken("type"), RtToken("value"), RtToken("nodename"), RtToken("output"), RtToken("channels"), 
                                                     RtToken("nodegraph"), RtToken("interfacename") };
-    static const RtTokenSet nodeMetadata        = { RtToken("name"), RtToken("type"), RtToken("node"), RtToken("xpos"), RtToken("ypos") };
-    static const RtTokenSet nodegraphMetadata   = { RtToken("name"), RtToken("xpos"), RtToken("ypos") };
-    static const RtTokenSet genericMetadata     = { RtToken("name"), RtToken("kind"), RtToken("xpos"), RtToken("ypos") };
+    static const RtTokenSet nodeMetadata        = { RtToken("name"), RtToken("type"), RtToken("node") };
+    static const RtTokenSet nodegraphMetadata   = { RtToken("name") };
+    static const RtTokenSet genericMetadata     = { RtToken("name"), RtToken("kind") };
     static const RtTokenSet stageMetadata       = {};
 
     static const RtToken DEFAULT_OUTPUT("out");
@@ -114,8 +114,8 @@ namespace
             const RtToken mdName(name);
             if (!ignoreList.count(mdName))
             {
-                // Store all custom attributes as string tokens.
-                RtTypedValue* md = dest->addMetadata(mdName, RtType::TOKEN);
+                // Store all generic metadata as strings.
+                RtTypedValue* md = dest->addMetadata(mdName, RtType::STRING);
                 md->getValue().asToken() = src->getAttribute(name);
             }
         }
@@ -143,36 +143,6 @@ namespace
             {
                 dest->setAttribute(name.str(), valueString);
             }
-        }
-    }
-
-    void readUiPosition(const ElementPtr& src, PvtObject* dest)
-    {
-        const string& xpos = src->getAttribute(XPOS);
-        if (!xpos.empty())
-        {
-            RtTypedValue* md = dest->addMetadata(XPOS, RtType::STRING);
-            md->getValue().asString() = xpos;
-        }
-        const string& ypos = src->getAttribute(YPOS);
-        if (!ypos.empty())
-        {
-            RtTypedValue* md = dest->addMetadata(YPOS, RtType::STRING);
-            md->getValue().asString() = ypos;
-        }
-    }
-
-    void writeUiPosition(const PvtObject* src, ElementPtr dest)
-    {
-        const RtTypedValue* xpos = src->getMetadata(XPOS);
-        if (xpos)
-        {
-            dest->setAttribute(XPOS.str(), xpos->getValue().asString());
-        }
-        const RtTypedValue* ypos = src->getMetadata(YPOS);
-        if (ypos)
-        {
-            dest->setAttribute(YPOS.str(), ypos->getValue().asString());
         }
     }
 
@@ -359,7 +329,6 @@ namespace
         mapper.addMapping(parent, nodeName, node->getName());
 
         readMetadata(src, node, attrMetadata);
-        readUiPosition(src, node);
 
         // Copy input values.
         for (auto elem : src->getChildrenOfType<ValueElement>())
@@ -395,7 +364,6 @@ namespace
         RtNodeGraph schema(nodegraph->hnd());
 
         readMetadata(src, nodegraph, nodegraphMetadata);
-        readUiPosition(src, nodegraph);
 
         // Create the interface either from a nodedef if given
         // otherwise from the graph itself.
@@ -497,7 +465,6 @@ namespace
         generic.setKind(category);
 
         readMetadata(src, prim, genericMetadata);
-        readUiPosition(src, prim);
 
         for (auto child : src->getChildren())
         {
@@ -910,7 +877,6 @@ namespace
         }
 
         writeMetadata(src, destNode, nodeMetadata, options);
-        writeUiPosition(src, destNode);
 
         return destNode;
     }
@@ -919,7 +885,6 @@ namespace
     {
         NodeGraphPtr destNodeGraph = dest->addNodeGraph(src->getName());
         writeMetadata(src, destNodeGraph, nodegraphMetadata, options);
-        writeUiPosition(src, destNodeGraph);
 
         RtNodeGraph nodegraph(src->hnd());
 
@@ -1112,7 +1077,6 @@ namespace
 
         ElementPtr elem = dest->addChildOfCategory(generic.getKind(), generic.getName());
         writeMetadata(src, elem, genericMetadata, options);
-        writeUiPosition(src, elem);
 
         for (auto child : src->getChildren())
         {

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -221,9 +221,9 @@ RtNodeLayout RtNodeDef::getNodeLayout()
     {
         layout.order.push_back(input.getName());
         RtTypedValue* data = input.getMetadata(UIFOLDER);
-        if (data && data->getType() == RtType::TOKEN)
+        if (data && data->getType() == RtType::STRING)
         {
-            layout.uifolder[input.getName()] = data->getValue().asToken();
+            layout.uifolder[input.getName()] = data->getValue().asString();
         }
     }
     return layout;

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -19,7 +19,7 @@ namespace MaterialX
 struct RtNodeLayout
 {
     RtTokenVec order;
-    RtTokenMap<RtToken> uifolder;
+    RtTokenMap<string> uifolder;
 };
 
 /// @class RtNodeDef

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -129,9 +129,9 @@ RtNodeLayout RtNodeGraph::getNodeLayout()
     {
         layout.order.push_back(input.getName());
         RtTypedValue* data = input.getMetadata(RtNodeDef::RtNodeDef::UIFOLDER);
-        if (data && data->getType() == RtType::TOKEN)
+        if (data && data->getType() == RtType::STRING)
         {
-            layout.uifolder[input.getName()] = data->getValue().asToken();
+            layout.uifolder[input.getName()] = data->getValue().asString();
         }
     }
     return layout;

--- a/source/MaterialXRuntime/RtNodeGraph.cpp
+++ b/source/MaterialXRuntime/RtNodeGraph.cpp
@@ -180,19 +180,19 @@ void RtNodeGraph::setNodeLayout(const RtNodeLayout& layout)
     for (RtAttribute input : getInputs())
     {
         auto it = layout.uifolder.find(input.getName());
-        if (it != layout.uifolder.end() && it->second != EMPTY_TOKEN)
+        if (it != layout.uifolder.end() && !it->second.empty())
         {
             RtTypedValue* data = input.getMetadata(RtNodeDef::UIFOLDER);
             if (!data)
             {
-                data = input.addMetadata(RtNodeDef::UIFOLDER, RtType::TOKEN);
+                data = input.addMetadata(RtNodeDef::UIFOLDER, RtType::STRING);
             }
-            else if (data->getType() != RtType::TOKEN)
+            else if (data->getType() != RtType::STRING)
             {
                 input.removeMetadata(RtNodeDef::UIFOLDER);
-                data = input.addMetadata(RtNodeDef::UIFOLDER, RtType::TOKEN);
+                data = input.addMetadata(RtNodeDef::UIFOLDER, RtType::STRING);
             }
-            data->getValue().asToken() = it->second;
+            data->getValue().asString() = it->second;
         }
         else
         {

--- a/source/MaterialXRuntime/RtToken.h
+++ b/source/MaterialXRuntime/RtToken.h
@@ -69,20 +69,6 @@ public:
         return *this;
     }
 
-    /// Assignment operator from std::string.
-    const RtToken& operator=(const string& other)
-    {
-        assign(RtToken(other));
-        return *this;
-    }
-
-    /// Assignment operator from raw string.
-    const RtToken& operator=(const char* other)
-    {
-        assign(RtToken(other));
-        return *this;
-    }
-
     /// Equality operator
     /// Fast compare of the token pointers.
     bool operator==(const RtToken& other) const

--- a/source/MaterialXRuntime/RtTypeInfo.cpp
+++ b/source/MaterialXRuntime/RtTypeInfo.cpp
@@ -25,7 +25,7 @@ RtTypeInfo::RtTypeInfo(const char* typeNameHierachy) :
 
     const RtToken longName(typeNameHierachy);
     StringVec names = splitString(longName, ":");
-    info->shortName = names.back();
+    info->shortName = RtToken(names.back());
     info->longName = longName;
     for (size_t i = 0; i < names.size() - 1; ++i)
     {

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -771,20 +771,20 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     mx::RtNodeLayout layout = oldLayout;
     REQUIRE(layout.order.size() == 3);
     std::swap(layout.order[0], layout.order[2]);
-    mx::RtToken path1("path1");
-    mx::RtToken path2("path1/path2");
+    std::string path1("path1");
+    std::string path2("path1/path2");
     layout.uifolder[A] = layout.uifolder[B] = path1;
     layout.uifolder[X] = path2;
     graph1.setNodeLayout(layout);
     mx::RtAttrIterator orderIt = graph1.getInputs();
     REQUIRE((*orderIt).getName() == X);
-    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asToken() == path2);
+    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asString() == path2);
     ++orderIt;
     REQUIRE((*orderIt).getName() == B);
-    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asToken() == path1);
+    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asString() == path1);
     ++orderIt;
     REQUIRE((*orderIt).getName() == A);
-    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asToken() == path1);
+    REQUIRE((*orderIt).getMetadata(UIFOLDER)->getValue().asString() == path1);
     // Reset the old order
     graph1.setNodeLayout(oldLayout);
     orderIt = graph1.getInputs();
@@ -1768,17 +1768,13 @@ TEST_CASE("Runtime: Looks", "[runtime]")
 mx::RtToken toTestResolver(const mx::RtToken& str, const mx::RtToken& type)
 {
     mx::StringResolverPtr resolver = mx::StringResolver::create();
-    mx::RtToken resolvedName = mx::RtToken(resolver->resolve(str, type).c_str());
-    resolvedName = resolvedName.str() + "_toTestResolver";
-    return resolvedName;
+    return mx::RtToken(resolver->resolve(str, type) + "_toTestResolver");
 }
 
 mx::RtToken fromTestResolver(const mx::RtToken& str, const mx::RtToken& type)
 {
     mx::StringResolverPtr resolver = mx::StringResolver::create();
-    mx::RtToken resolvedName = mx::RtToken(resolver->resolve(str, type).c_str());
-    resolvedName = resolvedName.str() + "_fromTestResolver";
-    return resolvedName;
+    return mx::RtToken(resolver->resolve(str, type) + "_fromTestResolver");
 }
 
 TEST_CASE("Runtime: NameResolvers", "[runtime]")


### PR DESCRIPTION
- Change storage type for generic metadata, string instead of token. Since we don't know what data might be stored in them using string is more safe.
- Removed assignment operator from string to RtToken. Since RtToken construction is expensive assignment/conversion from string to RtToken should be explicit.