### PR TITLE
Update env commands in GitHub Actions

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -52,12 +52,12 @@ jobs:
         sudo apt-get install libgl-dev libglu1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libx11-dev
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           sudo apt-get install -y g++-${{ matrix.compiler_version }} g++-${{ matrix.compiler_version }}-multilib
-          echo "::set-env name=CC::gcc-${{ matrix.compiler_version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.compiler_version }}"
+          echo "CC=gcc-${{ matrix.compiler_version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         else
           sudo apt-get install -y clang-${{ matrix.compiler_version }} g++-multilib
-          echo "::set-env name=CC::clang-${{ matrix.compiler_version }}"
-          echo "::set-env name=CXX::clang++-${{ matrix.compiler_version }}"
+          echo "CC=clang-${{ matrix.compiler_version }}" >> $GITHUB_ENV
+          echo "CXX=clang++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         fi
 
     - name: Install Python ${{ matrix.python }}

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -45,13 +45,13 @@ jobs:
         brew install cmake ninja
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           brew install gcc@${{ matrix.compiler_version }}
-          echo "::set-env name=CC::gcc-${{ matrix.compiler_version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.compiler_version }}"
+          echo "CC=gcc-${{ matrix.compiler_version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         else
           ls -ls /Applications/
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.compiler_version }}.app
-          echo "::set-env name=CC::clang"
-          echo "::set-env name=CXX::clang++"
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
         fi
 
     - name: Install Python ${{ matrix.python }}


### PR DESCRIPTION
Update #1007 

Update based on changes in MaterialX 1.38:
https://github.com/materialx/MaterialX/commit/45324365ed48681ab427bc90f2eae2992a84a49c

Addresses deprecation of set-env
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/