### PR TITLE
Set upgrade version to 1.38 instead of 1.37 

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1112,9 +1112,6 @@ void Document::upgradeVersion()
                 }
             }
         }
-
-        // While we are in the process of supporting 1.38. Leave files as 1.37
-        minorVersion = 37;
     }
 
     setVersionIntegers(majorVersion, minorVersion);


### PR DESCRIPTION
Update #460 
Remove keeping the version at 1.37 when an upgrade occurs for consistency.