### PR TITLE
Make v1.38 upgrade path only mark filename and string parameters as uniforms.

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1101,9 +1101,10 @@ void Document::upgradeVersion()
                     {
                         // Only strings and filename types should be set as uniforms.
                         const string& inputType = input->getType();
-                        bool isUniform = (inputType != FILENAME_TYPE_STRING &&
-                                          inputType != STRING_TYPE_STRING);
-                        input->setIsUniform(isUniform);
+                        if (inputType == FILENAME_TYPE_STRING || inputType == STRING_TYPE_STRING)
+                        {
+                            input->setIsUniform(true);
+                        }
                     }
                 }
             }

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1099,7 +1099,11 @@ void Document::upgradeVersion()
                     InputPtr input = updateChildSubclass<Input>(interface, param);
                     if (interface->isA<NodeDef>())
                     {
-                        input->setIsUniform(true);
+                        // Only strings and filename types should be set as uniforms.
+                        const string& inputType = input->getType();
+                        bool isUniform = (inputType != FILENAME_TYPE_STRING &&
+                                          inputType != STRING_TYPE_STRING);
+                        input->setIsUniform(isUniform);
                     }
                 }
             }


### PR DESCRIPTION
Update #632 
Set all non-filename and non-string parameters as non-uniform inputs as part of upgrade.