### PR TITLE
LOOKDEVX-402 | Putting back the make current call when unbinding geometry in the

### DIFF
--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -52,7 +52,10 @@ GlslRenderer::~GlslRenderer()
 {
     if (_program->geometryBound())
     {
-        _program->unbindGeometry();
+        if (_context->makeCurrent())
+        {
+            _program->unbindGeometry();
+        }
     }
 }
 


### PR DESCRIPTION
GlslRenderer. This is a temporary fix for now, we will need to discuss
the correct workaround in the future.