### PR TITLE
LucasFilm v1.38 merge update 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.37.3] - Development
 
-- Added a Render Transparency option to the Advanced Settings panel of the viewer.
+- Added Render Transparency and Render Double-Sided options to the Advanced Settings panel of the viewer.
 - Added a CMake option for building shared libraries on Linux and MacOS.
 
 ## [1.37.2] - 2020-09-06

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -3,7 +3,7 @@
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, sampler2D sampler)
 {
     vec2 res = textureSize(sampler, 0);
-    if (res.x > 0)
+    if (res.x > 1)
     {
         vec3 dir = normalize((transform * vec4(dir,0.0)).xyz);
         vec2 uv = mx_latlong_projection(dir);
@@ -15,7 +15,7 @@ vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, sampler2D sampler)
 vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lodBias, sampler2D sampler)
 {
     vec2 res = textureSize(sampler, 0);
-    if (res.x > 0)
+    if (res.x > 1)
     {
         // Heuristic for faking a blur by roughness
         int levels = 1 + int(floor(log2(max(res.x, res.y))));

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -54,7 +54,7 @@ vec3 mx_ggx_directional_albedo_table_lookup(float NdotV, float roughness, vec3 F
 {
 #if DIRECTIONAL_ALBEDO_METHOD == 1
     vec2 res = textureSize($albedoTable, 0);
-    if (res.x > 0)
+    if (res.x > 1)
     {
         vec2 AB = texture($albedoTable, vec2(NdotV, roughness)).rg;
         return F0 * AB.x + F90 * AB.y;

--- a/libraries/stdlib/genglsl/mx_image_color2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color2.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_color2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rg;

--- a/libraries/stdlib/genglsl/mx_image_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color3.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rgb;

--- a/libraries/stdlib/genglsl/mx_image_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color4.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv);

--- a/libraries/stdlib/genglsl/mx_image_float.glsl
+++ b/libraries/stdlib/genglsl/mx_image_float.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).r;

--- a/libraries/stdlib/genglsl/mx_image_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector2.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_vector2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rg;

--- a/libraries/stdlib/genglsl/mx_image_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector3.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_vector3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv).rgb;

--- a/libraries/stdlib/genglsl/mx_image_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector4.glsl
@@ -2,8 +2,7 @@
 
 void mx_image_vector4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
-    // TODO: Fix handling of addressmode
-    if(textureSize(tex_sampler, 0).x > 1)
+    if (textureSize(tex_sampler, 0).x > 1)
     {
         vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
         result = texture(tex_sampler, uv);

--- a/resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx
@@ -3,13 +3,12 @@
   <material name="Jade">
     <shaderref name="SR_jade" node="standard_surface">
       <bindinput name="base" type="float" value="0.5" />
-      <bindinput name="base_color" type="color3" value="0.0603, 0.43979999, 0.19159999" />
+      <bindinput name="base_color" type="color3" value="0.0603, 0.4398, 0.1916" />
       <bindinput name="specular_roughness" type="float" value="0.25" />
-      <bindinput name="specular_IOR" type="float" value="2.4179999828338623" />
+      <bindinput name="specular_IOR" type="float" value="2.418" />
       <bindinput name="specular_anisotropy" type="float" value="0.5" />
       <bindinput name="subsurface" type="float" value="0.4" />
-      <bindinput name="subsurface_color" type="color3" value="0.0603, 0.43979999, 0.19159999" />
-      <bindinput name="subsurface_scale" type="float" value="0.10000000149011612" />
+      <bindinput name="subsurface_color" type="color3" value="0.0603, 0.4398, 0.1916" />
     </shaderref>
   </material>
 </materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx
@@ -61,6 +61,8 @@
       <bindinput name="base_color" type="color3" nodegraph="NG_marble1" output="out" />
       <bindinput name="specular_color" type="color3" value="1, 1, 1" />
       <bindinput name="specular_roughness" type="float" value="0.1" />
+      <bindinput name="subsurface" type="float" value="0.4" />
+      <bindinput name="subsurface_color" type="color3" nodegraph="NG_marble1" output="out" />
     </shaderref>
   </material>
 </materialx>

--- a/resources/Materials/Examples/StandardSurface/standard_surface_metal_brushed.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_metal_brushed.mtlx
@@ -9,7 +9,7 @@
       <bindinput name="specular_roughness" type="float" value="0.25" />
       <bindinput name="specular_IOR" type="float" value="1.52" />
       <bindinput name="specular_anisotropy" type="float" value="0.65" />
-      <bindinput name="specular_rotation" type="float" value="0.5" />
+      <bindinput name="specular_rotation" type="float" value="0.0" />
       <bindinput name="metalness" type="float" value="1" />
     </shaderref>
   </material>

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -21,7 +21,7 @@
       <!-- Comma separated list of "language"_"target" specifiers to indicate which
            code generators to use.
        -->
-      <parameter name="languageAndTargets" type="string" value="genmdl_mdl,genglsl_glsl400,genosl_vanilla,genglsl_ogsfx,genglsl_ogsxml" />
+      <parameter name="languageAndTargets" type="string" value="genglsl_glsl400,genosl_vanilla,genmdl_mdl,genglsl_ogsfx,genglsl_ogsxml" />
 
       <!-- Check the count of number of implementations used for a given generator
         -->

--- a/resources/Materials/TestSuite/stdlib/texture/image.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image.mtlx
@@ -4,67 +4,47 @@
 Basic image unit test with one image node for each variation in input type.
 
 -->
-<materialx version="1.37">
-   <output name="image4_output" type="color4" nodename="image4" />
-   <image name="image4" type="color4">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+<materialx version="1.37" colorspace="srgb_texture">
 
-   <output name="image3_output" type="color3" nodename="image3" />
-   <image name="image3" type="color3">
-        <parameter name="file" type="filename" value="resources/Images/grid.png" />
-        <parameter name="uaddressmode" type="string" value="periodic"/>
-        <parameter name="vaddressmode" type="string" value="periodic"/>
-        <parameter name="filtertype" type="string" value="linear"/>
-        <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_color4" type="color4">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_color4_output" type="color4" nodename="image_color4" />
 
-   <output name="image2_output" type="color2" nodename="image2" />
-   <image name="image2" type="color2">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_color3" type="color3">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_color3_output" type="color3" nodename="image_color3" />
 
-   <output name="image1_output" type="float" nodename="image1" />
-   <image name="image1" type="float">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_color2" type="color2">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_color2_output" type="color2" nodename="image_color2" />
 
-   <output name="image4v_output" type="vector4" nodename="image4v" />
-   <image name="image4v" type="vector4">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_vector4" type="vector4">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_vector4_output" type="vector4" nodename="image_vector4" />
 
-   <output name="image3v_output" type="vector3" nodename="image3v" />
-   <image name="image3v" type="vector3">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_vector3" type="vector3">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_vector3_output" type="vector3" nodename="image_vector3" />
 
-   <output name="image2v_output" type="vector2" nodename="image2v" />
-   <image name="image2v" type="vector2">
-      <parameter name="file" type="filename" value="resources/Images/grid.png" />
-      <parameter name="uaddressmode" type="string" value="periodic"/>
-      <parameter name="vaddressmode" type="string" value="periodic"/>
-      <parameter name="filtertype" type="string" value="linear"/>
-      <parameter name="frameendaction" type="string" value="periodic"/>
-   </image>
+  <image name="image_vector2" type="vector2">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_vector2_output" type="vector2" nodename="image_vector2" />
+
+  <image name="image_float" type="float">
+    <parameter name="file" type="filename" value="resources/Images/grid.png" />
+  </image>
+  <output name="image_float_output" type="float" nodename="image_float" />
+
+   <image name="image_default" type="color3">
+    <parameter name="file" type="filename" value="resources/Images/invalid.png" />
+    <parameter name="default" type="color3" value="0.2, 0.2, 0.8" />
+  </image>
+  <output name="image_default_output" type="color3" nodename="image_default" />
+
 </materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -504,6 +504,14 @@ void Document::upgradeVersion(bool applyFutureUpdates)
                         nodeDef->removeAttribute("shaderprogram");
                     }
                 }
+                else if (child->getCategory() == "shaderref")
+                {
+                    if (child->hasAttribute("shadertype"))
+                    {
+                        child->setAttribute(TypedElement::TYPE_ATTRIBUTE, SURFACE_SHADER_TYPE_STRING);
+                        child->removeAttribute("shadertype");
+                    }
+                }
                 else if (child->isA<Parameter>())
                 {
                     ParameterPtr param = child->asA<Parameter>();
@@ -547,6 +555,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
                     if (nodeDef)
                     {
                         shaderRef->setNodeDefString(nodeDef->getName());
+                        shaderRef->setNodeString(nodeDef->getNodeString());
                     }
                 }
             }

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -604,6 +604,10 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
                 {
                     emitLine("float outAlpha = clamp(1.0 - dot(" + finalOutput + ".transparency, vec3(0.3333)), 0.0, 1.0)", stage);
                     emitLine(outputSocket->getVariable() + " = vec4(" + finalOutput + ".color, outAlpha)", stage);
+                    emitLine("if (outAlpha < " + HW::T_ALPHA_THRESHOLD + ")", stage, false);
+                    emitScopeBegin(stage);
+                    emitLine("discard", stage);
+                    emitScopeEnd(stage);
                 }
                 else
                 {

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -112,11 +112,6 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             shadergen.emitString("float surfaceOpacity = ", stage);
             shadergen.emitInput(node.getInput("opacity"), context, stage);
             shadergen.emitLineEnd(stage);
-            // Early out for 100% cutout transparency
-            shadergen.emitLine("if (surfaceOpacity < 0.001)", stage, false);
-            shadergen.emitScopeBegin(stage);
-            shadergen.emitLine("discard", stage);
-            shadergen.emitScopeEnd(stage);
             shadergen.emitLineBreak(stage);
         }
 

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -55,6 +55,7 @@ namespace HW
     const string T_FRAME                          = "$frame";
     const string T_TIME                           = "$time";
     const string T_GEOMPROP                       = "$geomprop";
+    const string T_ALPHA_THRESHOLD                = "$alphaThreshold";
     const string T_NUM_ACTIVE_LIGHT_SOURCES       = "$numActiveLightSources";
     const string T_ENV_MATRIX                     = "$envMatrix";
     const string T_ENV_RADIANCE                   = "$envRadiance";
@@ -105,6 +106,7 @@ namespace HW
     const string FRAME                            = "u_frame";
     const string TIME                             = "u_time";
     const string GEOMPROP                         = "u_geomprop";
+    const string ALPHA_THRESHOLD                  = "u_alphaThreshold";
     const string NUM_ACTIVE_LIGHT_SOURCES         = "u_numActiveLightSources";
     const string ENV_MATRIX                       = "u_envMatrix";
     const string ENV_RADIANCE                     = "u_envRadiance";
@@ -186,6 +188,7 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     _tokenSubstitutions[HW::T_FRAME] = HW::FRAME;
     _tokenSubstitutions[HW::T_TIME] = HW::TIME;
     _tokenSubstitutions[HW::T_GEOMPROP] = HW::GEOMPROP;
+    _tokenSubstitutions[HW::T_ALPHA_THRESHOLD] = HW::ALPHA_THRESHOLD;
     _tokenSubstitutions[HW::T_NUM_ACTIVE_LIGHT_SOURCES] = HW::NUM_ACTIVE_LIGHT_SOURCES;
     _tokenSubstitutions[HW::T_ENV_MATRIX] = HW::ENV_MATRIX;
     _tokenSubstitutions[HW::T_ENV_RADIANCE] = HW::ENV_RADIANCE;
@@ -262,6 +265,12 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 
     // Add a block for data from vertex to pixel shader.
     addStageConnectorBlock(HW::VERTEX_DATA, HW::T_VERTEX_DATA_INSTANCE, *vs, *ps);
+
+    // Add uniforms for transparent rendering.
+    if (context.getOptions().hwTransparency)
+    {
+        psPrivateUniforms->add(Type::FLOAT, HW::T_ALPHA_THRESHOLD, Value::createValue(0.001f));
+    }
 
     // Add uniforms for shadow map rendering.
     if (context.getOptions().hwShadowMap)

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -118,6 +118,7 @@ namespace HW
     extern const string T_FRAME;
     extern const string T_TIME;
     extern const string T_GEOMPROP;
+    extern const string T_ALPHA_THRESHOLD;
     extern const string T_NUM_ACTIVE_LIGHT_SOURCES;
     extern const string T_ENV_MATRIX;
     extern const string T_ENV_RADIANCE;
@@ -170,6 +171,7 @@ namespace HW
     extern const string FRAME;
     extern const string TIME;
     extern const string GEOMPROP;
+    extern const string ALPHA_THRESHOLD;
     extern const string NUM_ACTIVE_LIGHT_SOURCES;
     extern const string ENV_MATRIX;
     extern const string ENV_RADIANCE;

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -197,7 +197,7 @@ namespace HW
     extern const string LIGHT_DATA;       // Uniform inputs for light sources.
     extern const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
-    /// Variable names for direction vectors.
+    /// Variable names for lighting parameters.
     extern const string DIR_N;
     extern const string DIR_L;
     extern const string DIR_V;

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -340,9 +340,9 @@ class ShaderNode
         static const uint32_t CONDITIONAL   = 1 << 4;  /// A conditional node
         static const uint32_t CONSTANT      = 1 << 5;  /// A constant node
         // Specific closure types
-        static const uint32_t BSDF          = 1 << 6;  /// A BDFS node
-        static const uint32_t BSDF_R        = 1 << 7;  /// A BDFS node only for reflection
-        static const uint32_t BSDF_T        = 1 << 8;  /// A BDFS node only for transmission
+        static const uint32_t BSDF          = 1 << 6;  /// A BSDF node
+        static const uint32_t BSDF_R        = 1 << 7;  /// A BSDF node only for reflection
+        static const uint32_t BSDF_T        = 1 << 8;  /// A BSDF node only for transmission
         static const uint32_t EDF           = 1 << 9;  /// A EDF node
         static const uint32_t VDF           = 1 << 10; /// A VDF node
         static const uint32_t LAYER         = 1 << 11; /// A node for vertical layering of other closure nodes

--- a/source/MaterialXGenShader/ShaderTranslator.h
+++ b/source/MaterialXGenShader/ShaderTranslator.h
@@ -36,12 +36,7 @@ class ShaderTranslator
     ShaderTranslator();
 
     // Connect translation node inputs from the original shaderRef
-    void connectToTranslationInputs(ShaderRefPtr shaderRef, NodeDefPtr translationNodeDef);
-
-    // Copy translation nodegraph upstream node dependencies over to the working nodegraph.
-    // Used when normals need to be baked in tangent space but shaderref expects normals to 
-    // be in world space.
-    void insertUpstreamDependencies(OutputPtr translatedOutput, OutputPtr ngOutput);
+    void connectTranslationInputs(ShaderRefPtr shaderRef, NodeDefPtr translationNodeDef);
 
     // Connect translation node outputs to finalize shaderref translation
     void connectTranslationOutputs(ShaderRefPtr shaderRef);

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -332,6 +332,24 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
             }
         }
 
+        // Check existence
+        InputPtr existence = shaderNode->getActiveInput("existence");
+        if (existence)
+        {
+            if (existence->getConnectedOutput())
+            {
+                return true;
+            }
+            else
+            {
+                ValuePtr value = existence->getValue();
+                if (value && !isOne(value))
+                {
+                    return true;
+                }
+            }
+        }
+
         // Check transmission
         InputPtr transmission = shaderNode->getActiveInput("transmission");
         if (transmission)
@@ -462,6 +480,24 @@ bool isTransparentSurface(ElementPtr element, const ShaderGenerator& shadergen)
             else
             {
                 ValuePtr value = opacity->getValue();
+                if (value && !isOne(value))
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Check existence
+        BindInputPtr existence = shaderRef->getBindInput("existence");
+        if (existence)
+        {
+            if (existence->getConnectedOutput())
+            {
+                return true;
+            }
+            else
+            {
+                ValuePtr value = existence->getValue();
                 if (value && !isOne(value))
                 {
                     return true;

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -201,6 +201,14 @@ void computeDominantLight(ConstImagePtr env, Vector3& lightDir, Color3& lightCol
     // Project the environment to spherical harmonics.
     Sh3ColorCoeffs shEnv = projectEnvironment(env);
 
+    // Handle empty environments.
+    if (shEnv == Sh3ColorCoeffs())
+    {
+        lightDir = Vector3(0.0f, -1.0f, 0.0f);
+        lightColor = Color3(0.0f);
+        return;
+    }
+
     // Compute the dominant light direction.
     Vector3d dir = Vector3d(shEnv[3].dot(LUMA_COEFFS_REC709),
                             shEnv[1].dot(LUMA_COEFFS_REC709),

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -30,6 +30,16 @@ template <class C, size_t B> class ShCoeffs
     explicit ShCoeffs(const std::array<C, NUM_COEFFS>& arr) : _arr(arr) { }
     ~ShCoeffs() { }
 
+    /// @name Comparison Operators
+    /// @{
+
+    /// Return true if the given vector is identical to this one.
+    bool operator==(const ShCoeffs& rhs) const { return _arr == rhs._arr; }
+
+    /// Return true if the given vector differs from this one.
+    bool operator!=(const ShCoeffs& rhs) const { return _arr != rhs._arr; }
+
+    /// @}
     /// @name Indexing Operators
     /// @{
 

--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -247,6 +247,21 @@ Color4 Image::getTexelColor(unsigned int x, unsigned int y) const
     }
 }
 
+Color4 Image::getAverageColor()
+{
+    Color4 averageColor;
+    for (unsigned int y = 0; y < getHeight(); y++)
+    {
+        for (unsigned int x = 0; x < getWidth(); x++)
+        {
+            averageColor += getTexelColor(x, y);
+        }
+    }
+    unsigned int sampleCount = getWidth() * getHeight();
+    averageColor /= (float) sampleCount;
+    return averageColor;
+}
+
 bool Image::isUniformColor(Color4* uniformColor)
 {
     Color4 refColor = getTexelColor(0, 0);

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -104,6 +104,9 @@ class Image
     /// @name Image Analysis
     /// @{
 
+    /// Compute the average color of the image.
+    Color4 getAverageColor();
+
     /// Return true if all texels of this image are identical in color.
     /// @param uniformColor Return the uniform color of the image, if any.
     bool isUniformColor(Color4* uniformColor = nullptr);

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -40,7 +40,10 @@ const string ImageLoader::TXR_EXTENSION = "txr";
 ImageHandler::ImageHandler(ImageLoaderPtr imageLoader)
 {
     addLoader(imageLoader);
-    _zeroImage = createUniformImage(1, 1, 4, Image::BaseType::UINT8, Color4(0.0f));
+    _zeroImage = createUniformImage(2, 2, 4, Image::BaseType::UINT8, Color4(0.0f));
+
+    // Generated shaders interpret 1x1 textures as invalid images.
+    _invalidImage = createUniformImage(1, 1, 4, Image::BaseType::UINT8, Color4(0.0f));
 }
 
 void ImageHandler::addLoader(ImageLoaderPtr loader)
@@ -104,7 +107,7 @@ bool ImageHandler::saveImage(const FilePath& filePath,
     return false;
 }
 
-ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4* fallbackColor, string* message)
+ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, string* message)
 {
     FilePath foundFilePath = _searchPath.find(filePath);
     string extension = stringToLower(foundFilePath.getExtension());
@@ -123,7 +126,8 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
         }
         if (image)
         {
-            // Workaround for sampling issues with 1x1 textures.
+            // Generated shaders interpret 1x1 textures as invalid images, so valid 1x1
+            // images must be resized.
             if (image->getWidth() == 1 && image->getHeight() == 1)
             {
                 image = createUniformImage(2, 2, image->getChannelCount(),
@@ -150,17 +154,9 @@ ImagePtr ImageHandler::acquireImage(const FilePath& filePath, bool, const Color4
             *message = string("Image loader failed to parse image: ") + filePath.asString();
         }
     }
-    if (fallbackColor)
-    {
-        ImagePtr image = createUniformImage(2, 2, 4, Image::BaseType::UINT8, *fallbackColor);
-        if (image)
-        {
-            cacheImage(filePath, image);
-            return image;
-        }
-    }
 
-    return nullptr;
+    cacheImage(filePath, _invalidImage);
+    return _invalidImage;
 }
 
 bool ImageHandler::bindImage(ImagePtr, const ImageSamplingProperties&)

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -175,15 +175,11 @@ class ImageHandler
     /// found in the cache, then each image loader will be applied in turn.
     /// @param filePath File path of the image.
     /// @param generateMipMaps Generate mip maps if supported.
-    /// @param fallbackColor Optional uniform color of a fallback texture
-    ///    to create when the image cannot be loaded from the file system.
-    ///    By default, no fallback texture is created.
     /// @param message Optional pointer to a message string, where any warning
     ///    or error messages from the acquire operation will be stored.
     /// @return On success, a shared pointer to the acquired Image.
     virtual ImagePtr acquireImage(const FilePath& filePath,
                                   bool generateMipMaps = true,
-                                  const Color4* fallbackColor = nullptr,
                                   string* message = nullptr);
 
     /// Bind an image for rendering.
@@ -255,6 +251,7 @@ class ImageHandler
     FileSearchPath _searchPath;
     StringResolverPtr _resolver;
     ImagePtr _zeroImage;
+    ImagePtr _invalidImage;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -219,10 +219,13 @@ void Mesh::splitByUdims()
         }
     }
 
-    _partitions.clear();
-    for (const auto& pair : udimMap)
+    if (udimMap.size() >= 2)
     {
-        addPartition(pair.second);
+        _partitions.clear();
+        for (const auto& pair : udimMap)
+        {
+            addPartition(pair.second);
+        }
     }
 }
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -10,12 +10,13 @@
 
 #include <MaterialXRender/ShaderRenderer.h>
 
+#include <iostream>
+
 namespace MaterialX
 {
 
 GLTextureHandler::GLTextureHandler(ImageLoaderPtr imageLoader) :
-    ImageHandler(imageLoader),
-    _maxImageUnits(-1)
+    ImageHandler(imageLoader)
 {
     if (!glActiveTexture)
     {
@@ -61,17 +62,6 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
         }
     }
 
-    // Bind a texture to the next available slot
-    if (_maxImageUnits < 0)
-    {
-        glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &_maxImageUnits);
-    }
-    if (image->getResourceId() == GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID ||
-        image->getResourceId() == static_cast<unsigned int>(_maxImageUnits))
-    {
-        return false;
-    }
-
     // Update bound location if not already bound
     int textureUnit = getBoundTextureLocation(image->getResourceId());
     if (textureUnit < 0)
@@ -80,7 +70,8 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
     }
     if (textureUnit < 0)
     {
-        throw Exception("Exceeded maximum number of bound textures in GLTextureHandler::bindImage");
+        std::cerr << "Exceeded maximum number of bound textures in GLTextureHandler::bindImage" << std::endl;
+        return false;
     }      
     _boundTextureLocations[textureUnit] = image->getResourceId();
 
@@ -125,6 +116,11 @@ bool GLTextureHandler::createRenderResources(ImagePtr image, bool generateMipMap
     {
         unsigned int resourceId;
         glGenTextures(1, &resourceId);
+        if (resourceId == GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID)
+        {
+            std::cerr << "Failed to generate render resource for texture" << std::endl;
+            return false;
+        }
         image->setResourceId(resourceId);
     }
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -30,7 +30,6 @@ GLTextureHandler::GLTextureHandler(ImageLoaderPtr imageLoader) :
 
 ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
                                         bool generateMipMaps,
-                                        const Color4* fallbackColor,
                                         string* message)
 {
     // Resolve the input filepath.
@@ -41,14 +40,14 @@ ImagePtr GLTextureHandler::acquireImage(const FilePath& filePath,
     }
 
     // Return a cached image if available.
-    ImagePtr cachedDesc = getCachedImage(resolvedFilePath);
-    if (cachedDesc)
+    ImagePtr cachedImage = getCachedImage(resolvedFilePath);
+    if (cachedImage)
     {
-        return cachedDesc;
+        return cachedImage;
     }
 
     // Call the base acquire method.
-    return ImageHandler::acquireImage(resolvedFilePath, generateMipMaps, fallbackColor, message);
+    return ImageHandler::acquireImage(resolvedFilePath, generateMipMaps, message);
 }
 
 bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& samplingProperties)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -139,6 +139,11 @@ bool GLTextureHandler::createRenderResources(ImagePtr image, bool generateMipMap
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, image->getWidth(), image->getHeight(),
         0, glFormat, glType, image->getResourceBuffer());
+    if (image->getChannelCount() == 1)
+    {
+        GLint swizzleMask[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
+    }
 
     if (generateMipMaps)
     {

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -80,7 +80,7 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
     }
     if (textureUnit < 0)
     {
-        return false;
+        throw Exception("Exceeded maximum number of bound textures in GLTextureHandler::bindImage");
     }      
     _boundTextureLocations[textureUnit] = image->getResourceId();
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -68,7 +68,6 @@ class GLTextureHandler : public ImageHandler
     int getNextAvailableTextureLocation();
 
   protected:
-    int _maxImageUnits;
     std::vector<unsigned int> _boundTextureLocations;
 };
 

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -31,7 +31,6 @@ class GLTextureHandler : public ImageHandler
     /// found in the cache, then each image loader will be applied in turn.
     ImagePtr acquireImage(const FilePath& filePath,
                           bool generateMipMaps = true,
-                          const Color4* fallbackColor = nullptr,
                           string* message = nullptr) override;
 
     /// Bind an image. This method will bind the texture to an active texture

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -545,7 +545,7 @@ ImagePtr GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation,
     {
         // Acquire the image.
         string error;
-        ImagePtr image = imageHandler->acquireImage(filePath, generateMipMaps, &(samplingProperties.defaultColor));
+        ImagePtr image = imageHandler->acquireImage(filePath, generateMipMaps);
         if (imageHandler->bindImage(image, samplingProperties))
         {
             GLTextureHandlerPtr textureHandler = std::static_pointer_cast<GLTextureHandler>(imageHandler);

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -122,6 +122,7 @@ class TextureBaker : public GlslRenderer
     };
     using BakedImageVec = vector<BakedImage>;
     using BakedImageMap = std::unordered_map<OutputPtr, BakedImageVec>;
+    using BakedConstantMap = std::unordered_map<OutputPtr, Color4>;
 
     using WorldSpaceInputs = std::unordered_map<string, NodePtr>;
 
@@ -135,8 +136,8 @@ class TextureBaker : public GlslRenderer
     ConstNodePtr _shader;
     ConstNodePtr _material;
     WorldSpaceInputs _worldSpaceShaderInputs;
-    std::set<OutputPtr> _constantOutputs;
     BakedImageMap _bakedImageMap;
+    BakedConstantMap _bakedConstantMap;
 };
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -78,6 +78,18 @@ class TextureBaker : public GlslRenderer
         return _targetUnitSpace;
     }
 
+    /// Set whether images should be averaged to generate constants.   void setAverageImages(bool enable)
+    void setAverageImages(bool enable)
+    {
+        _averageImages = enable;
+    }
+
+    /// Return whether images should be averaged to generate constants.
+    bool getAverageImages()
+    {
+        return _averageImages;
+    }
+
     /// Set whether uniform textures should be stored as constants.  Defaults to true.
     void setOptimizeConstants(bool enable)
     {
@@ -130,6 +142,7 @@ class TextureBaker : public GlslRenderer
     string _extension;
     string _colorSpace;
     string _targetUnitSpace;
+    bool _averageImages;
     bool _optimizeConstants;
 
     ShaderGeneratorPtr _generator;

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -132,9 +132,15 @@ class TextureBaker : public GlslRenderer
         Color4 uniformColor;
         FilePath filename;
     };
+    class BakedConstant
+    {
+      public:
+        Color4 color;
+        bool isDefault = false;
+    };
     using BakedImageVec = vector<BakedImage>;
     using BakedImageMap = std::unordered_map<OutputPtr, BakedImageVec>;
-    using BakedConstantMap = std::unordered_map<OutputPtr, Color4>;
+    using BakedConstantMap = std::unordered_map<OutputPtr, BakedConstant>;
 
     using WorldSpaceInputs = std::unordered_map<string, NodePtr>;
 

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -427,7 +427,7 @@ ImagePtr OslRenderer::captureImage()
     }
 
     string error;
-    ImagePtr returnImage = _imageHandler->acquireImage(_oslOutputFileName, false, nullptr, &error);
+    ImagePtr returnImage = _imageHandler->acquireImage(_oslOutputFileName, false, &error);
     if (!returnImage)
     {
         errors.push_back("Failed to save to file: " + _oslOutputFileName.asString());

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -1149,7 +1149,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     }
                     else if (name == APPLY_LATEST_UPDATES)
                     {
-                    applyFutureUpdates = p->getValue()->asA<bool>();
+                        applyFutureUpdates = p->getValue()->asA<bool>();
                     }
                 }
             }

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -245,7 +245,6 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
             }
 
             const mx::FilePath filename = mx::FilePath(dir) / mx::FilePath(file);
-
             mx::DocumentPtr doc = mx::createDocument();
             try
             {

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -17,8 +17,6 @@ namespace {
 using MatrixXfProxy = Eigen::Map<const ng::MatrixXf>;
 using MatrixXuProxy = Eigen::Map<const ng::MatrixXu>;
 
-const mx::Color4 IMAGE_DEFAULT_COLOR(0, 0, 0, 1);
-
 const float PI = std::acos(-1.0f);
 
 } // anonymous namespace
@@ -301,7 +299,7 @@ void Material::bindImages(mx::ImageHandlerPtr imageHandler, const mx::FileSearch
         // Set the requested mipmap sampling property,
         samplingProperties.enableMipmaps = enableMipmaps;
 
-        mx::ImagePtr image = bindImage(filename, uniformVariable, imageHandler, samplingProperties, &IMAGE_DEFAULT_COLOR);
+        mx::ImagePtr image = bindImage(filename, uniformVariable, imageHandler, samplingProperties);
         if (image)
         {
             _boundImages.push_back(image);
@@ -310,7 +308,7 @@ void Material::bindImages(mx::ImageHandlerPtr imageHandler, const mx::FileSearch
 }
 
 mx::ImagePtr Material::bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
-                                 const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor)
+                                 const mx::ImageSamplingProperties& samplingProperties)
 {
     if (!_glShader)
     {
@@ -326,7 +324,7 @@ mx::ImagePtr Material::bindImage(const mx::FilePath& filePath, const std::string
     imageHandler->setFilenameResolver(resolver);
 
     // Acquire the given image.
-    mx::ImagePtr image = imageHandler->acquireImage(filePath, true, fallbackColor);
+    mx::ImagePtr image = imageHandler->acquireImage(filePath, true);
     if (!image)
     {
         return nullptr;

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -100,12 +100,10 @@ bool Material::generateShader(mx::GenContext& context)
         return false;
     }
 
-    _hasTransparency = context.getOptions().hwTransparency &&
-                       mx::isTransparentSurface(_elem, context.getShaderGenerator());
+    _hasTransparency = mx::isTransparentSurface(_elem, context.getShaderGenerator());
 
     mx::GenContext materialContext = context;
     materialContext.getOptions().hwTransparency = _hasTransparency;
-    materialContext.getOptions().hwShadowMap = materialContext.getOptions().hwShadowMap && !_hasTransparency;
 
     // Initialize in case creation fails and throws an exception
     clearShader();

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -100,7 +100,6 @@ class Material
         _material = val;
     }
 
-
     /// Get any associated udim identifier
     const std::string& getUdim()
     {
@@ -165,7 +164,7 @@ class Material
 
     /// Bind a single image.
     mx::ImagePtr bindImage(const mx::FilePath& filePath, const std::string& uniformName, mx::ImageHandlerPtr imageHandler,
-                           const mx::ImageSamplingProperties& samplingProperties, const mx::Color4* fallbackColor = nullptr);
+                           const mx::ImageSamplingProperties& samplingProperties);
 
     /// Bind lights to shader.
     void bindLights(const mx::GenContext& genContext, mx::LightHandlerPtr lightHandler, mx::ImageHandlerPtr imageHandler,

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -217,6 +217,7 @@ Viewer::Viewer(const std::string& materialFilename,
     _splitByUdims(true),
     _mergeMaterials(false),
     _renderTransparency(true),
+    _renderDoubleSided(true),
     _outlineSelection(false),
     _envSamples(envSampleCount),
     _drawEnvironment(false),
@@ -228,6 +229,7 @@ Viewer::Viewer(const std::string& materialFilename,
     _wedgeImageCount(8),
     _bakeTextures(false),
     _bakeHdr(false),
+    _bakeAverage(false),
     _bakeOptimize(true),
     _bakeTextureRes(DEFAULT_TEXTURE_RES),
     _bakeRequested(false)
@@ -835,7 +837,13 @@ void Viewer::createAdvancedSettings(Widget* parent)
     transparencyBox->setCallback([this](bool enable)
     {
         _renderTransparency = enable;
-        reloadShaders();
+    });
+
+    ng::CheckBox* doubleSidedBox = new ng::CheckBox(advancedPopup, "Render Double-Sided");
+    doubleSidedBox->setChecked(_renderDoubleSided);
+    doubleSidedBox->setCallback([this](bool enable)
+    {
+        _renderDoubleSided = enable;
     });
 
     ng::CheckBox* outlineSelectedGeometryBox = new ng::CheckBox(advancedPopup, "Outline Selected Geometry");
@@ -1009,10 +1017,10 @@ void Viewer::updateMaterialSelections()
     std::vector<std::string> items;
     for (const auto& material : _materials)
     {
-        mx::ElementPtr displayElem = material->getMaterialElement();
-        if (!displayElem)
-            displayElem = material->getElement();
-        std::string displayName = displayElem->getNamePath();
+        mx::ElementPtr displayElem = material->getMaterialElement() ?
+                                     material->getMaterialElement() :
+                                     material->getElement();
+        std::string displayName = displayElem->getName();
         if (!material->getUdim().empty())
         {
             displayName += " (" + material->getUdim() + ")";
@@ -1043,6 +1051,7 @@ void Viewer::updateMaterialSelectionUI()
             }
         }
     }
+    performLayout();
 }
 
 void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr libraries)
@@ -1645,27 +1654,41 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
         }
     }
 
-    // Allow left and right keys to cycle through the renderable elements
-    if ((key == GLFW_KEY_RIGHT || key == GLFW_KEY_LEFT) && action == GLFW_PRESS)
+    // Up and down keys cycle through selected geometries.
+    if ((key == GLFW_KEY_UP || key == GLFW_KEY_DOWN) && action == GLFW_PRESS)
     {
-        size_t materialCount = _materials.size();
-        size_t materialIndex = _selectedMaterial;
-        if (materialCount > 1)
+        if (_geometryList.size() > 1)
         {
-            if (key == GLFW_KEY_RIGHT)
+            if (key == GLFW_KEY_DOWN)
             {
-                _selectedMaterial = (materialIndex < materialCount - 1) ? materialIndex + 1 : 0;
+                _selectedGeom = (_selectedGeom < _geometryList.size() - 1) ? _selectedGeom + 1 : 0;
             }
             else
             {
-                _selectedMaterial = (materialIndex > 0) ? materialIndex - 1 : materialCount - 1;
-            }
-            if (!_geometryList.empty())
-            {
-                assignMaterial(getSelectedGeometry(), getSelectedMaterial());
-                updateMaterialSelectionUI();
+                _selectedGeom = (_selectedGeom > 0) ? _selectedGeom - 1 : _geometryList.size() - 1;
             }
         }
+        _geometrySelectionBox->setSelectedIndex((int) _selectedGeom);
+        updateMaterialSelectionUI();
+        return true;
+    }
+
+    // Left and right keys cycle through selected materials.
+    if ((key == GLFW_KEY_LEFT || key == GLFW_KEY_RIGHT) && action == GLFW_PRESS)
+    {
+        if (_materials.size() > 1)
+        {
+            if (key == GLFW_KEY_RIGHT)
+            {
+                _selectedMaterial = (_selectedMaterial < _materials.size() - 1) ? _selectedMaterial + 1 : 0;
+            }
+            else
+            {
+                _selectedMaterial = (_selectedMaterial > 0) ? _selectedMaterial - 1 : _materials.size() - 1;
+            }
+            assignMaterial(getSelectedGeometry(), getSelectedMaterial());
+            updateMaterialSelectionUI();
+       }
         return true;
     }
 
@@ -1685,7 +1708,7 @@ void Viewer::renderFrame()
     // Update shading tables
     updateAlbedoTable();
 
-    // Update lighting tate.
+    // Update lighting state.
     LightingState lightingState;
     lightingState.lightTransform = mx::Matrix44::createRotationY(_lightRotation / 180.0f * PI);
     lightingState.directLighting = _directLighting;
@@ -1732,6 +1755,13 @@ void Viewer::renderFrame()
             glDisable(GL_CULL_FACE);
             glCullFace(GL_BACK);
         }
+    }
+
+    // Enable backface culling if requested.
+    if (!_renderDoubleSided)
+    {
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
     }
 
     // Opaque pass
@@ -1794,6 +1824,10 @@ void Viewer::renderFrame()
         glDisable(GL_BLEND);
     }
 
+    if (!_renderDoubleSided)
+    {
+        glDisable(GL_CULL_FACE);
+    }
     glDisable(GL_FRAMEBUFFER_SRGB);
 
     // Wireframe pass
@@ -1972,8 +2006,11 @@ void Viewer::bakeTextures()
     // Compute material and UDIM lists.
     std::vector<MaterialPtr> materialsToBake;
     std::vector<std::string> udimSet;
-    mx::ValuePtr udimSetValue = bakeDoc->getGeomPropValue("udimset");
-    if (!material->getUdim().empty() && udimSetValue && _materials.size() > 1)
+    mx::ValuePtr udimSetValue = doc->getGeomPropValue("udimset");
+    if (_materials.size() > 1 &&
+        !material->getUdim().empty() &&
+        udimSetValue &&
+        !_bakeAverage)
     {
         materialsToBake = _materials;
         udimSet = udimSetValue->asA<std::vector<std::string>>();
@@ -1989,8 +2026,10 @@ void Viewer::bakeTextures()
         mx::TextureBakerPtr baker = mx::TextureBaker::create(_bakeTextureRes, _bakeTextureRes, baseType);
         baker->setupUnitSystem(_stdLib);
         baker->setTargetUnitSpace(_genContext.getOptions().targetDistanceUnit);
+        baker->setAverageImages(_bakeAverage);
+        baker->setOptimizeConstants(_bakeOptimize);
 
-        mx::StringResolverPtr resolver = mx::StringResolver::create();
+        mx::StringResolverPtr resolver = mx::StringResolver::c
 
         // Bake each material in the list.
         for (MaterialPtr mat : materialsToBake)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -214,11 +214,9 @@ Viewer::Viewer(const std::string& materialFilename,
     _genContextMdl(mx::MdlShaderGenerator::create()),
 #endif
     _unitRegistry(mx::UnitConverterRegistry::create()),
-    _splitByUdims(false),
+    _splitByUdims(true),
     _mergeMaterials(false),
-    _bakeTextures(false),
-    _bakeHdr(false),
-    _bakeTextureRes(DEFAULT_TEXTURE_RES),
+    _renderTransparency(true),
     _outlineSelection(false),
     _envSamples(envSampleCount),
     _drawEnvironment(false),
@@ -228,6 +226,10 @@ Viewer::Viewer(const std::string& materialFilename,
     _wedgePropertyMin(0.0f),
     _wedgePropertyMax(1.0f),
     _wedgeImageCount(8),
+    _bakeTextures(false),
+    _bakeHdr(false),
+    _bakeOptimize(true),
+    _bakeTextureRes(DEFAULT_TEXTURE_RES),
     _bakeRequested(false)
 {
     _window = new ng::Window(this, "Viewer Options");
@@ -243,7 +245,6 @@ Viewer::Viewer(const std::string& materialFilename,
     // Set default generator options.
     _genContext.getOptions().hwSpecularEnvironmentMethod = specularEnvironmentMethod;
     _genContext.getOptions().hwDirectionalAlbedoMethod = mx::DIRECTIONAL_ALBEDO_TABLE;
-    _genContext.getOptions().hwTransparency = true;
     _genContext.getOptions().hwShadowMap = true;
     _genContext.getOptions().targetColorSpaceOverride = "lin_rec709";
     _genContext.getOptions().fileTextureVerticalFlip = true;
@@ -830,10 +831,10 @@ void Viewer::createAdvancedSettings(Widget* parent)
     renderLabel->setFont("sans-bold");
 
     ng::CheckBox* transparencyBox = new ng::CheckBox(advancedPopup, "Render Transparency");
-    transparencyBox->setChecked(_genContext.getOptions().hwTransparency);
+    transparencyBox->setChecked(_renderTransparency);
     transparencyBox->setCallback([this](bool enable)
     {
-        _genContext.getOptions().hwTransparency = enable;
+        _renderTransparency = enable;
         reloadShaders();
     });
 
@@ -1739,7 +1740,7 @@ void Viewer::renderFrame()
         mx::MeshPartitionPtr geom = assignment.first;
         MaterialPtr material = assignment.second;
         shadowState.ambientOcclusionMap = getAmbientOcclusionImage(material);
-        if (!material || material->hasTransparency())
+        if (!material)
         {
             continue;
         }
@@ -1749,6 +1750,10 @@ void Viewer::renderFrame()
             glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
         }
         material->bindShader();
+        if (material->getShader()->uniform(mx::HW::ALPHA_THRESHOLD, false) != -1)
+        {
+            material->getShader()->setUniform(mx::HW::ALPHA_THRESHOLD, 0.99f);
+        }
         material->bindViewInformation(world, view, proj);
         material->bindLights(_genContext, _lightHandler, _imageHandler, lightingState, shadowState);
         material->bindImages(_imageHandler, _searchPath);
@@ -1761,27 +1766,34 @@ void Viewer::renderFrame()
     }
 
     // Transparent pass
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    for (const auto& assignment : _materialAssignments)
+    if (_renderTransparency)
     {
-        mx::MeshPartitionPtr geom = assignment.first;
-        MaterialPtr material = assignment.second;
-        shadowState.ambientOcclusionMap = getAmbientOcclusionImage(material);
-        if (!material || !material->hasTransparency())
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        for (const auto& assignment : _materialAssignments)
         {
-            continue;
-        }
+            mx::MeshPartitionPtr geom = assignment.first;
+            MaterialPtr material = assignment.second;
+            shadowState.ambientOcclusionMap = getAmbientOcclusionImage(material);
+            if (!material || !material->hasTransparency())
+            {
+                continue;
+            }
 
-        material->bindShader();
-        material->bindViewInformation(world, view, proj);
-        material->bindLights(_genContext, _lightHandler, _imageHandler, lightingState, shadowState);
-        material->bindImages(_imageHandler, _searchPath);
-        material->drawPartition(geom);
-        material->unbindImages(_imageHandler);
+            material->bindShader();
+            if (material->getShader()->uniform(mx::HW::ALPHA_THRESHOLD, false) != -1)
+            {
+                material->getShader()->setUniform(mx::HW::ALPHA_THRESHOLD, 0.001f);
+            }
+            material->bindViewInformation(world, view, proj);
+            material->bindLights(_genContext, _lightHandler, _imageHandler, lightingState, shadowState);
+            material->bindImages(_imageHandler, _searchPath);
+            material->drawPartition(geom);
+            material->unbindImages(_imageHandler);
+        }
+        glDisable(GL_BLEND);
     }
 
-    glDisable(GL_BLEND);
     glDisable(GL_FRAMEBUFFER_SRGB);
 
     // Wireframe pass
@@ -1952,6 +1964,9 @@ void Viewer::bakeTextures()
     mx::FileSearchPath searchPath = _searchPath;
     searchPath.append(documentFilename.getParentPath());
     mx::ImageHandlerPtr imageHandler = mx::GLTextureHandler::create(mx::StbImageLoader::create());
+#if MATERIALX_BUILD_OIIO
+    imageHandler->addLoader(mx::OiioImageLoader::create());
+#endif
     imageHandler->setSearchPath(searchPath);
 
     // Compute material and UDIM lists.

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -2007,7 +2007,7 @@ void Viewer::bakeTextures()
     // Compute material and UDIM lists.
     std::vector<MaterialPtr> materialsToBake;
     std::vector<std::string> udimSet;
-    mx::ValuePtr udimSetValue = doc->getGeomPropValue("udimset");
+    mx::ValuePtr udimSetValue = origDoc->getGeomPropValue("udimset");
     if (_materials.size() > 1 &&
         !material->getUdim().empty() &&
         udimSetValue &&
@@ -2030,7 +2030,7 @@ void Viewer::bakeTextures()
         baker->setAverageImages(_bakeAverage);
         baker->setOptimizeConstants(_bakeOptimize);
 
-        mx::StringResolverPtr resolver = mx::StringResolver::c
+        mx::StringResolverPtr resolver = mx::StringResolver::create();
 
         // Bake each material in the list.
         for (MaterialPtr mat : materialsToBake)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -2372,7 +2372,6 @@ mx::ImagePtr Viewer::getAmbientOcclusionImage(MaterialPtr material)
 {
     const mx::string AO_FILENAME_SUFFIX = "_ao";
     const mx::string AO_FILENAME_EXTENSION = "png";
-    const mx::Color4 AO_FALLBACK_COLOR(1.0f);
 
     if (!material || !_genContext.getOptions().hwAmbientOcclusion)
     {
@@ -2384,7 +2383,7 @@ mx::ImagePtr Viewer::getAmbientOcclusionImage(MaterialPtr material)
     aoFilename.removeExtension();
     aoFilename = aoFilename.asString() + aoSuffix;
     aoFilename.addExtension(AO_FILENAME_EXTENSION);
-    return _imageHandler->acquireImage(aoFilename, true, &AO_FALLBACK_COLOR);
+    return _imageHandler->acquireImage(aoFilename, true);
 }
 
 void Viewer::splitDirectLight(mx::ImagePtr envRadianceMap, mx::ImagePtr& indirectMap, mx::DocumentPtr& dirLightDoc)

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -576,8 +576,7 @@ void Viewer::createLoadMeshInterface(Widget* parent, const std::string& label)
                 _cameraViewAngle = DEFAULT_CAMERA_VIEW_ANGLE;
                 initCamera();
 
-                _imageHandler->releaseRenderResources(_shadowMap);
-                _shadowMap = nullptr;
+                invalidateShadowMap();
             }
             else
             {
@@ -625,9 +624,7 @@ void Viewer::createLoadEnvironmentInterface(Widget* parent, const std::string& l
             _envRadiancePath = filename;
             loadEnvironmentLight();
             loadDocument(_materialFilename, _stdLib);
-
-            _imageHandler->releaseRenderResources(_shadowMap);
-            _shadowMap = nullptr;
+            invalidateShadowMap();
         }
         mProcessEvents = true;
     });
@@ -794,8 +791,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
         _lightRotation, &ui, [this](float value)
     {
         _lightRotation = value;
-        _imageHandler->releaseRenderResources(_shadowMap);
-        _shadowMap = nullptr;
+        invalidateShadowMap();
     });
     lightRotationBox->setEditable(true);
 
@@ -1277,7 +1273,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 {
                     for (mx::MeshPartitionPtr geom : _geometryList)
                     {
-                        if (!_materialAssignments[geom] && geom->getIdentifier() == udim)
+                        if (geom->getIdentifier() == udim)
                         {
                             assignMaterial(geom, mat);
                         }
@@ -1286,11 +1282,15 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             }
 
             // Apply fallback assignments.
-            for (mx::MeshPartitionPtr geom : _geometryList)
+            MaterialPtr fallbackMaterial = newMaterials[0];
+            if (fallbackMaterial->getUdim().empty())
             {
-                if (!_materialAssignments[geom])
+                for (mx::MeshPartitionPtr geom : _geometryList)
                 {
-                    assignMaterial(geom, newMaterials[0]);
+                    if (!_materialAssignments[geom])
+                    {
+                        assignMaterial(geom, fallbackMaterial);
+                    }
                 }
             }
         }
@@ -1308,6 +1308,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
     updateMaterialSelections();
     updateMaterialSelectionUI();
 
+    invalidateShadowMap();
     performLayout();
 }
 
@@ -2394,7 +2395,10 @@ void Viewer::splitDirectLight(mx::ImagePtr envRadianceMap, mx::ImagePtr& indirec
 
     mx::computeDominantLight(imagePair.second, lightDir, lightColor);
     float lightIntensity = std::max(std::max(lightColor[0], lightColor[1]), lightColor[2]);
-    lightColor /= lightIntensity;
+    if (lightIntensity)
+    {
+        lightColor /= lightIntensity;
+    }
 
     dirLightDoc = mx::createDocument();
     mx::NodePtr dirLightNode = dirLightDoc->addNode(DIR_LIGHT_NODE_CATEGORY, "dir_light", mx::LIGHT_SHADER_TYPE_STRING);
@@ -2429,10 +2433,9 @@ void Viewer::updateShadowMap()
     // Render shadow geometry.
     _shadowMaterial->bindShader();
     _shadowMaterial->bindViewInformation(world, view, proj);
-    mx::MeshPtr mesh = _geometryHandler->getMeshes()[0];
-    for (size_t i = 0; i < mesh->getPartitionCount(); i++)
+    for (const auto& assignment : _materialAssignments)
     {
-        mx::MeshPartitionPtr geom = mesh->getPartition(i);
+        mx::MeshPartitionPtr geom = assignment.first;
         _shadowMaterial->drawPartition(geom);
     }
     _shadowMap = framebuffer->createColorImage();
@@ -2461,6 +2464,15 @@ void Viewer::updateShadowMap()
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glDrawBuffer(GL_BACK);
+}
+
+void Viewer::invalidateShadowMap()
+{
+    if (_shadowMap)
+    {
+        _imageHandler->releaseRenderResources(_shadowMap);
+        _shadowMap = nullptr;
+    }
 }
 
 void Viewer::updateAlbedoTable()

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -245,9 +245,6 @@ class Viewer : public ng::Screen
 
     // Material options
     bool _mergeMaterials;
-    bool _bakeTextures;
-    bool _bakeHdr;
-    int _bakeTextureRes;
 
     // Unit options
     mx::StringVec _distanceUnitOptions;
@@ -255,6 +252,7 @@ class Viewer : public ng::Screen
     mx::LinearUnitConverterPtr _distanceUnitConverter;
 
     // Render options
+    bool _renderTransparency;
     bool _outlineSelection;
     int _envSamples;
     bool _drawEnvironment;
@@ -273,6 +271,10 @@ class Viewer : public ng::Screen
     ng::ComboBox* _wedgeSelectionBox;
 
     // Texture baking
+    bool _bakeTextures;
+    bool _bakeHdr;
+    bool _bakeOptimize;
+    int _bakeTextureRes;
     bool _bakeRequested;
     mx::FilePath _bakeFilename;
 };

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -253,6 +253,7 @@ class Viewer : public ng::Screen
 
     // Render options
     bool _renderTransparency;
+    bool _renderDoubleSided;
     bool _outlineSelection;
     int _envSamples;
     bool _drawEnvironment;
@@ -273,6 +274,7 @@ class Viewer : public ng::Screen
     // Texture baking
     bool _bakeTextures;
     bool _bakeHdr;
+    bool _bakeAverage;
     bool _bakeOptimize;
     int _bakeTextureRes;
     bool _bakeRequested;

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -135,8 +135,8 @@ class Viewer : public ng::Screen
     /// returning a new indirect map and directional light document.
     void splitDirectLight(mx::ImagePtr envRadianceMap, mx::ImagePtr& indirectMap, mx::DocumentPtr& dirLightDoc);
 
-    /// Update the current shadow map.
     void updateShadowMap();
+    void invalidateShadowMap();
 
     /// Update the directional albedo table.
     void updateAlbedoTable();

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -74,11 +74,11 @@ void bindPyImageHandler(py::module& mod)
         .def("saveImage", &mx::ImageHandler::saveImage,
             py::arg("filePath"), py::arg("image"), py::arg("verticalFlip") = false, py::arg("message") = (std::string*) nullptr)
         .def("acquireImage", &mx::ImageHandler::acquireImage,
-            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("fallbackColor") = (mx::Color4*) nullptr, py::arg("message") = (std::string*) nullptr)
-        .def("acquireImage", [](mx::ImageHandler& handler, const mx::FilePath& filePath, bool generateMipMaps, const mx::Color4* fallbackColor)
+            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("message") = (std::string*) nullptr)
+        .def("acquireImage", [](mx::ImageHandler& handler, const mx::FilePath& filePath, bool generateMipMaps, const std::string*)
             {
                 // Convert from v1.37.2 function signature.
-                return handler.acquireImage(filePath, generateMipMaps, fallbackColor);
+                return handler.acquireImage(filePath, generateMipMaps);
             })
         .def("bindImage", &mx::ImageHandler::bindImage)
         .def("unbindImage", &mx::ImageHandler::unbindImage)

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
@@ -15,7 +15,7 @@ void bindPyGLTextureHandler(py::module& mod)
     py::class_<mx::GLTextureHandler, mx::ImageHandler, mx::GLTextureHandlerPtr>(mod, "GLTextureHandler")
         .def_static("create", &mx::GLTextureHandler::create)
         .def("acquireImage", &mx::GLTextureHandler::acquireImage,
-            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("fallbackColor") = (mx::Color4*) nullptr, py::arg("message") = (std::string*) nullptr)
+            py::arg("filePath"), py::arg("generateMipMaps") = true, py::arg("message") = (std::string*) nullptr)
         .def("bindImage", &mx::GLTextureHandler::bindImage)
         .def("mapAddressModeToGL", &mx::GLTextureHandler::mapAddressModeToGL)
         .def("mapFilterTypeToGL", &mx::GLTextureHandler::mapFilterTypeToGL);


### PR DESCRIPTION
Update #460 

- Merges from:
https://github.com/materialx/MaterialX/commit/fab32d0b783fb9b647224a3aa02b9e88616aef45
to
https://github.com/materialx/MaterialX/commit/2b5adc6b78bcb4fbb740846ff855d3b145abfdb5

**Change Log:**
   * Robustness improvements for translation and baking
   * Improvements to texture baking
   * Viewer improvements (without TextureBaker changes!)
   * Improvements to OpenGL texture handling
      - Fix an edge case in image resource construction.
      - Emit warnings when errors are encountered in image binding.
   * Add support for image averaging in baking
   * Additional viewer options.
   * Fix for single-channel textures in MaterialXRenderGlsl
      - This changelist fixes the rendering of single-channel textures in MaterialXRenderGlsl, setting the required state that replicates the red channel to RGB.
   * Handle empty environments in computeDominantLight
   * Viewer improvements
      - Handle UDIMs when merging multiple materials.
      - Invalidate shadow maps when a new material is loaded.
      - Check for zero intensities in splitDirectLight.
      - Consider "existence" bindings when computing transparency.
   * Image handling improvements (#520)

**Notes**
GLSL fidelity changes not updated.
- [Add GLSL subsurface scattering approximation](https://github.com/materialx/MaterialX/commit/f53f04862545045a8739fc15edbadd179129477a)
- [GLSL shading improvements](https://github.com/materialx/MaterialX/commit/a3686763511c28eb9f9993fd4553114670ae52de)

**Test results**
[Nov12_2020_unit_tests.pdf](https://github.com/autodesk-forks/MaterialX/files/5532201/Nov12_2020_unit_tests.pdf)
