### PR TITLE
1.38 : Support nodegraph connections for material to shader search

### DIFF
--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/surfacematerial_nodegraph_to_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/surfacematerial_nodegraph_to_surfaceshader.mtlx
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<materialx version="1.37">
+   <!-- Test of surfacematerial in nodegraph to shader node traversal -->
+   <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
+      <input name="base_color" type="color3" value="0.3,0.8,0.1" />
+   </standard_surface>
+  <nodegraph name="green_material_graph">
+    <input name="input_shader" type="surfaceshader" nodename="standard_surface" value="" />
+    <surfacematerial name="green_surfacematerial" type="material" >
+      <input name="surfaceshader" type="surfaceshader" interfacename="input_shader" />
+      <input name="displacementshader" type="displacementshader" value="" />
+    </surfacematerial>
+     <output name="green_material" nodename="green_surfacematerial" type="material" />
+  </nodegraph>
+
+   <!-- Test of surfacematerial nodegraph to shader nodegraph traversal -->
+   <nodegraph name="surfaceshader_graph">
+      <standard_surface name="standard_surface" type="surfaceshader" version="1.0.1">
+         <input name="base_color" type="color3" value="0.8,0.1,0.1" />
+      </standard_surface>
+      <output name="red_shader" nodename="standard_surface" type="surfaceshader" />
+   </nodegraph>
+   <nodegraph name="red_material_graph2">
+      <input name="input_shader" type="surfaceshader" nodegraph="surfaceshader_graph" />
+      <surfacematerial name="red_surfacematerial" type="material" >
+         <input name="surfaceshader" type="surfaceshader" interfacename="input_shader" />
+         <input name="displacementshader" type="displacementshader" value="" />
+      </surfacematerial>
+      <output name="red_material" nodename="red_surfacematerial" type="material" />
+   </nodegraph>   
+</materialx>

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -62,28 +62,25 @@ std::unordered_set<NodePtr> getShaderNodes(const NodePtr& materialNode, const st
     for (const InputPtr& input : inputs) 
     {
         // Scan for a node directly connected to the input.
+        // Note that this will handle traversing through interfacename associations.
         //
-        const string& inputShader = input->getNodeName();
-        if (!inputShader.empty())
+        NodePtr shaderNode = input->getConnectedNode();
+        if (shaderNode)
         {
-            NodePtr shaderNode = parent->getChildOfType<Node>(inputShader);
-            if (shaderNode)
+            if (!nodeType.empty() && shaderNode->getType() != nodeType)
             {
-                if (!nodeType.empty() && shaderNode->getType() != nodeType)
+                continue;
+            }
+                
+            if (!target.empty())
+            {
+                NodeDefPtr nodeDef = shaderNode->getNodeDef(target);
+                if (!nodeDef)
                 {
                     continue;
                 }
-                
-                if (!target.empty())
-                {
-                    NodeDefPtr nodeDef = shaderNode->getNodeDef(target);
-                    if (!nodeDef)
-                    {
-                        continue;
-                    }
-                }
-                shaderNodes.insert(shaderNode);
             }
+            shaderNodes.insert(shaderNode);
         }
 
         // Check upstream nodegraph connected to the input.


### PR DESCRIPTION
Update #385 

Update getShaderNodes() utility to find shaders which are connected to surfacematerial which is in a nodegraph.
Use getConnectedNodes() which handles these configurations properly now instead of directly trying to access the connected
node.
