### PR TITLE
Update drawScreenSpaceQuad to accept optional Attibute id

### DIFF
--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -102,8 +102,8 @@ class GlslRenderer : public ShaderRenderer
         return _program;
     }
 
-    /// Submit geometry for a screen-space quad.
-    static void drawScreenSpaceQuad();
+    /// Submit geometry for a screen-space quad. assumes shader expects postion attribute at 0, texture attribute at 1
+    static void drawScreenSpaceQuad(unsigned int position_attrib = 0, unsigned int texture_attrib = 1);
 
     /// Sets the clear color
     void setClearColor(const Color4& clearColor);

--- a/source/MaterialXRenderHw/SimpleWindow.h
+++ b/source/MaterialXRenderHw/SimpleWindow.h
@@ -48,6 +48,12 @@ class SimpleWindow
         return _height;
     }
 
+    /// DPI Scaling
+    float scaleFactor() const
+    {
+        return _scaleFactor;
+    }
+    
     /// Check for validity
     bool isValid() const
     {
@@ -69,11 +75,12 @@ class SimpleWindow
     WindowWrapperPtr _windowWrapper;
 
     // Window dimensions
-    unsigned int _width;
-    unsigned int _height;
-
+    unsigned int _width = 0;
+    unsigned int _height = 0;
+    /// scalefactor of the window
+    float _scaleFactor = 1.0f;
     // Unique window identifier generated dynamically at creation time.
-    unsigned int _id;
+    unsigned int _id = 0;
 
 #if defined(_WIN32)
     // Window class name for window generated at creation time.

--- a/source/MaterialXRenderHw/WindowCocoaWrappers.h
+++ b/source/MaterialXRenderHw/WindowCocoaWrappers.h
@@ -19,6 +19,7 @@ void NSUtilShowWindow(void* pWindow);
 void NSUtilHideWindow(void* pWindow);
 void NSUtilSetFocus(void* pWindow);
 void NSUtilDisposeWindow(void* pWindow);
+float NSUtilGetScaleFactor(void* pWindow);
 
 #ifdef __cplusplus
 }

--- a/source/MaterialXRenderHw/WindowCocoaWrappers.m
+++ b/source/MaterialXRenderHw/WindowCocoaWrappers.m
@@ -71,4 +71,11 @@ void NSUtilDisposeWindow(void* pWindow)
 	[pool release];
 }
 
+float NSUtilGetScaleFactor(void* pWindow)
+{
+    NSWindow* window = (NSWindow*)pWindow;
+    float scalefactor = [window backingScaleFactor];
+    return scalefactor;
+}
+
 #endif


### PR DESCRIPTION
The drawScreenSpaceQuad assumes
i_position at 0 and i_texcoord_0 at 1

But on macOS/GL Core Profile the locations are different.
e.g: i_position 1 and i_texcoord_0 0

This change queries the program for the input location.

Additonal changes include a helper in SimpleWindow to query scale factor for HDPI
(not currently used at the moment)