### PR TITLE
Add setCodeSearchPath to Baker Configuration

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -420,7 +420,10 @@ ListofBakedDocuments TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileS
 
     DefaultColorManagementSystemPtr cms = DefaultColorManagementSystem::create(genContext.getShaderGenerator().getLanguage());
     cms->loadLibrary(doc);
-    genContext.registerSourceCodeSearchPath(getDefaultSearchPath());
+    if (_codeSearchPath.isEmpty())
+        genContext.registerSourceCodeSearchPath(getDefaultSearchPath());
+    else
+        genContext.registerSourceCodeSearchPath(_codeSearchPath);
     genContext.getShaderGenerator().setColorManagementSystem(cms);
     StringResolverPtr resolver = StringResolver::create();
     ImageHandlerPtr imageHandler = GLTextureHandler::create(StbImageLoader::create());

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -142,6 +142,13 @@ class TextureBaker : public GlslRenderer
         return _outputImagePath;
     }
 
+
+    /// Set the "libraries" search path location. Otherwise will use getDefaultSearchPath()
+    void setCodeSearchPath(const FileSearchPath& codesearchPath)
+    {
+        _codeSearchPath = codesearchPath;
+    }
+
     string getBakingReport() const
     {
          return (_bakingReport.str());
@@ -200,6 +207,7 @@ class TextureBaker : public GlslRenderer
     bool _averageImages;
     bool _optimizeConstants;
     FilePath _outputImagePath;
+    FileSearchPath _codeSearchPath;
     std::stringstream _bakingReport;
 
     ShaderGeneratorPtr _generator;


### PR DESCRIPTION
The baker by default uses the Code Search path based on the Installed. 
Add an API to allow this to be configurable.