### PR TITLE
LOOKDEVX-374 : Targetdef update for contrib plugin

### DIFF
--- a/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
@@ -156,7 +156,7 @@ void Plugin::loadLibraries()
     }
 
     std::unordered_set<std::string> uniqueLibraryNames{
-        "targets", "adsklib", "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
+        "targets", "adsk", "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
     };
 
     {

--- a/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
+++ b/source/MaterialXContrib/MaterialXMaya/Plugin.cpp
@@ -148,15 +148,15 @@ void Plugin::loadLibraries()
 
     {
         SearchPathBuilder builder(_librarySearchPath);
-        builder.append(_pluginLoadPath);
         builder.append(_pluginLoadPath / mx::FilePath("../libraries"));
         builder.append(_pluginLoadPath / mx::FilePath("../../libraries"));
+        builder.append(_pluginLoadPath);
 
         builder.appendFromOptionVar("materialXLibrarySearchPaths");
     }
 
     std::unordered_set<std::string> uniqueLibraryNames{
-        "adsklib", "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
+        "targets", "adsklib", "stdlib", "pbrlib", "bxdf", "stdlib/genglsl", "pbrlib/genglsl", "lights", "lights/genglsl"
     };
 
     {


### PR DESCRIPTION
Update #1044 

- Add "targets" to contrib plugin so targetdefs are found.
- Also add in "adsk" so this library is found.
- Fix up texture path searching to resolve filenames properly and also look for default names from the nodedef if 
not specified on the node itself.
- All nodes in adsk_shaders.mtlx test file load and render correctly:
https://github.com/autodesk-forks/MaterialX/blob/adsk_contrib/dev/resources/Materials/TestSuite/adsklib/adsk_shaders.mtlx

Sample using "adsk" color correct as a texture node:
![image](https://user-images.githubusercontent.com/14275104/101811024-85b4b100-3ae7-11eb-8bdf-e9f717ca053a.png)

Sample using "adsk" shaders which require nodedef textures. 4 Maya shaders and 1 Maya texture (connected to to a Maya Phong)
![image](https://user-images.githubusercontent.com/14275104/101830864-2795c700-3b03-11eb-9b22-5293b34042b7.png)
