### PR TITLE
Category changing utility + TextureBaker fixes.

### DIFF
--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/mapped_surfaceshader.mtlx
@@ -1,91 +1,120 @@
 <?xml version="1.0"?>
 <materialx version="1.37">
-   <standard_surface name="MappedShader" type="surfaceshader" >
+
+   <!-- Basic color mapped test -->
+   <nodegraph name="RedRamp" xpos="315" ypos="1129">
+      <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
+         <input name="valuetl" type="color3" uniform="true" value="1, 0, 0" />
+         <input name="valuetr" type="color3" uniform="true" value="0.1, 0, 0" />
+         <input name="valuebl" type="color3" uniform="true" value="1, 0, 0" />
+         <input name="valuebr" type="color3" uniform="true" value="0.1, 0, 0" />
+      </ramp4>
+      <output name="out" type="color3" nodename="ramp4" />
+   </nodegraph>
+   <nodegraph name="GreenRamp" xpos="315" ypos="1348">
+      <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
+         <input name="valuetl" type="color3" uniform="true" value="0, 1, 0" />
+         <input name="valuetr" type="color3" uniform="true" value="0, 0.1, 0" />
+         <input name="valuebl" type="color3" uniform="true" value="0, 1, 0" />
+         <input name="valuebr" type="color3" uniform="true" value="0, 0.1, 0" />
+      </ramp4>
+      <output name="out" type="color3" nodename="ramp4" />
+   </nodegraph>
+   <standard_surface name="MappedShader" type="surfaceshader" version="1.0.1">
       <input name="base" type="float" value="1" />
       <input name="base_color" type="color3" nodegraph="RedRamp" />
-      <input name="metalness" type="float" value="1" />
+      <input name="metalness" type="float" value="0.333" />
       <input name="specular" type="float" value="0" />
       <input name="specular_color" type="color3" nodegraph="GreenRamp" />
-      <input name="specular_roughness" type="float" nodegraph="UnitGraph" />
       <input name="coat" type="float" value="1" />
    </standard_surface>
-   <standard_surface name="MappedShader2" type="surfaceshader" >
-      <input name="base" type="float" value="1" />
-      <input name="base_color" type="color3" nodegraph="YellowRamp" />
-      <input name="metalness" type="float" value="0" />
-      <input name="specular" type="float" value="1" />
-      <input name="specular_color" type="color3" nodegraph="BlueRamp" />
-      <input name="specular_roughness" type="float" nodegraph="UnitGraph" />
-      <input name="coat" type="float" value="0" />
-   </standard_surface>
-   <nodegraph name="RedRamp">
-      <ramp4 name="ramp4" type="color3" >
-         <input name="valuetl" type="color3" value="1, 0, 0" />
-         <input name="valuetr" type="color3" value="0, 0, 0" />
-         <input name="valuebl" type="color3" value="1, 0, 0" />
-         <input name="valuebr" type="color3" value="0, 0, 0" />
-      </ramp4>
-      <output name="out" type="color3" nodename="ramp4" />
-   </nodegraph>
-   <nodegraph name="GreenRamp">
-      <ramp4 name="ramp4" type="color3" >
-         <input name="valuetl" type="color3" value="0, 1, 0" />
-         <input name="valuetr" type="color3" value="0, 0, 0" />
-         <input name="valuebl" type="color3" value="0, 1, 0" />
-         <input name="valuebr" type="color3" value="0, 0, 0" />
-      </ramp4>
-      <output name="out" type="color3" nodename="ramp4" />
-   </nodegraph>
-   <nodegraph name="BlueRamp">
-      <ramp4 name="ramp4" type="color3" >
-         <input name="valuetl" type="color3" value="0, 0, 1" />
-         <input name="valuetr" type="color3" value="0, 0, 0" />
-         <input name="valuebl" type="color3" value="0, 0, 1" />
-         <input name="valuebr" type="color3" value="0, 0, 0" />
-      </ramp4>
-      <output name="out" type="color3" nodename="ramp4" />
-   </nodegraph>
-   <nodegraph name="YellowRamp">
-      <ramp4 name="ramp4" type="color3" >
-         <input name="valuetl" type="color3" value="1, 1, 0" />
-         <input name="valuetr" type="color3" value="0, 0, 0" />
-         <input name="valuebl" type="color3" value="1, 1, 0" />
-         <input name="valuebr" type="color3" value="0, 0, 0" />
-      </ramp4>
-      <output name="out" type="color3" nodename="ramp4" />
-   </nodegraph>
-   <nodegraph name="UnitGraph">
-      <constant name="realscale" type="float">
-         <parameter name="value" type="float" value="100" unit="centimeter" unittype="distance" />
-      </constant>
-      <output name="out" type="float" nodename="realscale" />
-   </nodegraph>
-   <surfacematerial name="MappedShaderMaterial" type="material" >
+   <surfacematerial name="MappedShaderMaterial" type="material" xpos="925" ypos="1098">
       <input name="surfaceshader" type="surfaceshader" nodename="MappedShader" />
       <input name="displacementshader" type="displacementshader" value="" />
    </surfacematerial>
-   <surfacematerial name="MappedShaderMaterial2" type="material" >
-      <input name="surfaceshader" type="surfaceshader" nodename="MappedShader2" />
+
+   <!-- real world units test -->
+   <nodegraph name="UnitGraph" xpos="336.442" ypos="884.044">
+      <tiledimage name="tiledimage" type="float" xpos="-47" ypos="-72">
+         <input name="file" type="filename" uniform="true" value="resources/Images/grid.png" />
+         <input name="realworldimagesize" type="vector2" value="1, 1" />
+         <input name="realworldtilesize" type="vector2" value="100, 50" unit="centimeter" unittype="distance" />
+         <input name="default" type="float" value="0.0" uniform="true" />
+         <input name="uvtiling" type="vector2" value="2, 3" />
+         <input name="uvoffset" type="vector2" value="0.2, 0.2" />
+      </tiledimage>
+      <output name="out" type="float" nodename="tiledimage" />
+   </nodegraph>
+   <nodegraph name="BlueRamp" xpos="315" ypos="657.618">
+      <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-61">
+         <input name="valuetl" type="color3" uniform="true" value="0, 0, 1" />
+         <input name="valuetr" type="color3" uniform="true" value="0, 0, 0.1" />
+         <input name="valuebl" type="color3" uniform="true" value="0, 0, 1" />
+         <input name="valuebr" type="color3" uniform="true" value="0, 0, 0.1" />
+      </ramp4>
+      <output name="out" type="color3" nodename="ramp4" />
+   </nodegraph>
+   <nodegraph name="YellowRamp" xpos="315" ypos="438.871">
+      <ramp4 name="ramp4" type="color3" xpos="-79" ypos="-60">
+         <input name="valuetl" type="color3" uniform="true" value="1, 1, 0" />
+         <input name="valuetr" type="color3" uniform="true" value="0, 0, 0" />
+         <input name="valuebl" type="color3" uniform="true" value="1, 1, 0" />
+         <input name="valuebr" type="color3" value="1, 1, 1" uniform="true" />
+      </ramp4>
+      <output name="out" type="color3" nodename="ramp4" />
+   </nodegraph>
+   <standard_surface name="UnitMappedShader" type="surfaceshader" version="1.0.1">
+      <input name="base" type="float" nodegraph="UnitGraph" />
+      <input name="base_color" type="color3" nodegraph="YellowRamp" />
+      <input name="metalness" type="float" value="0.1" />
+      <input name="specular" type="float" value="1" />
+      <input name="specular_color" type="color3" nodegraph="BlueRamp" />
+   </standard_surface>
+   <surfacematerial name="UnitMappedShaderMaterial" type="material" xpos="925" ypos="494">
+      <input name="surfaceshader" type="surfaceshader" nodename="UnitMappedShader" />
       <input name="displacementshader" type="displacementshader" value="" />
    </surfacematerial>
 
-   <nodegraph name="ColorSpaceGraph">
-      <constant name="color_gamma22" type="color4">
-         <parameter name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma22" />
+   <!-- color space test -->
+   <nodegraph name="ColorSpaceGraph" xpos="10" ypos="82">
+      <constant name="color_gamma22" type="color3">
+         <input name="value" type="color3" uniform="true" value="0.5, 0, 0" colorspace="gamma22" />
       </constant>
-      <output name="out" type="color4" nodename="color_gamma22" />
+      <output name="out" type="color3" nodename="color_gamma22" />
    </nodegraph>
-   <standard_surface name="ColorSpaceShader" type="surfaceshader" >
+   <standard_surface name="ColorSpaceShader" type="surfaceshader" version="1.0.1">
       <input name="base" type="float" value="0.5" />
-      <input name="base_color" type="color3" nodegraph="ColorSpaceGraph" channels="rgb"/>
+      <input name="base_color" type="color3" nodegraph="ColorSpaceGraph" />
       <input name="metalness" type="float" value="0" />
       <input name="specular" type="float" value="1" />
-      <input name="specular_color" type="color3" value="0.2,0.6,0.8" colorspace="g22_ap1"/>
+      <input name="specular_color" type="color3" value="0.2, 0.6, 0.8" colorspace="g22_ap1" />
       <input name="specular_roughness" type="float" value="0.2" />
       <input name="coat" type="float" value="0" />
    </standard_surface>
-   <surfacematerial name="ColorSpaceShaderMaterial" type="material" >
+   <surfacematerial name="ColorSpaceShaderMaterial" type="material">
       <input name="surfaceshader" type="surfaceshader" nodename="ColorSpaceShader" />
       <input name="displacementshader" type="displacementshader" value="" />
    </surfacematerial>
+
+   <!-- normal map test -->
+   <standard_surface name="NormalMapShader" type="surfaceshader" version="1.0.1" xpos="-29.5" ypos="-184">
+      <input name="base_color" type="color3" value="0.2, 0.5, 0.9"  />
+      <input name="normal" type="vector3" nodegraph="Compound"  />
+   </standard_surface>
+   <surfacematerial name="NormalMapMaterial" type="material" xpos="160" ypos="-269">
+      <input name="surfaceshader" type="surfaceshader" nodename="NormalMapShader"  />
+      <input name="displacementshader" type="displacementshader" value=""  />
+   </surfacematerial>
+   <nodegraph name="Compound" xpos="-351.5" ypos="-41" >
+      <input name="file" type="filename" uniform="true" value="" />
+      <normalmap name="normalmap" type="vector3" xpos="20" ypos="-95">
+         <input name="in" type="vector3" nodename="tiledimage"  />
+      </normalmap>
+      <tiledimage name="tiledimage" type="vector3" xpos="-218.5" ypos="-107.905">
+         <input name="file" type="filename" uniform="true" value="resources/Images/mesh_wire_norm.png"  />
+         <input name="uvtiling" type="vector2" value="10, 10"  />
+      </tiledimage>
+      <output name="out" type="vector3" nodename="normalmap" />
+   </nodegraph>
+
 </materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -21,17 +21,6 @@ namespace {
 const string DOCUMENT_VERSION_STRING = std::to_string(MATERIALX_MAJOR_VERSION) + "." +
                                        std::to_string(MATERIALX_MINOR_VERSION);
 
-template<class T> shared_ptr<T> updateChildSubclass(ElementPtr parent, ElementPtr origChild)
-{
-    string childName = origChild->getName();
-    int childIndex = parent->getChildIndex(childName);
-    parent->removeChild(childName);
-    shared_ptr<T> newChild = parent->addChild<T>(childName);
-    parent->setChildIndex(childName, childIndex);
-    newChild->copyContentFrom(origChild);
-    return newChild;
-}
-
 } // anonymous namespace
 
 //
@@ -351,7 +340,7 @@ bool Document::convertParametersToInputs()
         {
             if (child->getCategory() == PARAMETER_CATEGORY_STRING)
             {
-                InputPtr newInput = updateChildSubclass<Input>(elem, child);
+                InputPtr newInput = changeChildCategory(elem, child, Input::CATEGORY)->asA<Input>();
                 if (uniformTypes.count(child->getAttribute(TypedElement::TYPE_ATTRIBUTE)))
                 {
                     newInput->setIsUniform(true);
@@ -387,7 +376,7 @@ bool Document::convertUniformInputsToParameters()
             InputPtr input = child->asA<Input>();
             if (input && input->getIsUniform())
             {
-                ParameterPtr newParameter = updateChildSubclass<Parameter>(elem, child);
+                ParameterPtr newParameter = changeChildCategory(elem, child, Parameter::CATEGORY)->asA<Parameter>();
                 newParameter->removeAttribute(ValueElement::UNIFORM_ATTRIBUTE);
                 anyConverted = true;
             }
@@ -440,7 +429,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
             {
                 if (child->getCategory() == "assign")
                 {
-                    updateChildSubclass<MaterialAssign>(elem, child);
+                    changeChildCategory(elem, child, MaterialAssign::CATEGORY);
                 }
             }
         }
@@ -489,11 +478,11 @@ void Document::upgradeVersion(bool applyFutureUpdates)
             {
                 if (child->getCategory() == "opgraph")
                 {
-                    updateChildSubclass<NodeGraph>(elem, child);
+                    changeChildCategory(elem, child, NodeGraph::CATEGORY);
                 }
                 else if (child->getCategory() == "shader")
                 {
-                    NodeDefPtr nodeDef = updateChildSubclass<NodeDef>(elem, child);
+                    NodeDefPtr nodeDef = changeChildCategory(elem, child, NodeDef::CATEGORY)->asA<NodeDef>();
                     if (nodeDef->hasAttribute("shadertype"))
                     {
                         nodeDef->setType(SURFACE_SHADER_TYPE_STRING);
@@ -520,7 +509,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
                     {
                         if (elem->isA<Node>())
                         {
-                            InputPtr input = updateChildSubclass<Input>(elem, param);
+                            InputPtr input = changeChildCategory(elem, param, Input::CATEGORY)->asA<Input>();
                             input->setNodeName(input->getAttribute("value"));
                             input->removeAttribute("value");
                             if (input->getConnectedNode())
@@ -595,7 +584,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
             {
                 if (child->getCategory() == "geomattr")
                 {
-                    updateChildSubclass<GeomProp>(geomInfo, child);
+                    changeChildCategory(geomInfo, child, GeomProp::CATEGORY);
                 }
             }
         }
@@ -768,7 +757,7 @@ void Document::upgradeVersion(bool applyFutureUpdates)
             {
                 if (child->getCategory() == "geomattr")
                 {
-                    updateChildSubclass<GeomProp>(geomInfo, child);
+                    changeChildCategory(geomInfo, child, GeomProp::CATEGORY);
                 }
             }
         }

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -126,6 +126,17 @@ bool stringEndsWith(const string& str, const string& suffix)
     return false;
 }
 
+string trimSpaces(const string& str)
+{
+    const string SPACE(" ");
+
+    size_t start = str.find_first_not_of(SPACE);
+    string result = (start == std::string::npos) ? EMPTY_STRING : str.substr(start);
+    size_t end = result.find_last_not_of(SPACE);
+    result = (end == std::string::npos) ? EMPTY_STRING : result.substr(0, end + 1);
+    return result;
+}
+
 StringVec splitNamePath(const string& namePath)
 {
     StringVec nameVec = splitString(namePath, NAME_PATH_SEPARATOR);

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -3,9 +3,9 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
-#include <MaterialXCore/Types.h>
-
 #include <cctype>
+#include <MaterialXCore/Types.h>
+#include <MaterialXCore/Element.h>
 
 namespace MaterialX
 {
@@ -151,6 +151,17 @@ string parentNamePath(const string& namePath)
         return createNamePath(nameVec);
     }
     return EMPTY_STRING;
+}
+
+ElementPtr changeChildCategory(ElementPtr parent, ElementPtr origChild, const string& category)
+{
+    string childName = origChild->getName();
+    int childIndex = parent->getChildIndex(childName);
+    parent->removeChild(childName);
+    ElementPtr newChild = parent->addChildOfCategory(category, childName);
+    parent->setChildIndex(childName, childIndex);
+    newChild->copyContentFrom(origChild);
+    return newChild;
 }
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -14,6 +14,9 @@
 namespace MaterialX
 {
 
+class Element;
+using ElementPtr = shared_ptr<Element>;
+
 extern const string EMPTY_STRING;
 
 /// Return the version of the MaterialX library as a string.
@@ -59,6 +62,9 @@ string createNamePath(const StringVec& nameVec);
 
 /// Given a name path, return the parent name path
 string parentNamePath(const string& namePath);
+
+/// Change the category of a child element
+ElementPtr changeChildCategory(ElementPtr parent, ElementPtr origChild, const string& category);
 
 } // namespace MaterialX
 

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -48,6 +48,9 @@ string stringToLower(string str);
 /// Return true if the given string ends with the given suffix.
 bool stringEndsWith(const string& str, const string& suffix);
 
+/// Trim leading an trailing spaces from a string
+string trimSpaces(const string& str);
+
 /// Combine the hash of a value with an existing seed.
 template<typename T> void hashCombine(size_t& seed, const T& value)
 {

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -434,6 +434,10 @@ bool GlslSyntax::remapEnumeration(const string& value, const TypeDesc* type, con
     if (!value.empty())
     {
         StringVec valueElemEnumsVec = splitString(enumNames, ",");
+        for (size_t i=0; i<valueElemEnumsVec.size(); i++)
+        {
+            valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
+        }
         auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
         if (pos == valueElemEnumsVec.end())
         {

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -596,6 +596,10 @@ bool MdlSyntax::remapEnumeration(const string& value, const TypeDesc* type, cons
         }
 
         StringVec valueElemEnumsVec = splitString(enumNames, ",");
+        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
+        {
+            valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
+        }
         auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
         if (pos == valueElemEnumsVec.end())
         {

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -990,7 +990,7 @@ void getUdimScaleAndOffset(const vector<Vector2>& udimCoordinates, Vector2& scal
 NodePtr connectsToNodeOfCategory(OutputPtr output, const StringSet& categories)
 {
     ElementPtr connectedElement = output ? output->getConnectedNode() : nullptr;
-    NodePtr connectedNode = connectedElement->asA<Node>();
+    NodePtr connectedNode = connectedElement ? connectedElement->asA<Node>() : nullptr;
     if (!connectedNode)
     {
         return nullptr;

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -401,7 +401,7 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
 
 ListofBakedDocuments TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& imageSearchPath)
 {
-    GenContext genContext = GlslShaderGenerator::create();
+    GenContext genContext(_generator);
     genContext.getOptions().hwSpecularEnvironmentMethod = SPECULAR_ENVIRONMENT_FIS;
     genContext.getOptions().hwDirectionalAlbedoMethod = DIRECTIONAL_ALBEDO_TABLE;
     genContext.getOptions().hwShadowMap = true;

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -61,6 +61,7 @@ string getValueStringFromColor(const Color4& color, const string& type)
 TextureBaker::TextureBaker(unsigned int width, unsigned int height, Image::BaseType baseType) :
     GlslRenderer(width, height, baseType),
     _targetUnitSpace("meter"),
+    _targetColorSpace(LIN_REC709),
     _bakedGraphName("NG_baked"),
     _bakedGeomInfoName("GI_baked"),
     _averageImages(false),
@@ -100,6 +101,7 @@ FilePath TextureBaker::generateTextureFilename(OutputPtr output, const string& s
 void TextureBaker::bakeShaderInputs(NodePtr material, NodePtr shader, GenContext& context, const string& udim)
 {
     _material = material;
+    _targetColorSpace = context.getOptions().targetColorSpaceOverride;
     
     if (!shader)
     {
@@ -310,6 +312,10 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
             bakedInput = bakedShader->addInput(sourceName, sourceType, sourceInput->getIsUniform());
         }
 
+        // Check for non-image inputs whether to keep in target color space
+        bool wantLinearInput = (_colorSpace != _targetColorSpace &&
+            (bakedInput->getType() == "color3" || bakedInput->getType() == "color4"));
+
         OutputPtr output = sourceInput->getConnectedOutput();
         if (output)
         {
@@ -325,6 +331,10 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
                 Color4 uniformColor = _bakedConstantMap[output].color;
                 string uniformColorString = getValueStringFromColor(uniformColor, bakedInput->getType());
                 bakedInput->setValueString(uniformColorString);
+                if (wantLinearInput)
+                {
+                    bakedInput->setColorSpace(_targetColorSpace);
+                }
             }
             else
             {
@@ -361,6 +371,10 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
         else
         {
             bakedInput->copyContentFrom(sourceInput);
+            if (wantLinearInput && bakedInput->getColorSpace() == EMPTY_STRING)
+            {
+                bakedInput->setColorSpace(_targetColorSpace);
+            }
         }
     }
 
@@ -405,7 +419,7 @@ ListofBakedDocuments TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileS
     genContext.getOptions().hwSpecularEnvironmentMethod = SPECULAR_ENVIRONMENT_FIS;
     genContext.getOptions().hwDirectionalAlbedoMethod = DIRECTIONAL_ALBEDO_TABLE;
     genContext.getOptions().hwShadowMap = true;
-    genContext.getOptions().targetColorSpaceOverride = LIN_REC709;
+    genContext.getOptions().targetColorSpaceOverride = _targetColorSpace;
     genContext.getOptions().fileTextureVerticalFlip = true;
     genContext.getOptions().targetDistanceUnit = _targetUnitSpace;
 

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -189,6 +189,7 @@ class TextureBaker : public GlslRenderer
     string _extension;
     string _colorSpace;
     string _targetUnitSpace;
+    string _targetColorSpace;
     string _bakedGraphName;
     string _bakedGeomInfoName;
     bool _averageImages;


### PR DESCRIPTION
Update #974 
- Separate out utility to change the category of a child element to Core Util: 
  - ElementPtr changeChildCategory(ElementPtr parent, ElementPtr origChild, const string& category);
- Fix TextureBaker::bakeAllMaterials() to use the generator created at class initialization as unit system setup is done on that generator.
- Fix enum parsing during shader generation. Was not handling cases where there were any spaces between comma separated lists. e.g. ("tangent, object") would not parse "object" as a valid enum.
