### PR TITLE
Expose methods to allow parameter<->uniform input translation.

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -373,8 +373,6 @@ bool Document::convertUniformInputsToParameters()
     bool anyConverted = false;
 
     const StringSet uniformTypes = { FILENAME_TYPE_STRING, STRING_TYPE_STRING };
-    const string PARAMETER_CATEGORY_STRING("parameter");
-    const string INPUT_CATEGORY_STRING("input");
     for (ElementPtr e : traverseTree())
     {
         InterfaceElementPtr elem = e->asA<InterfaceElement>();

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -331,12 +331,14 @@ bool Document::validate(string* message) const
     return GraphElement::validate(message) && res;
 }
 
-void convertParameterToInput(DocumentPtr doc)
+bool Document::convertParametersToInputs()
 {
+    bool anyConverted = false;
+
     // Convert all parameters to be inputs. If needed set them to be "uniform".
     const StringSet uniformTypes = { FILENAME_TYPE_STRING, STRING_TYPE_STRING };
     const string PARAMETER_CATEGORY_STRING("parameter");
-    for (ElementPtr e : doc->traverseTree())
+    for (ElementPtr e : traverseTree())
     {
         InterfaceElementPtr elem = e->asA<InterfaceElement>();
         if (!elem)
@@ -357,11 +359,42 @@ void convertParameterToInput(DocumentPtr doc)
                 {
                     // TODO: Determine based on usage whether to make
                     // the input a uniform. 
-                    newInput->setIsUniform(false);
+                    newInput->setIsUniform(true);
                 }
+                anyConverted = true;
             }
         }
     }
+    return anyConverted;
+}
+
+bool Document::convertUniformInputsToParameters()
+{
+    bool anyConverted = false;
+
+    const StringSet uniformTypes = { FILENAME_TYPE_STRING, STRING_TYPE_STRING };
+    const string PARAMETER_CATEGORY_STRING("parameter");
+    const string INPUT_CATEGORY_STRING("input");
+    for (ElementPtr e : traverseTree())
+    {
+        InterfaceElementPtr elem = e->asA<InterfaceElement>();
+        if (!elem)
+        {
+            continue;
+        }
+        vector<ElementPtr> children = elem->getChildren();
+        for (ElementPtr child : children)
+        {
+            InputPtr input = child->asA<Input>();
+            if (input && input->getIsUniform())
+            {
+                ParameterPtr newParameter = updateChildSubclass<Parameter>(elem, child);
+                newParameter->removeAttribute(ValueElement::UNIFORM_ATTRIBUTE);
+                anyConverted = true;
+            }
+        }
+    }
+    return anyConverted;
 }
 
 void Document::upgradeVersion(bool applyFutureUpdates)
@@ -1010,7 +1043,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
 
     if (applyFutureUpdates)
     {
-        convertParameterToInput(asA<Document>());
+        convertParametersToInputs();
     }
 
     if (majorVersion == MATERIALX_MAJOR_VERSION &&

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -673,6 +673,16 @@ class Document : public GraphElement
     bool validate(string* message = nullptr) const override;
 
     /// @}
+    /// @name Versioning
+    /// @{
+
+    /// Convert Parameter Elements to Input Elements
+    bool convertParametersToInputs();
+
+    /// Convert Input Elements which are uniform to Parameter Elements
+    bool convertUniformInputsToParameters();
+
+    /// @}
     /// @name Callbacks
     /// @{
 

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -180,6 +180,7 @@ TEST_CASE("Version", "[document]")
         mx::DocumentPtr doc2 = mx::createDocument();
         mx::readFromXmlFile(doc2, "1_37_to_1_38_updated.mtlx");
         REQUIRE(doc2->validate());
+        std::string doc2String = mx::writeToXmlString(doc2);
 
         // atan2 test
         const std::string ATAN2 = "atan2";
@@ -216,6 +217,19 @@ TEST_CASE("Version", "[document]")
         REQUIRE(testNodeGraph->getNode("add2"));
         REQUIRE(testNodeGraph->getNode("add2")->getInput("in1")->getInterfaceName() == "add");
         REQUIRE(testNodeGraph->getNode("add1")->getInput("in1")->getNodeName() == "add2");
+
+        // Convert back and forth between parameters and inputs
+        REQUIRE(doc2->convertUniformInputsToParameters());
+        REQUIRE(doc2->validate());
+        mx::writeToXmlFile(doc2, "1_38_to_1_37_parameters.mtlx", &writeOptions);
+        mx::DocumentPtr doc3 = mx::createDocument();
+        mx::XmlReadOptions noParamUpdateOptions;
+        noParamUpdateOptions.applyFutureUpdates = false;
+        mx::readFromXmlFile(doc3, "1_38_to_1_37_parameters.mtlx", mx::FileSearchPath(), &noParamUpdateOptions);
+        REQUIRE(doc3->validate());
+        REQUIRE(doc3->convertParametersToInputs());
+        std::string doc3String = mx::writeToXmlString(doc3);
+        REQUIRE(doc2String == doc3String);
     }
 }
 

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -101,5 +101,7 @@ void bindPyDocument(py::module& mod)
         .def("getColorManagementSystem", &mx::Document::getColorManagementSystem)
         .def("setColorManagementConfig", &mx::Document::setColorManagementConfig)
         .def("hasColorManagementConfig", &mx::Document::hasColorManagementConfig)
-        .def("getColorManagementConfig", &mx::Document::getColorManagementConfig);
+        .def("getColorManagementConfig", &mx::Document::getColorManagementConfig)
+        .def("convertParametersToInputs", &mx::Document::convertParametersToInputs)
+        .def("convertUniformInputsToParameters", &mx::Document::convertUniformInputsToParameters);
 }


### PR DESCRIPTION
Update #632 
- Allow for a downgrade path from uniform inputs to parameters.
- Change to always tag parameters as inputs on upgrade so they can be found.
