### PR TITLE
ShaderRenderer API to getImageList

### DIFF
--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -1,0 +1,38 @@
+//
+// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRender/ShaderRenderer.h>
+#include <MaterialXGenShader/HwShaderGenerator.h>
+
+namespace MaterialX
+{
+
+    ImageVec ShaderRenderer::getImageList(const ShaderPtr& shader)
+    {
+        if (!shader && !_imageHandler)
+            return {};
+
+        ImageVec imageList;
+        // Prefetch all required images for Public Uniforms and query their dimensions. 
+        // Since Images are cached by ImageHandler, they will be reused during bindTextures
+        const ShaderStage& stage = shader->getStage(Stage::PIXEL);
+        const VariableBlock& block = stage.getUniformBlock(HW::PUBLIC_UNIFORMS);
+        for (const auto& uniform : block.getVariableOrder())
+        {
+            if (uniform->getType() == Type::FILENAME)
+            {
+                const string fileName(uniform->getValue()->getValueString());
+                ImagePtr image = _imageHandler->acquireImage(fileName);
+                if (image)
+                {
+                    imageList.push_back(image);
+                }
+            }
+        }
+
+        return imageList;
+    }
+
+} // namespace MaterialX

--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -9,7 +9,7 @@
 namespace MaterialX
 {
 
-    ImageVec ShaderRenderer::getImageList(const ShaderPtr& shader)
+    ImageVec ShaderRenderer::getReferencedImages(const ShaderPtr& shader)
     {
         if (!shader && !_imageHandler)
             return {};

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -119,8 +119,8 @@ class ShaderRenderer
     /// Save the current contents of the off-screen hardware buffer to disk.
     virtual void saveImage(const FilePath& filePath, ConstImagePtr image, bool verticalFlip) = 0;
 
-    /// Load images required for shader and return list of images loaded
-    virtual ImageVec getImageList (const ShaderPtr& shader);
+    /// Load images referenced by shader program and return list of images loaded
+    virtual ImageVec getReferencedImages (const ShaderPtr& shader);
     /// @}
 
   protected:

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -119,6 +119,8 @@ class ShaderRenderer
     /// Save the current contents of the off-screen hardware buffer to disk.
     virtual void saveImage(const FilePath& filePath, ConstImagePtr image, bool verticalFlip) = 0;
 
+    /// Load images required for shader and return list of images loaded
+    virtual ImageVec getImageList (const ShaderPtr& shader);
     /// @}
 
   protected:

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -316,7 +316,6 @@ void GlslRenderer::saveImage(const FilePath& filePath, ConstImagePtr image, bool
     }
 }
 
-
 ImageVec GlslRenderer::getImageList(const ShaderPtr& /*shader*/)
 {
     ImageVec imageList;

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -316,6 +316,32 @@ void GlslRenderer::saveImage(const FilePath& filePath, ConstImagePtr image, bool
     }
 }
 
+
+ImageVec GlslRenderer::getImageList(const ShaderPtr& /*shader*/)
+{
+    ImageVec imageList;
+    const GlslProgram::InputMap& uniformList = _program->getUniformsList();
+    for (const auto& uniform : uniformList)
+    {
+        GLenum uniformType = uniform.second->gltype;
+        GLint uniformLocation = uniform.second->location;
+        if (uniformLocation >= 0 && uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
+        {
+            const string fileName(uniform.second->value ? uniform.second->value->getValueString() : "");
+            if (fileName != HW::ENV_RADIANCE &&
+                fileName != HW::ENV_IRRADIANCE)
+            {
+                ImagePtr image = _imageHandler->acquireImage(fileName);
+                if (image)
+                {
+                    imageList.push_back(image);
+                }
+            }
+        }
+    }
+    return imageList;
+}
+
 void GlslRenderer::drawScreenSpaceQuad()
 {
     const float QUAD_VERTICES[] =

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -316,7 +316,7 @@ void GlslRenderer::saveImage(const FilePath& filePath, ConstImagePtr image, bool
     }
 }
 
-ImageVec GlslRenderer::getImageList(const ShaderPtr& /*shader*/)
+ImageVec GlslRenderer::getReferencedImages(const ShaderPtr& /*shader*/)
 {
     ImageVec imageList;
     const GlslProgram::InputMap& uniformList = _program->getUniformsList();

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -89,8 +89,8 @@ class GlslRenderer : public ShaderRenderer
     /// Save the current contents of the off-screen hardware buffer to disk.
     void saveImage(const FilePath& filePath, ConstImagePtr image, bool verticalFlip) override;
 
-    /// Load images required for shader program and return list of images loaded
-    ImageVec getImageList(const ShaderPtr& shader) override;
+    /// Load images referenced by shader program and return list of images loaded
+    ImageVec getReferencedImages(const ShaderPtr& shader) override;
 
     /// Return the GL frame buffer.
     GLFrameBufferPtr getFrameBuffer() const

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -89,6 +89,9 @@ class GlslRenderer : public ShaderRenderer
     /// Save the current contents of the off-screen hardware buffer to disk.
     void saveImage(const FilePath& filePath, ConstImagePtr image, bool verticalFlip) override;
 
+    /// Load images required for shader program and return list of images loaded
+    ImageVec getImageList(const ShaderPtr& shader) override;
+
     /// Return the GL frame buffer.
     GLFrameBufferPtr getFrameBuffer() const
     {

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -153,30 +153,17 @@ void TextureBaker::bakeGraphOutput(OutputPtr output, GenContext& context, const 
         unsigned int bakedTextureHeight = 0;
         unsigned int bakedTextureWidth = 0;
         bool requiresResize = false;
-        // Prefetch all required images and query thier dimensions. 
+
+        // Prefetch all required images and query their dimensions. 
         // Since Images are cached by ImageHandler, they will be reused during bindTextures
-        const GlslProgram::InputMap& uniformList = program->getUniformsList();
-        for (const auto& uniform : uniformList)
+        ImageVec imageList = getImageList(shader);
+        for (const auto& image : imageList)
         {
-            GLenum uniformType = uniform.second->gltype;
-            GLint uniformLocation = uniform.second->location;
-            if (uniformLocation >= 0 && uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
-            {
-                const string fileName(uniform.second->value ? uniform.second->value->getValueString() : "");
-                if (fileName != HW::ENV_RADIANCE &&
-                    fileName != HW::ENV_IRRADIANCE)
-                {
-                    ImagePtr image = _imageHandler->acquireImage(fileName);
-                    if (image)
-                    {
-                        const unsigned int imageHeight = image->getHeight();
-                        const unsigned int imageWidth = image->getWidth();
-                        bakedTextureHeight = imageHeight > bakedTextureHeight ? imageHeight : bakedTextureHeight;
-                        bakedTextureWidth = imageWidth > bakedTextureWidth ? imageWidth : bakedTextureWidth;
-                        requiresResize = true;
-                    }
-                }
-            }
+            const unsigned int imageHeight = image->getHeight();
+            const unsigned int imageWidth = image->getWidth();
+            bakedTextureHeight = imageHeight > bakedTextureHeight ? imageHeight : bakedTextureHeight;
+            bakedTextureWidth = imageWidth > bakedTextureWidth ? imageWidth : bakedTextureWidth;
+            requiresResize = true;
         }
 
         if (requiresResize)

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -156,7 +156,7 @@ void TextureBaker::bakeGraphOutput(OutputPtr output, GenContext& context, const 
 
         // Prefetch all required images and query their dimensions. 
         // Since Images are cached by ImageHandler, they will be reused during bindTextures
-        ImageVec imageList = getImageList(shader);
+        ImageVec imageList = getReferencedImages(shader);
         for (const auto& image : imageList)
         {
             const unsigned int imageHeight = image->getHeight();

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -94,7 +94,8 @@ void bindPyShaderRenderer(py::module& mod)
         .def("createProgram", static_cast<void (mx::ShaderRenderer::*)(const mx::ShaderRenderer::StageMap&)>(&mx::ShaderRenderer::createProgram))
         .def("validateInputs", &mx::ShaderRenderer::validateInputs)
         .def("render", &mx::ShaderRenderer::render)
-        .def("saveImage", &mx::ShaderRenderer::saveImage);
+        .def("saveImage", &mx::ShaderRenderer::saveImage)
+        .def("getImageList", &mx::ShaderRenderer::getImageList);
 
     static py::exception<mx::ExceptionShaderRenderError> pyExceptionShaderRenderError(mod, "ExceptionShaderRenderError");
 

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -95,7 +95,7 @@ void bindPyShaderRenderer(py::module& mod)
         .def("validateInputs", &mx::ShaderRenderer::validateInputs)
         .def("render", &mx::ShaderRenderer::render)
         .def("saveImage", &mx::ShaderRenderer::saveImage)
-        .def("getImageList", &mx::ShaderRenderer::getImageList);
+        .def("getReferencedImages", &mx::ShaderRenderer::getReferencedImages);
 
     static py::exception<mx::ExceptionShaderRenderError> pyExceptionShaderRenderError(mod, "ExceptionShaderRenderError");
 

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
@@ -23,5 +23,5 @@ void bindPyGlslRenderer(py::module& mod)
         .def("captureImage", &mx::GlslRenderer::captureImage)
         .def("saveImage", &mx::GlslRenderer::saveImage)
         .def("getProgram", &mx::GlslRenderer::getProgram)
-        .def("getImageList", &mx::GlslRenderer::getImageList);
+        .def("getReferencedImages", &mx::GlslRenderer::getReferencedImages);
 }

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
@@ -22,5 +22,6 @@ void bindPyGlslRenderer(py::module& mod)
         .def("renderTextureSpace", &mx::GlslRenderer::renderTextureSpace)
         .def("captureImage", &mx::GlslRenderer::captureImage)
         .def("saveImage", &mx::GlslRenderer::saveImage)
-        .def("getProgram", &mx::GlslRenderer::getProgram);
+        .def("getProgram", &mx::GlslRenderer::getProgram)
+        .def("getImageList", &mx::GlslRenderer::getImageList);
 }


### PR DESCRIPTION
Update #921 

Load images required for shader and return list of images loaded
`virtual ImageVec getImageList (const ShaderPtr& shader);`

This inspects the Shader and loads images required by the shader.
The ImageVec contains the list of Images loaded.