### PR TITLE
Cleanup TextureBaker and Translator (including re-initialization)

### DIFF
--- a/libraries/translation/standard_surface_to_UsdPreviewSurface.mtlx
+++ b/libraries/translation/standard_surface_to_UsdPreviewSurface.mtlx
@@ -13,52 +13,55 @@
 -->
 
 <materialx version="1.37">
-  <nodedef name="ND_standard_surface_to_UsdPreviewSurface" node="standard_surface_to_UsdPreviewSurface" nodegroup="translation">
-    <input name="base" type="float" value="0" />
-    <input name="base_color" type="color3" value="0.18, 0.18, 0.18" />
-    <input name="specular" type="float" value="0" />
-    <input name="specular_color" type="color3" value="0.18, 0.18, 0.18" />
-    <input name="specular_roughness" type="float" value="0" />
-    <input name="specular_IOR" type="float" value="1.5" />
-    <input name="metalness" type="float" value="1" />
-    <output name="diffuseColor_out" type="color3" />
-    <output name="specularColor_out" type="color3" />
-    <output name="roughness_out" type="float" />
-    
-    <output name="metalness_out" type="float" />
-    <output name="ior_out" type="float" value="50" />
-    
-  </nodedef>
+   <nodedef name="ND_standard_surface_to_UsdPreviewSurface" node="standard_surface_to_UsdPreviewSurface" nodegroup="translation">
+      <input name="base" type="float" value="0" />
+      <input name="base_color" type="color3" value="0.18, 0.18, 0.18" />
+      <input name="specular" type="float" value="0" />
+      <input name="specular_color" type="color3" value="0.18, 0.18, 0.18" />
+      <input name="specular_roughness" type="float" value="0" />
+      <input name="specular_IOR" type="float" value="1.5" />
+      <input name="metalness" type="float" value="1" />
+      <output name="diffuseColor_out" type="color3" />
+      <output name="specularColor_out" type="color3" />
+      <output name="roughness_out" type="float" />
 
-  <nodegraph name="NG_standard_surface_to_UsdPreviewSurface" nodedef="ND_standard_surface_to_UsdPreviewSurface">
-    <!-- Partial translation of Autodesk Standard Surface to UsdPreview surface conversion -->
-    <multiply name="base_colorToDiffuseColor" type="color3">
-      <input name="in1" type="color3" interfacename="base_color" />
-      <input name="in2" type="float" interfacename="base" />
-    </multiply>
-    <multiply name="specular_colorToSpecularColor" type="color3">
-      <input name="in1" type="color3" interfacename="specular_color" />
-      <input name="in2" type="float" interfacename="specular" />
-    </multiply>
-    
-    <dot name="metalnessTometalness" type="float">
-      <input name="in" type="float" interfacename="metalness" />
-    </dot>
-   
-    <dot name="specular_roughnessToroughness" type="float">
-      <input name="in" type="float" interfacename="specular_roughness" />
-    </dot>
-     <dot name="specular_IORToior" type="float">
-        <input name="in" type="float" interfacename="specular_IOR" />
-     </dot>
+      <output name="metalness_out" type="float" />
+      <output name="ior_out" type="float" value="50" />
 
-     <!-- Outputs -->
-    <output name="diffuseColor_out" type="color3" nodename="base_colorToDiffuseColor" />
-    <output name="specularColor_out" type="color3" nodename="specular_colorToSpecularColor" />
-    <output name="roughness_out" type="float" nodename="specular_roughnessToroughness" />
-    
-    <output name="metalness_out" type="float" nodename="metalnessTometalness" />
-    <output name="ior_out" type="float" nodename="specular_IORToior" />
-    
-  </nodegraph>
+   </nodedef>
+
+   <nodegraph name="NG_standard_surface_to_UsdPreviewSurface" nodedef="ND_standard_surface_to_UsdPreviewSurface">
+      <!-- Partial translation of Autodesk Standard Surface to UsdPreview surface conversion -->
+      <multiply name="base_colorToDiffuseColor" type="color3">
+         <input name="in1" type="color3" interfacename="base_color" />
+         <input name="in2" type="float" interfacename="base" />
+      </multiply>
+      <multiply name="specular_colorToSpecularColor" type="color3">
+         <input name="in1" type="color3" interfacename="specular_color" />
+         <input name="in2" type="float" interfacename="specular" />
+      </multiply>
+
+      <!-- Pass through -->
+      <multiply name="metalnessTometalness" type="float">
+         <input name="in1" type="float" interfacename="metalness" />
+         <input name="in2" type="float" value="1.0" />
+      </multiply>
+      <multiply name="specular_roughnessToroughness" type="float">
+         <input name="in1" type="float" interfacename="specular_roughness" />
+         <input name="in2" type="float" value="1.0" />
+      </multiply>
+      <multiply name="specular_IORToior" type="float">
+         <input name="in1" type="float" interfacename="specular_IOR" />
+         <input name="in2" type="float" value="1.0" />
+      </multiply>
+
+      <!-- Outputs -->
+      <output name="diffuseColor_out" type="color3" nodename="base_colorToDiffuseColor" />
+      <output name="specularColor_out" type="color3" nodename="specular_colorToSpecularColor" />
+      <output name="roughness_out" type="float" nodename="specular_roughnessToroughness" />
+
+      <output name="metalness_out" type="float" nodename="metalnessTometalness" />
+      <output name="ior_out" type="float" nodename="specular_IORToior" />
+
+   </nodegraph>
 </materialx>

--- a/source/MaterialXCore/MaterialNode.cpp
+++ b/source/MaterialXCore/MaterialNode.cpp
@@ -293,9 +293,9 @@ vector<OutputPtr> getConnectedOutputs(const NodePtr& node)
 {
     vector<OutputPtr> outputVec;
     std::set<OutputPtr> outputSet;
-    for (InputPtr bindInput : node->getInputs())
+    for (InputPtr input : node->getInputs())
     {
-        OutputPtr output = bindInput->getConnectedOutput();
+        OutputPtr output = input->getConnectedOutput();
         if (output && !outputSet.count(output))
         {
             outputVec.push_back(output);

--- a/source/MaterialXCore/MaterialNode.h
+++ b/source/MaterialXCore/MaterialNode.h
@@ -46,7 +46,7 @@ std::unordered_set<NodePtr> getShaderNodes(const NodePtr& materialNode,
 vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const string& geom);
 
 
-/// Return a vector of all outputs that this element references.
+/// Return a vector of all outputs that this nodes inputs are connected to.
 vector<OutputPtr> getConnectedOutputs(const NodePtr& node);
 
 } // namespace MaterialX

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -171,6 +171,13 @@ void TextureBaker::optimizeBakedTextures(NodePtr shader)
         return;
     }
 
+    // Early exist if not optimizing
+    if (!_optimizeConstants)
+    {
+        _bakedConstantMap.clear();
+        return;
+    }
+
     // If the graph used to create the texture has any of the following attributes
     // then it's value has changed from the original, and even if the image is a constant
     // it must not be optmized away.
@@ -379,9 +386,11 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
         }
     }
 
-    // Clear image cache
+    // Clear cached information after each material bake
     _bakedImageMap.clear();
     _bakedConstantMap.clear();
+    _worldSpaceShaderInputs.clear();
+    _material = nullptr;
 
     if (bakingSuccessful)
         return bakedTextureDoc;
@@ -450,6 +459,9 @@ ListofBakedDocuments TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileS
         // Iterate over material tags.
         for (const string& tag : materialTags)
         {
+            // Always clear any cached implementations before generation.
+            genContext.clearNodeImplementations();
+
             ShaderPtr hwShader = createShader("Shader", genContext, shaderNode);
             if (!hwShader)
             {

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -210,25 +210,40 @@ TEST_CASE("GenShader: OSL Reference Implementation Check", "[genshader]")
 
 TEST_CASE("GenShader: Shader Translation", "[translate]")
 {
-    mx::DocumentPtr doc = mx::createDocument();
     mx::FileSearchPath searchPath;
     searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    loadLibraries({ "stdlib", "pbrlin", "bxdf", "translation" }, searchPath, doc);
-    const mx::FilePath mtlxFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface/standard_surface_wood_tiled.mtlx");
-    mx::readFromXmlFile(doc, mtlxFile, searchPath);
-    mx::writeToXmlFile(doc, "standard_surface_wood_tiled_untranslated.mtlx");
 
     mx::ShaderTranslatorPtr shaderTranslator = mx::ShaderTranslator::create();
-    shaderTranslator->translateAllMaterials(doc, "UsdPreviewSurface");
 
-    std::string validationErrors;
-    bool valid = doc->validate(&validationErrors);
-    if (!valid)
+    const std::string USD_PREVIEW_SURFACE_NAME("UsdPreviewSurface");
+
+    mx::FilePath testPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    for (mx::FilePath& mtlxFile : testPath.getFilesInDirectory("mtlx"))
     {
-        std::cout << validationErrors << std::endl;
-    }
-    REQUIRE(valid);
+        mx::DocumentPtr doc = mx::createDocument();
+        mx::StringSet libFiles = loadLibraries({ "stdlib", "pbrlin", "bxdf", "translation" }, searchPath, doc);
 
-    mx::writeToXmlFile(doc, "standard_surface_wood_tiled_translated.mtlx");
+        mx::readFromXmlFile(doc, testPath / mtlxFile, searchPath);
+        mtlxFile.removeExtension();
+        mx::writeToXmlFile(doc, mtlxFile.asString() + "_untranslated.mtlx");
+
+        try {
+            shaderTranslator->translateAllMaterials(doc, USD_PREVIEW_SURFACE_NAME);
+        }
+        catch (mx::Exception &e)
+        {
+            std::cout << "Failed translating: " << (testPath / mtlxFile).asString() << ": " << e.what() << std::endl;
+        }
+
+        mx::writeToXmlFile(doc, mtlxFile.asString() + "_translated.mtlx");
+        std::string validationErrors;
+        bool valid = doc->validate(&validationErrors);
+        std::cout << "SHader translation of : " << (testPath / mtlxFile).asString() << (valid ?  ": passed"  : ": falied") << std::endl;
+        if (!valid)
+        {
+            std::cout << "Validation errors: " << validationErrors << std::endl;
+        }
+        CHECK(valid);
+    }
 }
 


### PR DESCRIPTION
Update #921 
- Minor patches to re-initialize cached state after each material/shader baked or translated.
- Update translate test to perform multiple translates. Bake test already performs multiple bakes per document.
- Fix "optimize" constants to skip any prep work for optimization to not leave state cached image state incorrect if turned off.
