### PR TITLE
Updates to TextureBaker

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -117,12 +117,6 @@ void TextureBaker::bakeShaderInputs(NodePtr material, NodePtr shader, GenContext
         OutputPtr output = input->getConnectedOutput();
         if (output && !bakedOutputs.count(output))
         {
-            ElementPtr outputNode = output->getParent();
-            if (outputNode && outputNode->isA<NodeGraph>())
-            {
-                NodeGraphPtr outputGraph = outputNode->asA<NodeGraph>();
-            }
-
             bakedOutputs.insert(output);
             NodePtr normalMapNode = connectsToNodeOfCategory(output, categories);
             if (normalMapNode)

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -121,7 +121,6 @@ void TextureBaker::bakeShaderInputs(NodePtr material, NodePtr shader, GenContext
             if (outputNode && outputNode->isA<NodeGraph>())
             {
                 NodeGraphPtr outputGraph = outputNode->asA<NodeGraph>();
-                outputGraph->flattenSubgraphs();
             }
 
             bakedOutputs.insert(output);
@@ -386,16 +385,18 @@ DocumentPtr TextureBaker::getBakedMaterial(NodePtr shader, const StringVec& udim
         {
             continue;
         }
+
+        _bakingReport.clear();
         for (const BakedImage& baked : pair.second)
         {
             if (!_imageHandler->saveImage(baked.filename, baked.image, true))
             {
                 bakingSuccessful = false;
-                std::cerr << "Failed to write baked image: " << baked.filename.asString() << std::endl;
+                _bakingReport << "Failed to write baked image: " << baked.filename.asString() << std::endl;
             }
             else
             {
-                std::cout << "Write baked image:" << baked.filename.asString() << std::endl;
+                _bakingReport << "Write baked image:" << baked.filename.asString() << std::endl;
             }
         }
     }

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -142,7 +142,7 @@ class TextureBaker : public GlslRenderer
         return _outputImagePath;
     }
 
-    const string& getBakingReport() const
+    string getBakingReport() const
     {
          return (_bakingReport.str());
     }

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -142,6 +142,11 @@ class TextureBaker : public GlslRenderer
         return _outputImagePath;
     }
 
+    const string& getBakingReport() const
+    {
+         return (_bakingReport.str());
+    }
+
     /// Bake textures for all graph inputs of the given shader.
     void bakeShaderInputs(NodePtr material, NodePtr shader, GenContext& context, const string& udim = EMPTY_STRING);
 
@@ -195,6 +200,7 @@ class TextureBaker : public GlslRenderer
     bool _averageImages;
     bool _optimizeConstants;
     FilePath _outputImagePath;
+    std::stringstream _bakingReport;
 
     ShaderGeneratorPtr _generator;
     ConstNodePtr _material;

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -223,7 +223,7 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
     for (mx::FilePath& mtlxFile : testPath.getFilesInDirectory("mtlx"))
     {
         mx::DocumentPtr doc = mx::createDocument();
-        mx::StringSet libFiles = loadLibraries({ "stdlib", "pbrlin", "bxdf", "translation" }, searchPath, doc);
+        mx::StringSet libFiles = loadLibraries({ "stdlib", "pbrlib", "bxdf", "translation" }, searchPath, doc);
 
         mx::readFromXmlFile(doc, testPath / mtlxFile, searchPath);
         mtlxFile.removeExtension();
@@ -240,7 +240,7 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
         mx::writeToXmlFile(doc, mtlxFile.asString() + "_translated.mtlx");
         std::string validationErrors;
         bool valid = doc->validate(&validationErrors);
-        std::cout << "SHader translation of : " << (testPath / mtlxFile).asString() << (valid ?  ": passed"  : ": falied") << std::endl;
+        std::cout << "SHader translation of : " << (testPath / mtlxFile).asString() << (valid ?  ": passed"  : ": failed") << std::endl;
         if (!valid)
         {
             std::cout << "Validation errors: " << validationErrors << std::endl;


### PR DESCRIPTION
Disable Graphflatten as part of BakeShaderInputs since this corrupts the nodes that are dot connected.
Add a simple stringstream to capture baking log instead of writing to std::cerr, std::cout
