### PR TITLE
1.38 Update for OGS XML Updates and Maya Plugin usage fixes

### DIFF
--- a/source/MaterialXContrib/MaterialXMaya/CreateMaterialXNodeCmd.h
+++ b/source/MaterialXContrib/MaterialXMaya/CreateMaterialXNodeCmd.h
@@ -4,11 +4,10 @@
 /// @file
 /// Maya command for creating MaterialX shading nodes.
 
-#include <maya/MPxCommand.h>
-#include <maya/MDGModifier.h>
-
 #include <MaterialXCore/Document.h>
 #include <MaterialXRender/Util.h>
+#include <maya/MDGModifier.h>
+#include <maya/MPxCommand.h>
 
 #include <vector>
 
@@ -29,7 +28,10 @@ class CreateMaterialXNodeCmd : MPxCommand
     /// @name Maya API methods
     /// @{
     MStatus doIt(const MArgList&) override;
-    bool isUndoable() const override { return false; }
+    bool isUndoable() const override
+    {
+        return false;
+    }
 
     static MSyntax newSyntax();
     static void* creator();
@@ -42,13 +44,12 @@ class CreateMaterialXNodeCmd : MPxCommand
     /// Specifies the type of shading node to create
     enum class NodeTypeToCreate
     {
-        AUTO,       ///< Determined by the type of the MaterialX element
-        SURFACE,    ///< A surface shading node
-        TEXTURE     ///< A texture shading node
+        AUTO,    ///< Determined by the type of the MaterialX element
+        SURFACE, ///< A surface shading node
+        TEXTURE  ///< A texture shading node
     };
 
     /// Create a new Maya node for a given renderable element.
-    /// @param document The document containing the element.
     /// @param renderableElement The element to use.
     /// @param nodeTypeToCreate The type of shading node to create.
     /// @param documentFilePath Path to the document.
@@ -57,14 +58,12 @@ class CreateMaterialXNodeCmd : MPxCommand
     /// @param envIrradianceFileName The file name of the environment map to use for diffuse shading.
     /// @return Name of Maya node created.
     ///
-    std::string createNode(
-        mx::DocumentPtr document,
-        mx::TypedElementPtr renderableElement,
-        NodeTypeToCreate nodeTypeToCreate,
-        const MString& documentFilePath,
-        const mx::FileSearchPath& searchPath,
-        const MString& envRadianceFileName,
-        const MString& envIrradianceFileName );
+    std::string createNode(mx::TypedElementPtr renderableElement,
+                           NodeTypeToCreate nodeTypeToCreate,
+                           const MString& documentFilePath,
+                           const mx::FileSearchPath& searchPath,
+                           const MString& envRadianceFileName,
+                           const MString& envIrradianceFileName);
 
     /// Used to make the necessary changes to Maya's dependency graph.
     MDGModifier _dgModifier;

--- a/source/MaterialXContrib/MaterialXMaya/MaterialXNode.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/MaterialXNode.cpp
@@ -111,18 +111,18 @@ MStatus MaterialXNode::initialize()
     MObject outColorB = nAttr.create(outColorName + "B", "ocb", MFnNumericData::kFloat, 0.0);
     OUT_ATTRIBUTE = nAttr.create(outColorName, "oc", outColorR, outColorG, outColorB);
 
-    CHECK_MSTATUS(nAttr.setKeyable(false));
-    CHECK_MSTATUS(nAttr.setStorable(false));
-    CHECK_MSTATUS(nAttr.setReadable(true));
-    CHECK_MSTATUS(nAttr.setWritable(false));
-    CHECK_MSTATUS(nAttr.setUsedAsColor(true));
+    CHECK_MSTATUS(nAttr.setKeyable(false))
+    CHECK_MSTATUS(nAttr.setStorable(false))
+    CHECK_MSTATUS(nAttr.setReadable(true))
+    CHECK_MSTATUS(nAttr.setWritable(false))
+    CHECK_MSTATUS(nAttr.setUsedAsColor(true))
 
-    CHECK_MSTATUS(addAttribute(OUT_ATTRIBUTE));
+    CHECK_MSTATUS(addAttribute(OUT_ATTRIBUTE))
 
-    CHECK_MSTATUS(attributeAffects(DOCUMENT_ATTRIBUTE, OUT_ATTRIBUTE));
-    CHECK_MSTATUS(attributeAffects(ELEMENT_ATTRIBUTE, OUT_ATTRIBUTE));
-    CHECK_MSTATUS(attributeAffects(ENV_RADIANCE_ATTRIBUTE, OUT_ATTRIBUTE));
-    CHECK_MSTATUS(attributeAffects(ENV_IRRADIANCE_ATTRIBUTE, OUT_ATTRIBUTE));
+    CHECK_MSTATUS(attributeAffects(DOCUMENT_ATTRIBUTE, OUT_ATTRIBUTE))
+    CHECK_MSTATUS(attributeAffects(ELEMENT_ATTRIBUTE, OUT_ATTRIBUTE))
+    CHECK_MSTATUS(attributeAffects(ENV_RADIANCE_ATTRIBUTE, OUT_ATTRIBUTE))
+    CHECK_MSTATUS(attributeAffects(ENV_IRRADIANCE_ATTRIBUTE, OUT_ATTRIBUTE))
 
     return MS::kSuccess;
 }
@@ -148,10 +148,9 @@ void MaterialXNode::createAndRegisterFragment()
 
         if (!_document)
         {
-            _document = MaterialXUtil::loadDocument(
-                _documentFilePath.asChar(), Plugin::instance().getLibraryDocument()
-            );
-        };
+            _document =
+                MaterialXUtil::loadDocument(_documentFilePath.asChar(), Plugin::instance().getLibraryDocument());
+        }
 
         if (_elementPath.length() == 0)
         {
@@ -161,14 +160,10 @@ void MaterialXNode::createAndRegisterFragment()
             return;
         }
 
-        _ogsFragment.reset(new OgsFragment(
-            _document->getDescendant(_elementPath.asChar()),
-            Plugin::instance().getLibrarySearchPath()
-        ));
+        _ogsFragment.reset(new OgsFragment(_document->getDescendant(_elementPath.asChar()),
+                                           Plugin::instance().getLibrarySearchPath()));
 
-        MayaUtil::registerFragment(
-            _ogsFragment->getFragmentName(), _ogsFragment->getFragmentSource()
-        );
+        MayaUtil::registerFragment(_ogsFragment->getFragmentName(), _ogsFragment->getFragmentSource());
     }
     catch (std::exception& e)
     {
@@ -208,7 +203,7 @@ bool MaterialXNode::setInternalValue(const MPlug& plug, const MDataHandle& dataH
         _documentFilePath = value;
         _document.reset();
         _ogsFragment.reset();
-        
+
         createAndRegisterFragment();
     }
     else if (plug == ELEMENT_ATTRIBUTE)
@@ -307,7 +302,7 @@ void* MaterialXTextureNode::creator()
 
 MStatus MaterialXTextureNode::initialize()
 {
-    CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME));
+    CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME))
     return MS::kSuccess;
 }
 
@@ -323,31 +318,26 @@ void* MaterialXSurfaceNode::creator()
 
 MStatus MaterialXSurfaceNode::initialize()
 {
-    CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME));
+    CHECK_MSTATUS(inheritAttributesFrom(MATERIALX_NODE_TYPENAME))
 
     MFnNumericAttribute nAttr;
-    VP2_TRANSPARENCY_ATTRIBUTE = nAttr.create(
-        mx::OgsXmlGenerator::VP_TRANSPARENCY_NAME.c_str(),
-        "vp2t",
-        MFnNumericData::kFloat,
-        0.0
-    );
+    VP2_TRANSPARENCY_ATTRIBUTE =
+        nAttr.create(mx::OgsXmlGenerator::VP_TRANSPARENCY_NAME.c_str(), "vp2t", MFnNumericData::kFloat, 0.0);
 
-    CHECK_MSTATUS(nAttr.setInternal(true));
-    CHECK_MSTATUS(nAttr.setKeyable(false));
+    CHECK_MSTATUS(nAttr.setInternal(true))
+    CHECK_MSTATUS(nAttr.setKeyable(false))
 
     // otherwise Maya refuses to map it to the eponymous fragment input
-    CHECK_MSTATUS(nAttr.setWritable(true));
+    CHECK_MSTATUS(nAttr.setWritable(true))
 
-    CHECK_MSTATUS(nAttr.setHidden(true));
-    CHECK_MSTATUS(nAttr.setAffectsAppearance(true));
-    CHECK_MSTATUS(addAttribute(VP2_TRANSPARENCY_ATTRIBUTE));
+    CHECK_MSTATUS(nAttr.setHidden(true))
+    CHECK_MSTATUS(nAttr.setAffectsAppearance(true))
+    CHECK_MSTATUS(addAttribute(VP2_TRANSPARENCY_ATTRIBUTE))
 
     return MS::kSuccess;
 }
 
-bool
-MaterialXSurfaceNode::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
+bool MaterialXSurfaceNode::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
 {
     if (plug == VP2_TRANSPARENCY_ATTRIBUTE)
     {

--- a/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.cpp
@@ -46,6 +46,7 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath, mx::Const
 
     // Read document contents from disk
     mx::XmlReadOptions readOptions;
+    readOptions.applyFutureUpdates = true;
     mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
 
     return document;

--- a/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.cpp
@@ -14,8 +14,7 @@ namespace MaterialXMaya
 namespace MaterialXUtil
 {
 
-mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
-                                  const mx::FilePath& filePath)
+mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths, const mx::FilePath& filePath)
 {
     mx::FilePath foundPath;
     for (size_t i = 0; i < searchPaths.size(); i++)
@@ -33,8 +32,7 @@ mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
     return foundPath;
 }
 
-mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
-                             mx::ConstDocumentPtr libraryDocument)
+mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath, mx::ConstDocumentPtr libraryDocument)
 {
     // Create document
     mx::DocumentPtr document = mx::createDocument();
@@ -44,20 +42,17 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
     }
 
     // Import libraries.
-    mx::CopyOptions copyOptions;
-    copyOptions.skipConflictingElements = true;
-    document->importLibrary(libraryDocument, &copyOptions);
+    document->importLibrary(libraryDocument);
 
     // Read document contents from disk
     mx::XmlReadOptions readOptions;
-    readOptions.skipConflictingElements = true;
     mx::readFromXmlFile(document, materialXDocumentPath, mx::EMPTY_STRING, &readOptions);
 
     return document;
 }
 
-mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document, 
-                                         const std::vector<mx::TypedElementPtr>& renderableElements, 
+mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document,
+                                         const std::vector<mx::TypedElementPtr>& renderableElements,
                                          const std::string& desiredElementPath)
 {
     if (!desiredElementPath.empty())
@@ -68,18 +63,16 @@ mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document,
             throw mx::Exception("The specified element " + desiredElementPath + " does not exist in the document");
         }
 
-        auto it = std::find_if(renderableElements.begin(),
-                               renderableElements.end(),
-                               [element](mx::TypedElementPtr renderableElement) -> bool
-                               {
-                                    return (element->getNamePath() == renderableElement->getNamePath());
+        auto it = std::find_if(renderableElements.begin(), renderableElements.end(),
+                               [element](mx::TypedElementPtr renderableElement) -> bool {
+                                   return (element->getNamePath() == renderableElement->getNamePath());
                                });
 
         if (it == renderableElements.end())
         {
-            throw mx::Exception("The specified element " + desiredElementPath + "is not renderable");
+            throw mx::Exception("The specified element " + desiredElementPath + " is not renderable");
         }
-        
+
         return element->asA<mx::TypedElement>();
     }
     return nullptr;

--- a/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.h
+++ b/source/MaterialXContrib/MaterialXMaya/MaterialXUtil.h
@@ -17,12 +17,10 @@ namespace MaterialXUtil
 
 /// Find a given file path under a set of search paths. The search is performed
 /// on all subdirectories for each search path
-mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths,
-                                  const mx::FilePath& filePath);
+mx::FilePath findInSubdirectories(const mx::FileSearchPath& searchPaths, const mx::FilePath& filePath);
 
 /// Load in a document and import associated libraries.
-mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
-                             mx::ConstDocumentPtr libraryDocument);
+mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath, mx::ConstDocumentPtr libraryDocument);
 
 /// Given an element path return a pointer to the element within a document if
 /// it is considered to be renderable.
@@ -30,8 +28,8 @@ mx::DocumentPtr loadDocument(const std::string& materialXDocumentPath,
 /// @param renderableElements List of elements in the document that are considered to be renderable.
 /// @param desiredElementPath Path to element to find.
 mx::TypedElementPtr getRenderableElement(mx::DocumentPtr document,
-                                        const std::vector<mx::TypedElementPtr>& renderableElements,
-                                        const std::string& desiredElementPath);
+                                         const std::vector<mx::TypedElementPtr>& renderableElements,
+                                         const std::string& desiredElementPath);
 
 } // namespace MaterialXUtil
 } // namespace MaterialXMaya

--- a/source/MaterialXContrib/MaterialXMaya/MayaUtil.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/MayaUtil.cpp
@@ -23,8 +23,7 @@ void registerFragment(const std::string& fragmentName, const std::string& fragme
     }
 
     MHWRender::MRenderer* const theRenderer = MHWRender::MRenderer::theRenderer();
-    MHWRender::MFragmentManager* const fragmentManager =
-        theRenderer ? theRenderer->getFragmentManager() : nullptr;
+    MHWRender::MFragmentManager* const fragmentManager = theRenderer ? theRenderer->getFragmentManager() : nullptr;
 
     if (!fragmentManager)
     {
@@ -34,8 +33,7 @@ void registerFragment(const std::string& fragmentName, const std::string& fragme
     if (!fragmentManager->hasFragment(fragmentName.c_str()))
     {
         constexpr bool hidden = false;
-        const MString registeredFragment =
-            fragmentManager->addShadeFragmentFromBuffer(fragmentSource.c_str(), hidden);
+        const MString registeredFragment = fragmentManager->addShadeFragmentFromBuffer(fragmentSource.c_str(), hidden);
 
         if (registeredFragment.length() == 0)
         {
@@ -57,8 +55,7 @@ void TextureDeleter::operator()(MHWRender::MTexture* texture)
         return;
     }
 
-    MHWRender::MTextureManager* const
-        textureMgr = renderer->getTextureManager();
+    MHWRender::MTextureManager* const textureMgr = renderer->getTextureManager();
 
     if (!textureMgr)
     {
@@ -68,7 +65,7 @@ void TextureDeleter::operator()(MHWRender::MTexture* texture)
     textureMgr->releaseTexture(texture);
 };
 
-void SamplerDeleter::operator () (const MHWRender::MSamplerState* sampler)
+void SamplerDeleter::operator()(const MHWRender::MSamplerState* sampler)
 {
     if (sampler)
     {

--- a/source/MaterialXContrib/MaterialXMaya/MayaUtil.h
+++ b/source/MaterialXContrib/MaterialXMaya/MayaUtil.h
@@ -4,8 +4,8 @@
 /// @file
 /// Maya Viewport 2.0 utilities.
 
-#include <maya/MTextureManager.h>
 #include <maya/MStateManager.h>
+#include <maya/MTextureManager.h>
 
 #include <string>
 #include <memory>
@@ -27,10 +27,7 @@ struct TextureDeleter
     void operator()(MHWRender::MTexture* texture);
 };
 
-using TextureUniquePtr = std::unique_ptr<
-    MHWRender::MTexture,
-    TextureDeleter
->;
+using TextureUniquePtr = std::unique_ptr<MHWRender::MTexture, TextureDeleter>;
 
 struct SamplerDeleter
 {
@@ -38,10 +35,7 @@ struct SamplerDeleter
     void operator()(const MHWRender::MSamplerState* sampler);
 };
 
-using SamplerUniquePtr = std::unique_ptr<
-    const MHWRender::MSamplerState,
-    SamplerDeleter
->;
+using SamplerUniquePtr = std::unique_ptr<const MHWRender::MSamplerState, SamplerDeleter>;
 
 } // namespace MayaUtil
 } // namespace MaterialXMaya

--- a/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
@@ -5,6 +5,7 @@
 #include "MaterialXNode.h"
 #include "ShadingNodeOverrides.h"
 
+#include <MaterialXFormat/Util.h>
 #ifdef MATERIALX_BUILD_CROSS
 #include <MaterialXCross/Cross.h>
 #endif
@@ -23,9 +24,8 @@ namespace
 {
 class SearchPathBuilder
 {
-  public:
-    explicit SearchPathBuilder(mx::FileSearchPath& searchPath)
-        : _searchPath(searchPath)
+public:
+    explicit SearchPathBuilder(mx::FileSearchPath& searchPath) : _searchPath(searchPath)
     {
         _searchPath = mx::FileSearchPath();
     }
@@ -60,7 +60,7 @@ void setIntermediateDumpPath()
     bool optionVarExists = false;
     MString path = MGlobal::optionVarStringValue("materialXIntermediateDumpPath", &optionVarExists);
 
-    if ( !optionVarExists || path.length() == 0 )
+    if (!optionVarExists || path.length() == 0)
     {
         return;
     }
@@ -153,7 +153,7 @@ void Plugin::loadLibraries()
     }
 
     mx::loadLibraries(
-        mx::StringVec(uniqueLibraryNames.begin(), uniqueLibraryNames.end()),
+        mx::FilePathVec(uniqueLibraryNames.begin(), uniqueLibraryNames.end()),
         _librarySearchPath,
         _libraryDocument
     );

--- a/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
@@ -118,7 +118,9 @@ mx::FileSearchPath Plugin::getResourceSearchPath() const
     // Search in standard installed resources directories and plug-in relative resources
     builder.append(_pluginLoadPath);
     builder.append(_pluginLoadPath / mx::FilePath("../../resources"));
+    builder.append(_pluginLoadPath / mx::FilePath("../../libraries"));
     builder.append(_pluginLoadPath / mx::FilePath("../resources"));
+    builder.append(_pluginLoadPath / mx::FilePath("../libraries"));
     builder.append(_pluginLoadPath / mx::FilePath(".."));
 
     builder.appendFromOptionVar("materialXResourceSearchPaths");
@@ -139,7 +141,7 @@ void Plugin::loadLibraries()
     }
 
     std::unordered_set<std::string> uniqueLibraryNames{
-        "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
+        "adsklib", "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
     };
 
     {

--- a/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXLibrariesCmd.h
+++ b/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXLibrariesCmd.h
@@ -19,7 +19,10 @@ public:
     ~ReloadMaterialXLibrariesCmd() override;
 
     MStatus doIt(const MArgList&) override;
-    bool isUndoable() { return false; }
+    bool isUndoable() const override
+    {
+        return false;
+    }
 
     static MSyntax newSyntax();
     static void* creator();

--- a/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXNodeCmd.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXNodeCmd.cpp
@@ -25,7 +25,7 @@ ReloadMaterialXNodeCmd::~ReloadMaterialXNodeCmd()
 {
 }
 
-MStatus ReloadMaterialXNodeCmd::doIt(const MArgList &args)
+MStatus ReloadMaterialXNodeCmd::doIt(const MArgList& args)
 {
     MArgParser parser(syntax(), args);
 
@@ -39,13 +39,13 @@ MStatus ReloadMaterialXNodeCmd::doIt(const MArgList &args)
     try
     {
         MString materialXNodeName;
-        CHECK_MSTATUS(argData.getCommandArgument(0, materialXNodeName));
+        CHECK_MSTATUS(argData.getCommandArgument(0, materialXNodeName))
 
         MSelectionList list;
-        CHECK_MSTATUS(list.add(materialXNodeName));
+        CHECK_MSTATUS(list.add(materialXNodeName))
 
         MObject node;
-        CHECK_MSTATUS(list.getDependNode(0, node));
+        CHECK_MSTATUS(list.getDependNode(0, node))
 
         MFnDependencyNode depNode(node);
         auto materialXNode = dynamic_cast<MaterialXNode*>(depNode.userNode());

--- a/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXNodeCmd.h
+++ b/source/MaterialXContrib/MaterialXMaya/ReloadMaterialXNodeCmd.h
@@ -22,7 +22,10 @@ public:
     ~ReloadMaterialXNodeCmd() override;
 
     MStatus doIt(const MArgList&) override;
-    bool isUndoable() { return false; }
+    bool isUndoable() const override
+    {
+        return false;
+    }
 
     static MSyntax newSyntax();
     static void* creator();

--- a/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.cpp
@@ -34,9 +34,9 @@ const MString
 namespace
 {
 // This should be a shared utility
-MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance, 
+MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
                         const std::string& parameterName,
-                        const mx::FileSearchPath& searchPath, 
+                        const mx::FileSearchPath& searchPath,
                         const std::string& fileName,
                         const MHWRender::MSamplerStateDesc& samplerDescription,
                         MHWRender::MTextureDescription& textureDescription,
@@ -46,15 +46,14 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
 
     // Bind file texture
     MHWRender::MRenderer* const renderer = MHWRender::MRenderer::theRenderer();
-    MHWRender::MTextureManager* const textureManager =
-        renderer ? renderer->getTextureManager() : nullptr;
+    MHWRender::MTextureManager* const textureManager = renderer ? renderer->getTextureManager() : nullptr;
 
     if (textureManager)
     {
         MayaUtil::TextureUniquePtr texturePtr;
         if (udimIdentifiers && !udimIdentifiers->empty())
         {
-            const std::vector<mx::Vector2> udimCoordinates{ mx::getUdimCoordinates(*udimIdentifiers) };
+            const std::vector<mx::Vector2> udimCoordinates{mx::getUdimCoordinates(*udimIdentifiers)};
 
             // Make sure we have 1:1 match of paths to coordinates.
             if (udimCoordinates.size() != udimIdentifiers->size())
@@ -71,8 +70,7 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
                 resolver->setUdimString((*udimIdentifiers)[i]);
 
                 mx::FilePath resolvedPath = MaterialXUtil::findInSubdirectories(
-                    searchPath, resolver->resolve(fileName, mx::FILENAME_TYPE_STRING)
-                );
+                    searchPath, resolver->resolve(fileName, mx::FILENAME_TYPE_STRING));
                 mTilePaths.append(resolvedPath.asString().c_str());
                 mTilePositions.append(udimCoordinates[i][0]);
                 mTilePositions.append(udimCoordinates[i][1]);
@@ -98,8 +96,9 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
             MStringArray failedTilePaths;
             MFloatArray uvScaleOffset;
 
-            // Note: we do not use the uv scale and offset. Ideally this should be used for the texture lookup code
-            // but at this point the shader code has already been generated.
+            // Note: we do not use the uv scale and offset. Ideally this should
+            // be used for the texture lookup code but at this point the shader
+            // code has already been generated.
             texturePtr.reset(textureManager->acquireTiledTexture(fileName.c_str(), mTilePaths, mTilePositions,
                                                                  undefinedColor, udimBakeWidth, udimBakeHeight,
                                                                  failedTilePaths, uvScaleOffset));
@@ -109,7 +108,8 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
             const mx::FilePath imagePath = MaterialXUtil::findInSubdirectories(searchPath, fileName);
             if (!imagePath.isEmpty())
             {
-                texturePtr.reset(textureManager->acquireTexture(imagePath.asString().c_str(), mx::EMPTY_STRING.c_str()));
+                texturePtr.reset(
+                    textureManager->acquireTexture(imagePath.asString().c_str(), mx::EMPTY_STRING.c_str()));
             }
         }
 
@@ -138,9 +138,7 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
     }
 
     // Bind the sampler
-    if (MayaUtil::SamplerUniquePtr samplerState{
-        MHWRender::MStateManager::acquireSamplerState(samplerDescription)
-    })
+    if (MayaUtil::SamplerUniquePtr samplerState{MHWRender::MStateManager::acquireSamplerState(samplerDescription)})
     {
         const std::string samplerParameterName = mx::OgsXmlGenerator::textureToSamplerName(parameterName);
         status = shaderInstance.setParameter(samplerParameterName.c_str(), *samplerState);
@@ -151,9 +149,9 @@ MStatus bindFileTexture(MHWRender::MShaderInstance& shaderInstance,
 
 // This should be a shared utility
 void bindEnvironmentLighting(MHWRender::MShaderInstance& shaderInstance,
-                            const MStringArray& parameterList,
-                            const mx::FileSearchPath& imageSearchPath,
-                            const MaterialXNode& node)
+                             const MStringArray& parameterList,
+                             const mx::FileSearchPath& imageSearchPath,
+                             const MaterialXNode& node)
 {
     MHWRender::MSamplerStateDesc samplerDescription;
     samplerDescription.filter = MHWRender::MSamplerState::kAnisotropic;
@@ -272,7 +270,7 @@ void ShadingNodeOverride<BASE>::updateShader(MHWRender::MShaderInstance& shaderI
     // Set up image file name search path.
     mx::FilePath documentPath(node->getDocumentFilePath().asChar());
     documentPath = documentPath.getParentPath();
-    mx::FileSearchPath imageSearchPath = Plugin::instance().getResourceSearchPath(); 
+    mx::FileSearchPath imageSearchPath = Plugin::instance().getResourceSearchPath();
     imageSearchPath.prepend(documentPath);
 
     bindEnvironmentLighting(shaderInstance, parameterList, imageSearchPath, *node);
@@ -280,7 +278,7 @@ void ShadingNodeOverride<BASE>::updateShader(MHWRender::MShaderInstance& shaderI
     mx::DocumentPtr document = ogsFragment->getDocument();
 
     // Look for any udimset on the document to use for texture binding.
-    mx::ValuePtr udimSetValue = document->getGeomAttrValue("udimset");
+    mx::ValuePtr udimSetValue = document->getGeomPropValue("udimset");
     const mx::StringVec* udimIdentifiers = nullptr;
     if (udimSetValue && udimSetValue->isA<mx::StringVec>())
     {
@@ -402,7 +400,7 @@ void ShadingNodeOverride<BASE>::updateShader(MHWRender::MShaderInstance& shaderI
                     }
 
                     status = bindFileTexture(shaderInstance, textureParameterName, imageSearchPath, valueString,
-                        samplerDescription, textureDescription, udimIdentifiers);
+                                             samplerDescription, textureDescription, udimIdentifiers);
                 }
             }
         }
@@ -412,15 +410,13 @@ void ShadingNodeOverride<BASE>::updateShader(MHWRender::MShaderInstance& shaderI
 template class ShadingNodeOverride<MHWRender::MPxShadingNodeOverride>;
 template class ShadingNodeOverride<MHWRender::MPxSurfaceShadingNodeOverride>;
 
-MHWRender::MPxSurfaceShadingNodeOverride*
-SurfaceOverride::creator(const MObject& obj)
+MHWRender::MPxSurfaceShadingNodeOverride* SurfaceOverride::creator(const MObject& obj)
 {
     std::cout.rdbuf(std::cerr.rdbuf());
     return new SurfaceOverride(obj);
 }
 
-MString
-SurfaceOverride::transparencyParameter() const
+MString SurfaceOverride::transparencyParameter() const
 {
     return mx::OgsXmlGenerator::VP_TRANSPARENCY_NAME.c_str();
 }

--- a/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.h
+++ b/source/MaterialXContrib/MaterialXMaya/ShadingNodeOverrides.h
@@ -13,8 +13,7 @@ namespace MaterialXMaya
 /// Base class for surface and texture shading node overrides, templated since
 /// they need to derive from different Maya API classes.
 ///
-template <class BASE>
-class ShadingNodeOverride : public BASE
+template <class BASE> class ShadingNodeOverride : public BASE
 {
   public:
     MHWRender::DrawAPI supportedDrawAPIs() const override
@@ -31,10 +30,7 @@ class ShadingNodeOverride : public BASE
 
     /// Set VP2 shader parameters based on MaterialX values and bind texture
     /// resources.
-    void updateShader(
-        MHWRender::MShaderInstance&,
-        const MHWRender::MAttributeParameterMappingList&
-    ) override;
+    void updateShader(MHWRender::MShaderInstance&, const MHWRender::MAttributeParameterMappingList&) override;
 
     /// Determine if changing the value of the specified plug should refresh
     /// the shader in the viewport.
@@ -52,8 +48,7 @@ class ShadingNodeOverride : public BASE
 /// VP2 surface shading node override.
 /// Implements shading for a MaterialXSurfaceNode.
 //
-class SurfaceOverride
-    : public ShadingNodeOverride<MHWRender::MPxSurfaceShadingNodeOverride>
+class SurfaceOverride : public ShadingNodeOverride<MHWRender::MPxSurfaceShadingNodeOverride>
 {
 public:
     static MHWRender::MPxSurfaceShadingNodeOverride* creator(const MObject&);
@@ -72,8 +67,7 @@ private:
 /// VP2 texture shading node override.
 /// Implements shading for a MaterialXTextureNode
 ///
-class TextureOverride
-    : public ShadingNodeOverride<MHWRender::MPxShadingNodeOverride>
+class TextureOverride : public ShadingNodeOverride<MHWRender::MPxShadingNodeOverride>
 {
 public:
     static MHWRender::MPxShadingNodeOverride* creator(const MObject&);

--- a/source/MaterialXTest/MaterialXGenOgsFx/GenOgsFx.cpp
+++ b/source/MaterialXTest/MaterialXGenOgsFx/GenOgsFx.cpp
@@ -121,7 +121,7 @@ static void generateOgsFxCode()
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genglsl_ogsfx_generate_test.txt");
 
-    bool writeShadersToDisk = false;
+    bool writeShadersToDisk = true;
     OgsFxShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;

--- a/source/MaterialXTest/MaterialXGenOgsXml/GenOgsXml.cpp
+++ b/source/MaterialXTest/MaterialXGenOgsXml/GenOgsXml.cpp
@@ -40,7 +40,6 @@ public:
             writeShadersToDisk
         )
     {
-        dumpMaterials = { "Tiled_Brass", "Brass_Wire_Mesh" };
     }
 
     void setTestStages() override
@@ -56,10 +55,8 @@ public:
     }
 
     // Generate source code for a given element and check that code was produced.
-    bool generateCode(
-        mx::GenContext& context, const std::string& /*shaderName*/, mx::TypedElementPtr element,
-        std::ostream& log, mx::StringVec /*testStages*/, mx::StringVec& /*sourceCode*/
-    ) override
+    bool generateCode(mx::GenContext& context, const std::string& /*shaderName*/, mx::TypedElementPtr element,
+                      std::ostream& log, mx::StringVec /*testStages*/, mx::StringVec& sourceCode ) override
     {
         std::unique_ptr<MaterialXMaya::OgsFragment> fragment;
         try
@@ -77,16 +74,12 @@ public:
             return false;
         }
 
-        if (mx::ShaderRefPtr shaderRef = element->asA<mx::ShaderRef>())
-        {
-            mx::MaterialPtr material = shaderRef->getParent()->asA<mx::Material>();
-            if (material && dumpMaterials.count(material->getName()))
-            {
-                std::ofstream file(material->getName() + ".xml");
-                file << fragment->getFragmentSource();
-                file.close();
-            }
-        }
+        sourceCode.push_back(fragment->getFragmentSource());
+
+        // Write output to disk
+        //std::ofstream file(material->getName() + ".xml");
+        //file << fragment->getFragmentSource();
+        //file.close();
 
         return true;
     }
@@ -101,8 +94,6 @@ protected:
             "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl", "IM_angle", "material", "ND_material"
         };
     }
-
-    mx::StringSet dumpMaterials;
 };
 
 static void generateXmlCode()
@@ -118,7 +109,7 @@ static void generateXmlCode()
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     const mx::FilePath logPath("genogsxml_generate_test.txt");
 
-    bool writeShadersToDisk = false;
+    bool writeShadersToDisk = true;
     OgsXmlShaderGeneratorTester tester(testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
 
     const mx::GenOptions genOptions;

--- a/source/MaterialXTest/MaterialXGenOgsXml/GenOgsXml.cpp
+++ b/source/MaterialXTest/MaterialXGenOgsXml/GenOgsXml.cpp
@@ -76,11 +76,6 @@ public:
 
         sourceCode.push_back(fragment->getFragmentSource());
 
-        // Write output to disk
-        //std::ofstream file(material->getName() + ".xml");
-        //file << fragment->getFragmentSource();
-        //file.close();
-
         return true;
     }
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -861,7 +861,10 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                         }
                         else
                         {
-                            path = path / (elementName + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage()));
+                            path = path / (elementName + "."  
+                                + _shaderGenerator->getTarget() 
+                                + "." + getFileExtensionForLanguage(_shaderGenerator->getLanguage())
+                                );
                             sourceCodePaths.push_back(path);
                             std::ofstream file(path.asString());
                             _logFile << "Write source code: " << path.asString() << std::endl;

--- a/source/MaterialXTest/MaterialXRenderOgsFx/RenderOgsFx.cpp
+++ b/source/MaterialXTest/MaterialXRenderOgsFx/RenderOgsFx.cpp
@@ -181,7 +181,7 @@ bool OgsFxShaderRenderTester::runRenderer(const std::string& shaderName,
     return true;
 }
 
-TEST_CASE("Render: OgsFx TestSuite", "[renderglsl]")
+TEST_CASE("Render: OgsFx TestSuite", "[renderogsfx]")
 {
     // Use the Maya version of the OgsFx generator,
     // so we can render the shaders in Maya's viewport.


### PR DESCRIPTION
LOOKDEVX-349  Update for OGS XML Updates and Maya Plugin usage fixes

Update #460 
- Update to support 1.38 material nodes for OGSXML fragment generation and usage in Maya sample plugin.
  - Port fix for units and update to include "adsk" library pathing into plugin.
- Update test configuration to write out ogsfx and ogsxml source output
