### PR TITLE
Change "master prim" registration to nodedef registration.

### DIFF
--- a/source/MaterialXRuntime/Private/PvtApi.cpp
+++ b/source/MaterialXRuntime/Private/PvtApi.cpp
@@ -79,7 +79,7 @@ void PvtApi::unloadLibrary(const RtToken& name)
     }
 }
 
-RtToken PvtApi::makeUniqueName(const RtToken& name) const
+RtToken PvtApi::makeUniqueStageName(const RtToken& name) const
 {
     RtToken newName = name;
 

--- a/source/MaterialXRuntime/Private/PvtApi.cpp
+++ b/source/MaterialXRuntime/Private/PvtApi.cpp
@@ -15,16 +15,16 @@ namespace MaterialX
 
 void PvtApi::reset()
 {
-    static const RtTypeInfo masterPrimRootType("api_masterprimroot");
-    static const RtToken libRootName("api_libroot");
+    static const RtTypeInfo defRootType("api_def_root");
+    static const RtToken libRootName("api_lib_root");
 
-    _masterPrimRoot.reset(new PvtPrim(&masterPrimRootType, masterPrimRootType.getShortTypeName(), nullptr));
+    _definitionsRootPrim.reset(new PvtPrim(&defRootType, defRootType.getShortTypeName(), nullptr));
     _createFunctions.clear();
     _stages.clear();
 
-    _libraryRoot.reset();
+    _libraryRootStage.reset();
     _libraries.clear();
-    _libraryRoot = RtStage::createNew(libRootName);
+    _libraryRootStage = RtStage::createNew(libRootName);
 
     _unitDefinitions = UnitConverterRegistry::create();
 }
@@ -41,7 +41,7 @@ void PvtApi::createLibrary(const RtToken& name)
     RtStagePtr lib = RtStage::createNew(name);
     _libraries[name] = lib;
 
-    _libraryRoot->addReference(lib);
+    _libraryRootStage->addReference(lib);
 }
 
 void PvtApi::loadLibrary(const RtToken& name, const RtReadOptions& options)
@@ -59,7 +59,7 @@ void PvtApi::loadLibrary(const RtToken& name, const RtReadOptions& options)
     RtFileIo file(lib);
     file.readLibraries({ name.str() }, _searchPaths, options);
 
-    _libraryRoot->addReference(lib);
+    _libraryRootStage->addReference(lib);
 }
 
 void PvtApi::unloadLibrary(const RtToken& name)
@@ -71,7 +71,7 @@ void PvtApi::unloadLibrary(const RtToken& name)
         RtSchemaPredicate<RtNodeDef> nodedefFilter;
         for (RtPrim nodedef : lib->getRootPrim().getChildren(nodedefFilter))
         {
-            unregisterMasterPrim(nodedef.getName());
+            unregisterNodeDef(nodedef.getName());
         }
 
         // Delete the library.

--- a/source/MaterialXRuntime/Private/PvtApi.h
+++ b/source/MaterialXRuntime/Private/PvtApi.h
@@ -204,11 +204,11 @@ public:
         _userDefinitionPath = path;
     }
 
-    RtToken makeUniqueName(const RtToken& name) const;
+    RtToken makeUniqueStageName(const RtToken& name) const;
 
     RtStagePtr createStage(const RtToken& name)
     {
-        const RtToken newName = makeUniqueName(name);
+        const RtToken newName = makeUniqueStageName(name);
         RtStagePtr stage = RtStage::createNew(newName);
         _stages[newName] = stage;
         return stage;
@@ -232,7 +232,7 @@ public:
         {
             throw ExceptionRuntimeError("Can't find a stage named '" + name.str() + "' to rename");
         }
-        const RtToken uniqueName = makeUniqueName(newName);
+        const RtToken uniqueName = makeUniqueStageName(newName);
         stage->setName(uniqueName);
         _stages[uniqueName] = stage;
         _stages.erase(name);

--- a/source/MaterialXRuntime/Private/PvtApi.h
+++ b/source/MaterialXRuntime/Private/PvtApi.h
@@ -11,6 +11,8 @@
 
 #include <MaterialXRuntime/RtApi.h>
 #include <MaterialXRuntime/RtStage.h>
+#include <MaterialXRuntime/RtSchema.h>
+#include <MaterialXRuntime/RtNodeDef.h>
 
 #include <MaterialXRuntime/Private/PvtObject.h>
 #include <MaterialXRuntime/Private/PvtPrim.h>
@@ -86,39 +88,40 @@ public:
         return it != _createFunctions.end() ? it->second : nullptr;
     }
 
-    void registerMasterPrim(const RtPrim& prim)
+    void registerNodeDef(const RtPrim& prim)
     {
-        if (getMasterPrim(prim.getName()))
+        if (getNodeDef(prim.getName()))
         {
-            throw ExceptionRuntimeError("A master prim with name '" + prim.getName().str() + "' is already registered");
+            throw ExceptionRuntimeError("A nodedef with name '" + prim.getName().str() + "' is already registered");
         }
-        _masterPrimRoot->asA<PvtPrim>()->addChildPrim(PvtObject::ptr<PvtPrim>(prim));
+        _definitionsRootPrim->asA<PvtPrim>()->addChildPrim(PvtObject::ptr<PvtPrim>(prim));
     }
 
-    void unregisterMasterPrim(const RtToken& name)
+    void unregisterNodeDef(const RtToken& name)
     {
-        PvtPrim* prim = _masterPrimRoot->asA<PvtPrim>()->getChild(name);
+        RtPrim prim = getNodeDef(name);
         if (prim)
         {
-            _masterPrimRoot->asA<PvtPrim>()->removeChildPrim(prim);
+            _definitionsRootPrim->asA<PvtPrim>()->removeChildPrim(PvtObject::ptr<PvtPrim>(prim));
         }
     }
 
-    bool hasMasterPrim(const RtToken& name)
+    bool hasNodeDef(const RtToken& name)
     {
-        PvtPrim* prim = _masterPrimRoot->asA<PvtPrim>()->getChild(name);
-        return prim != nullptr;
+        PvtPrim* prim = _definitionsRootPrim->asA<PvtPrim>()->getChild(name);
+        return prim && prim->hasApi<RtNodeDef>();
     }
 
-    RtPrim getMasterPrim(const RtToken& name)
+    RtPrim getNodeDef(const RtToken& name)
     {
-        PvtPrim* prim = _masterPrimRoot->asA<PvtPrim>()->getChild(name);
-        return prim ? prim->hnd() : RtPrim();
+        PvtPrim* prim = _definitionsRootPrim->asA<PvtPrim>()->getChild(name);
+        return prim && prim->hasApi<RtNodeDef>() ? prim->hnd() : RtPrim();
     }
 
-    RtPrimIterator getMasterPrims(RtObjectPredicate predicate = nullptr)
+    RtPrimIterator getNodeDefs()
     {
-        return RtPrimIterator(_masterPrimRoot, predicate);
+        RtSchemaPredicate<RtNodeDef> filter;
+        return RtPrimIterator(_definitionsRootPrim, filter);
     }
 
     void clearSearchPath()
@@ -181,7 +184,7 @@ public:
 
     RtStagePtr getLibraryRoot()
     {
-        return _libraryRoot;
+        return _libraryRootStage;
     }
 
     RtTokenVec getLibraryNames() const
@@ -268,11 +271,11 @@ public:
     FileSearchPath _implementationSearchPaths;
     FileSearchPath _textureSearchPaths;
     FilePath _userDefinitionPath;
-    RtStagePtr _libraryRoot;
+    RtStagePtr _libraryRootStage;
     RtTokenMap<RtStagePtr> _libraries;
     UnitConverterRegistryPtr  _unitDefinitions;
 
-    PvtDataHandle _masterPrimRoot;
+    PvtDataHandle _definitionsRootPrim;
     RtTokenMap<RtPrimCreateFunc> _createFunctions;
     RtTokenMap<RtStagePtr> _stages;
 };

--- a/source/MaterialXRuntime/Private/PvtStage.cpp
+++ b/source/MaterialXRuntime/Private/PvtStage.cpp
@@ -60,11 +60,11 @@ PvtPrim* PvtStage::createPrim(const PvtPath& parentPath, const RtToken& name, co
     }
     else
     {
-        // Second, try finding a registered master prim.
-        const RtPrim master = RtApi::get().getMasterPrim(typeName);
-        if (master && master.getTypeInfo()->getShortTypeName() == RtNodeDef::typeName())
+        // Second, try finding a registered nodedef.
+        const RtPrim nodedef = RtApi::get().getNodeDef(typeName);
+        if (nodedef)
         {
-            // This is a nodedef, so create a node instance from it.
+            // A nodedef exists with this name, so create a node instance.
             RtPrimCreateFunc nodeCreator = RtApi::get().getCreateFunction(RtNode::typeName());
             primH = PvtObject::hnd(nodeCreator(typeName, name, parent->hnd()));
         }

--- a/source/MaterialXRuntime/RtApi.cpp
+++ b/source/MaterialXRuntime/RtApi.cpp
@@ -107,39 +107,39 @@ void RtApi::unregisterCreateFunction(const RtToken& typeName)
     _cast(_ptr)->unregisterCreateFunction(typeName);
 }
 
-bool RtApi::hasCreateFunction(const RtToken& typeName)
+bool RtApi::hasCreateFunction(const RtToken& typeName) const
 {
     return _cast(_ptr)->hasCreateFunction(typeName);
 }
 
-RtPrimCreateFunc RtApi::getCreateFunction(const RtToken& typeName)
+RtPrimCreateFunc RtApi::getCreateFunction(const RtToken& typeName) const
 {
     return _cast(_ptr)->getCreateFunction(typeName);
 }
 
-void RtApi::registerMasterPrim(const RtPrim& prim)
+void RtApi::registerNodeDef(const RtPrim& prim)
 {
-    _cast(_ptr)->registerMasterPrim(prim);
+    _cast(_ptr)->registerNodeDef(prim);
 }
 
-void RtApi::unregisterMasterPrim(const RtToken& name)
+void RtApi::unregisterNodeDef(const RtToken& name)
 {
-    _cast(_ptr)->unregisterMasterPrim(name);
+    _cast(_ptr)->unregisterNodeDef(name);
 }
 
-bool RtApi::hasMasterPrim(const RtToken& name)
+bool RtApi::hasNodeDef(const RtToken& name) const
 {
-    return _cast(_ptr)->hasMasterPrim(name);
+    return _cast(_ptr)->hasNodeDef(name);
 }
 
-RtPrim RtApi::getMasterPrim(const RtToken& name)
+RtPrim RtApi::getNodeDef(const RtToken& name) const
 {
-    return _cast(_ptr)->getMasterPrim(name);
+    return _cast(_ptr)->getNodeDef(name);
 }
 
-RtPrimIterator RtApi::getMasterPrims(RtObjectPredicate predicate)
+RtPrimIterator RtApi::getNodeDefs() const
 {
-    return RtPrimIterator(_cast(_ptr)->_masterPrimRoot, predicate);
+    return _cast(_ptr)->getNodeDefs();
 }
 
 void RtApi::clearSearchPath()

--- a/source/MaterialXRuntime/RtApi.h
+++ b/source/MaterialXRuntime/RtApi.h
@@ -50,30 +50,27 @@ public:
     void unregisterCreateFunction(const RtToken& typeName);
 
     /// Return true if the given typename has a create function registered.
-    bool hasCreateFunction(const RtToken& typeName);
+    bool hasCreateFunction(const RtToken& typeName) const;
 
     /// Return the create function for given typename.
     /// Or nullptr if no such create function has been registered.
-    RtPrimCreateFunc getCreateFunction(const RtToken& typeName);
+    RtPrimCreateFunc getCreateFunction(const RtToken& typeName) const;
 
-    /// Register a master prim to be used for creating instances from.
-    /// A typical use case is for registering a nodedef prim to be used for
-    /// creating node instances.
-    void registerMasterPrim(const RtPrim& prim);
+    /// Register a nodedef prim to be used for creating node instances from.
+    void registerNodeDef(const RtPrim& prim);
 
-    /// Unregister a master prim.
-    void unregisterMasterPrim(const RtToken& name);
+    /// Unregister a nodedef.
+    void unregisterNodeDef(const RtToken& name);
 
-    /// Return true if a master prim with the given name has been registered.
-    bool hasMasterPrim(const RtToken& name);
+    /// Return true if a nodedef prim with the given name has been registered.
+    bool hasNodeDef(const RtToken& name) const;
 
-    /// Return the master prim with given name.
-    /// Or a null object if no such prim has been registered.
-    RtPrim getMasterPrim(const RtToken& name);
+    /// Return the nodedef prim with given name. Or a null object if no such 
+    /// nodedef prim has been registered.
+    RtPrim getNodeDef(const RtToken& name) const;
 
-    /// Return and iterator over all registered master prims,
-    /// optionally filtered using a predicate.
-    RtPrimIterator getMasterPrims(RtObjectPredicate predicate = nullptr);
+    /// Return and iterator over all registered nodedefs.
+    RtPrimIterator getNodeDefs() const;
 
     /// Register a typed prim schema.
     template<class T, class ConnectableApi = RtConnectableApi>

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -303,16 +303,15 @@ namespace
             return nodedefName;
         }
 
-        // Third, try resolving among existing registered master prim nodedefs.
+        // Third, try resolving among existing registered nodedefs.
         const RtToken nodeName(node->getCategory());
         const RtToken nodeType(node->getType());
         const vector<ValueElementPtr> nodePorts = node->getActiveValueElements();
-        RtSchemaPredicate<RtNodeDef> nodedefFilter;
-        for (RtPrim masterPrim : RtApi::get().getMasterPrims(nodedefFilter))
+        for (RtPrim prim : RtApi::get().getNodeDefs())
         {
-            RtNodeDef candidate(masterPrim);
+            RtNodeDef candidate(prim);
             if (candidate.getNamespacedNode() == nodeName && 
-                matchingSignature(PvtObject::ptr<PvtPrim>(masterPrim), nodeType, nodePorts))
+                matchingSignature(PvtObject::ptr<PvtPrim>(prim), nodeType, nodePorts))
             {
                 return candidate.getName();
             }
@@ -681,10 +680,10 @@ namespace
         {
             if (!filter || filter(nodedef))
             {
-                if (!RtApi::get().hasMasterPrim(RtToken(nodedef->getName())))
+                if (!RtApi::get().hasNodeDef(RtToken(nodedef->getName())))
                 {
                     PvtPrim* prim = readNodeDef(nodedef, stage);
-                    RtNodeDef(prim->hnd()).registerMasterPrim();
+                    RtApi::get().registerNodeDef(prim->hnd());
                 }
             }
         }
@@ -1192,17 +1191,17 @@ namespace
         }
     }
 
-    void writeMasterPrim(DocumentPtr document, PvtStage* stage, PvtPrim* prim, const RtWriteOptions* options)
+    void writeNodeDefAndImplementation(DocumentPtr document, PvtStage* stage, PvtPrim* prim, const RtWriteOptions* options)
     {
         if (!prim || prim->isDisposed())
         {
-            throw ExceptionRuntimeError("Trying to write invalid definition" +  (prim ? (": '" + prim->getName().str() + "'") :  EMPTY_STRING));
+            throw ExceptionRuntimeError("Trying to write invalid nodedef" +  (prim ? (": '" + prim->getName().str() + "'") :  EMPTY_STRING));
         }
 
         // Write the definition
         writeNodeDef(prim, document, options);
 
-        // Write the corresponding nodegraph if any.
+        // Write the corresponding nodegraph implementation if any.
         // Currently there is no "implementation" association kept other than
         // on the node graph referencing the definition it represents.
         //
@@ -1232,21 +1231,21 @@ namespace
         if (names.empty())
         {
             // Write all nodedefs.
-            RtSchemaPredicate<RtNodeDef> nodedefFilter;
-            for (RtPrim masterPrim : api.getMasterPrims(nodedefFilter))
+            for (const RtPrim& prim : api.getNodeDefs())
             {
-                PvtPrim* prim = PvtObject::ptr<PvtPrim>(masterPrim);
-                writeMasterPrim(document, stage, prim, options);
+                writeNodeDefAndImplementation(document, stage, PvtObject::ptr<PvtPrim>(prim), options);
             }
         }
         else
         {
-            // Write the specified nodedefs.
+            // Write only the specified nodedefs.
             for (const RtToken& name : names)
             {
-                RtPrim masterPrim = api.getMasterPrim(name);
-                PvtPrim* prim = PvtObject::ptr<PvtPrim>(masterPrim);
-                writeMasterPrim(document, stage, prim, options);
+                RtPrim prim = api.getNodeDef(name);
+                if (prim)
+                {
+                    writeNodeDefAndImplementation(document, stage, PvtObject::ptr<PvtPrim>(prim), options);
+                }
             }
         }      
     }
@@ -1316,6 +1315,7 @@ void RtFileIo::read(std::istream& stream, const RtReadOptions* options)
 
 void RtFileIo::readLibraries(const FilePathVec& libraryPaths, const FileSearchPath& searchPaths, const RtReadOptions& options)
 {
+    RtApi& api = RtApi::get();
     PvtStage* stage = PvtStage::ptr(_stage);
 
     // Load all content into a document.
@@ -1337,10 +1337,10 @@ void RtFileIo::readLibraries(const FilePathVec& libraryPaths, const FileSearchPa
     // when node instances are loaded later.
     for (const NodeDefPtr& nodedef : doc->getNodeDefs())
     {
-        if (!RtApi::get().hasMasterPrim(RtToken(nodedef->getName())))
+        if (!api.hasNodeDef(RtToken(nodedef->getName())))
         {
             PvtPrim* prim = readNodeDef(nodedef, stage);
-            RtNodeDef(prim->hnd()).registerMasterPrim();
+            api.registerNodeDef(prim->hnd());
         }
     }
 
@@ -1377,7 +1377,7 @@ void RtFileIo::readLibraries(const FilePathVec& libraryPaths, const FileSearchPa
         }
         catch(const ExceptionRuntimeError &e)
         {
-            RtApi::get().log(RtLogger::ERROR, e.what());
+            api.log(RtLogger::ERROR, e.what());
         }
     }
 }

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -1184,8 +1184,7 @@ namespace
 
     void readUnitDefinitions(DocumentPtr doc)
     {
-        RtApi& api = RtApi::get();
-        UnitConverterRegistryPtr unitDefinitions = api.getUnitDefinitions();
+        UnitConverterRegistryPtr unitDefinitions = RtApi::get().getUnitDefinitions();
         for (UnitTypeDefPtr unitTypeDef : doc->getUnitTypeDefs())
         {
             LinearUnitConverterPtr unitConvert = LinearUnitConverter::create(unitTypeDef);
@@ -1229,12 +1228,12 @@ namespace
 
     void writeNodeDefs(DocumentPtr document, PvtStage* stage, const RtTokenVec& names, const RtWriteOptions* options)
     {
-        // Write all definitions if no names provided
-        RtApi& rtApi = RtApi::get();
+        RtApi& api = RtApi::get();
         if (names.empty())
         {
+            // Write all nodedefs.
             RtSchemaPredicate<RtNodeDef> nodedefFilter;
-            for (RtPrim masterPrim : rtApi.getMasterPrims(nodedefFilter))
+            for (RtPrim masterPrim : api.getMasterPrims(nodedefFilter))
             {
                 PvtPrim* prim = PvtObject::ptr<PvtPrim>(masterPrim);
                 writeMasterPrim(document, stage, prim, options);
@@ -1242,9 +1241,10 @@ namespace
         }
         else
         {
+            // Write the specified nodedefs.
             for (const RtToken& name : names)
             {
-                RtPrim masterPrim = rtApi.getMasterPrim(name);
+                RtPrim masterPrim = api.getMasterPrim(name);
                 PvtPrim* prim = PvtObject::ptr<PvtPrim>(masterPrim);
                 writeMasterPrim(document, stage, prim, options);
             }

--- a/source/MaterialXRuntime/RtNodeDef.cpp
+++ b/source/MaterialXRuntime/RtNodeDef.cpp
@@ -49,14 +49,13 @@ RtToken RtNodeDef::getNamespacedNode() const
 {
     const RtToken& nodeToken = getNode();
     string nodeString = nodeToken.c_str();
-    string namespaceString = getNamespace().c_str();;
+    string namespaceString = getNamespace().c_str();
     if (!namespaceString.empty())
     {
         return RtToken(namespaceString + NAME_PREFIX_SEPARATOR + nodeString);
     }
     return nodeToken;
 }
-
 
 void RtNodeDef::setNode(const RtToken& node)
 {
@@ -227,21 +226,6 @@ RtNodeLayout RtNodeDef::getNodeLayout()
         }
     }
     return layout;
-}
-
-void RtNodeDef::registerMasterPrim() const
-{
-    RtApi::get().registerMasterPrim(prim()->hnd());
-}
-
-void RtNodeDef::unregisterMasterPrim() const
-{
-    RtApi::get().unregisterMasterPrim(prim()->getName());
-}
-
-bool RtNodeDef::isMasterPrim() const
-{
-    return RtApi::get().hasMasterPrim(prim()->getName());
 }
 
 }

--- a/source/MaterialXRuntime/RtNodeDef.h
+++ b/source/MaterialXRuntime/RtNodeDef.h
@@ -119,16 +119,6 @@ public:
     /// Containing its input ordering and uifolder hierarchy.
     RtNodeLayout getNodeLayout();
 
-    /// Register this nodedef as a master prim
-    /// to make it instantiable for node creation.
-    void registerMasterPrim() const;
-
-    /// Unregister this nodedef as a master prim.
-    void unregisterMasterPrim() const;
-
-    /// Return true if this nodedef is registerd as a master prim.
-    bool isMasterPrim() const;
-
     static RtToken NODE;
     static RtToken NODEDEF;
     static RtToken NODEGROUP;

--- a/source/MaterialXRuntime/RtStage.h
+++ b/source/MaterialXRuntime/RtStage.h
@@ -49,14 +49,14 @@ public:
     /// If an empty name is given a name will be generated.
     RtPrim createPrim(const RtPath& parentPath, const RtToken& name, const RtToken& typeName);
 
-    /// Create a node definition based on a nodegraph
-    RtPrim createNodeDef(RtNodeGraph& nodeGraph, 
-                         const RtToken& nodeDefName, const RtToken& nodeName, const RtToken& version, bool isDefaultVersion, const RtToken& nodeGroup = EMPTY_TOKEN);
+    /// Create a nodedef based on a nodegraph
+    RtPrim createNodeDef(RtNodeGraph& nodeGraph, const RtToken& nodeDefName, const RtToken& nodeName,
+                         const RtToken& version, bool isDefaultVersion, const RtToken& nodeGroup = EMPTY_TOKEN);
 
-    /// Return the implementation for a given definition if it exists.
-    /// Currently only nodegraph implemenations are considered. If the implementaiton is not a nodegraph
-    /// an invalid RtPrim will be returned.
-    RtPrim getImplementation(const RtNodeDef& definition) const;
+    /// Return the implementation for a given nodedef if it exists.
+    /// Currently only nodegraph implemenations are considered.
+    /// If no implementation is found an invalid RtPrim will be returned.
+    RtPrim getImplementation(const RtNodeDef& nodedef) const;
 
     /// Remove a prim from the stage.
     void removePrim(const RtPath& path);

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -472,7 +472,7 @@ TEST_CASE("Runtime: Prims", "[runtime]")
     nodedef.setNode(FOO);
     REQUIRE(nodedef.getNode() == FOO);
     REQUIRE_THROWS(stage->createPrim(nodedef.getName()));
-    nodedef.registerMasterPrim();
+    api->registerNodeDef(nodedefPrim);
     REQUIRE(stage->createPrim(nodedef.getName()));
 
     mx::RtPrim nodePrim = stage->createPrim(nodedefPrim.getName());
@@ -608,8 +608,8 @@ TEST_CASE("Runtime: Nodes", "[runtime]")
     // Node creation without a valid nodedef should throw.
     REQUIRE_THROWS(stage->createPrim("/add1", FOO));
 
-    // Register as a master prim so we can create node instance from it.
-    nodedef.registerMasterPrim();
+    // Register so we can create node instance from it.
+    api->registerNodeDef(nodedef.getPrim());
 
     // Create two new node instances from the add nodedef
     mx::RtPrim add1Prim = stage->createPrim("/add1", nodedef.getName());
@@ -720,7 +720,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     addFloat.createInput(IN1, mx::RtType::FLOAT);
     addFloat.createInput(IN2, mx::RtType::FLOAT);
     addFloat.createOutput(OUT, mx::RtType::FLOAT);
-    addFloat.registerMasterPrim();
+    api->registerNodeDef(addFloat.getPrim());
 
     // Create a nodegraph object.
     mx::RtNodeGraph graph1 = stage->createPrim("/graph1", mx::RtNodeGraph::typeName());
@@ -829,7 +829,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
 
     REQUIRE(graph1.getDefinition() == ND_ADDGRAPH);
     REQUIRE(graph1.getVersion() == ADDGRAPH_VERSION);
-    REQUIRE(addgraphDef.isMasterPrim());
+    REQUIRE(api->hasNodeDef(addgraphDef.getName()));
     REQUIRE(addgraphDef.numInputs() == 2);
     REQUIRE(addgraphDef.numOutputs() == 1);
     REQUIRE(addgraphDef.getOutput().getName() == OUT);
@@ -2420,7 +2420,7 @@ TEST_CASE("Runtime: duplicate name", "[runtime]")
     addFloat.createInput(IN1, mx::RtType::FLOAT);
     addFloat.createInput(IN2, mx::RtType::FLOAT);
     addFloat.createOutput(OUT, mx::RtType::FLOAT);
-    addFloat.registerMasterPrim();
+    api->registerNodeDef(addFloat.getPrim());
 
     // Create a nodegraph object.
     mx::RtNodeGraph graph1 = stage->createPrim("/graph1", mx::RtNodeGraph::typeName());


### PR DESCRIPTION
The concept of a "master prim" for instancing is only used for nodedef, and will probably never be used for anything other than nodedefs. So to clarify the API I have renamed this and removed the concept of "master prim" registration, now calling it nodedef registration instead.