### PR TITLE
Fix ShaderTranslator upstream output search logic 

### DIFF
--- a/source/MaterialXCore/MaterialNode.cpp
+++ b/source/MaterialXCore/MaterialNode.cpp
@@ -289,4 +289,20 @@ vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const
     return matAssigns;
 }
 
+vector<OutputPtr> getConnectedOutputs(const NodePtr& node)
+{
+    vector<OutputPtr> outputVec;
+    std::set<OutputPtr> outputSet;
+    for (InputPtr bindInput : node->getInputs())
+    {
+        OutputPtr output = bindInput->getConnectedOutput();
+        if (output && !outputSet.count(output))
+        {
+            outputVec.push_back(output);
+            outputSet.insert(output);
+        }
+    }
+    return outputVec;
+}
+
 } // namespace MaterialX

--- a/source/MaterialXCore/MaterialNode.h
+++ b/source/MaterialXCore/MaterialNode.h
@@ -46,6 +46,9 @@ std::unordered_set<NodePtr> getShaderNodes(const NodePtr& materialNode,
 vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const string& geom);
 
 
+/// Return a vector of all outputs that this element references.
+vector<OutputPtr> getConnectedOutputs(const NodePtr& node);
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -139,10 +139,10 @@ void ShaderTranslator::translateShader(NodePtr shader, const string& destCategor
     }
 
     DocumentPtr doc = shader->getDocument();
-    vector<OutputPtr> referencedOutputs = shader->getOutputs();
+    vector<OutputPtr> referencedOutputs = getConnectedOutputs(shader);
     if (!referencedOutputs.empty())
     {
-        _graph = referencedOutputs[0]->getParent()->asA<NodeGraph>();
+        _graph = referencedOutputs[0]->getParent() ? referencedOutputs[0]->getParent()->asA<NodeGraph>() : nullptr;
     }
     if (!_graph)
     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -214,8 +214,10 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
     mx::FileSearchPath searchPath;
     searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
     loadLibraries({ "stdlib", "pbrlin", "bxdf", "translation" }, searchPath, doc);
-    const mx::FilePath mtlxFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    const mx::FilePath mtlxFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx");
     mx::readFromXmlFile(doc, mtlxFile, searchPath);
+    mx::writeToXmlFile(doc, "standard_surface_wood_tiled_untranslated.mtlx");
+
     mx::ShaderTranslatorPtr shaderTranslator = mx::ShaderTranslator::create();
     shaderTranslator->translateAllMaterials(doc, "UsdPreviewSurface");
 
@@ -226,5 +228,7 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
         std::cout << validationErrors << std::endl;
     }
     REQUIRE(valid);
+
+    mx::writeToXmlFile(doc, "standard_surface_wood_tiled_translated.mtlx");
 }
 

--- a/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
@@ -80,6 +80,6 @@ void bindPyMaterial(py::module& mod)
     mod.def("convertMaterialsToNodes", &mx::convertMaterialsToNodes);
     mod.def("getShaderNodes", &mx::getShaderNodes);
     mod.def("getGeometryBindings", &mx::getGeometryBindings);
-
+    mod.def("getConnectedOutputs", &mx::getConnectedOutputs);
 }
 


### PR DESCRIPTION
Update #1023 

Add equivalent to ShaderRef::gerReferencedOutputs() via new utility getConnnectedOutputs() in MaterialNode.
This should fix incorrect upgrade inside ShaderTranslator to find upstream graphs properly now.

### Untranslated
![image](https://user-images.githubusercontent.com/14275104/99583142-14368680-29b1-11eb-9505-f11f8e2cef98.png)
![image](https://user-images.githubusercontent.com/14275104/99583231-30d2be80-29b1-11eb-8f4c-97d623b04f13.png)

### Translated
![image](https://user-images.githubusercontent.com/14275104/99583052-f2d59a80-29b0-11eb-8790-6cad5d3e1bc3.png)
![image](https://user-images.githubusercontent.com/14275104/99582955-cf125480-29b0-11eb-8bc3-49e259a7791b.png)
