### PR TITLE
Add additional testing for Arnold OSL output

### DIFF
--- a/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
@@ -76,4 +76,21 @@
     <output name="out1" type="color3" nodename="splittb" />
     <output name="out2" type="vector3" nodename="tangent" />
   </nodegraph>
+  <nodegraph name="constant_check">
+      <standard_surface name="standard_surface" type="surfaceshader">
+         <input name="base_color" type="color3" nodename="add" />
+         <input name="base" type="float" value="0.8" />
+      </standard_surface>
+      <add name="add" type="color3">
+         <input name="in1" type="color3" nodename="constant" />
+         <input name="in2" type="color3" nodename="constant1" />
+      </add>
+      <constant name="constant" type="color3">
+         <parameter name="value" type="color3" value="1, 0, 0" />
+      </constant>
+      <constant name="constant1" type="color3">
+         <parameter name="value" type="color3" value="0, 0, 1" />
+      </constant>
+      <output name="krishan_issue" type="surfaceshader" nodename="standard_surface" />
+   </nodegraph> 
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_38_parameter_to_input.mtlx
@@ -72,11 +72,11 @@
     <constant name="constant3" type="filename">
       <input name="value" type="filename" value="grid.png" />
     </constant>
-    <output name="out" type="color3" nodename="ramp4" />
-    <output name="out1" type="color3" nodename="splittb" />
-    <output name="out2" type="vector3" nodename="tangent" />
+    <output name="ramp4_out" type="color3" nodename="ramp4" />
+    <output name="splittb_out" type="color3" nodename="splittb" />
+    <output name="tangent_out" type="vector3" nodename="tangent" />
   </nodegraph>
-  <nodegraph name="constant_check">
+  <nodegraph name="constant_graph_upgrade">
       <standard_surface name="standard_surface" type="surfaceshader">
          <input name="base_color" type="color3" nodename="add" />
          <input name="base" type="float" value="0.8" />
@@ -91,6 +91,6 @@
       <constant name="constant1" type="color3">
          <parameter name="value" type="color3" value="0, 0, 1" />
       </constant>
-      <output name="krishan_issue" type="surfaceshader" nodename="standard_surface" />
+      <output name="constant_parameter_value_out" type="surfaceshader" nodename="standard_surface" />
    </nodegraph> 
 </materialx>

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -74,6 +74,9 @@ endif()
 if (MATERIALX_BUILD_GEN_MDL)
     LIST(APPEND LIBS MaterialXGenMdl)
 endif()
+if (MATERIALX_BUILD_GEN_ARNOLD)
+    LIST(APPEND LIBS MaterialXGenArnold)
+endif()
 
 target_link_libraries(
      ${LIBS}

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -14,6 +14,9 @@
 
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 #include <MaterialXGenOsl/OslShaderGenerator.h>
+#ifdef MATERIALX_BUILD_GEN_ARNOLD
+#include <MaterialXGenArnold/ArnoldShaderGenerator.h>
+#endif
 
 #include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/Util.h>
@@ -229,6 +232,9 @@ Viewer::Viewer(const std::string& materialFilename,
 #endif
 #if MATERIALX_BUILD_GEN_MDL
     _genContextMdl(mx::MdlShaderGenerator::create()),
+#endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+    _genContextArnold(mx::ArnoldShaderGenerator::create()),
 #endif
     _unitRegistry(mx::UnitConverterRegistry::create()),
     _splitByUdims(true),
@@ -1396,6 +1402,14 @@ void Viewer::saveShaderSource(mx::GenContext& context)
                     new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved MDL source: ", baseName);
                 }
 #endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+                else if (context.getShaderGenerator().getTarget() == mx::ArnoldShaderGenerator::TARGET)
+                {
+                    const std::string& pixelShader = shader->getSourceCode(mx::Stage::PIXEL);
+                    writeTextFile(pixelShader, baseName + "_arnold.osl");
+                    new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved Arnold OSL source: ", baseName);
+                }
+#endif
             }
         }
     }
@@ -1532,6 +1546,9 @@ void Viewer::loadStandardLibraries()
 #if MATERIALX_BUILD_GEN_MDL
     initContext(_genContextMdl);
 #endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+    initContext(_genContextArnold);
+#endif
 }
 
 bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
@@ -1590,6 +1607,15 @@ bool Viewer::keyboardEvent(int key, int scancode, int action, int modifiers)
     if (key == GLFW_KEY_M && action == GLFW_PRESS)
     {
         saveShaderSource(_genContextMdl);
+        return true;
+    }
+#endif
+
+#if MATERIALX_BUILD_GEN_ARNOLD
+    // Save MDL shader source to file.
+    if (key == GLFW_KEY_A && action == GLFW_PRESS)
+    {
+        saveShaderSource(_genContextArnold);
         return true;
     }
 #endif

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -302,6 +302,9 @@ class Viewer : public ng::Screen
 #if MATERIALX_BUILD_GEN_MDL
     mx::GenContext _genContextMdl;
 #endif
+#if MATERIALX_BUILD_GEN_ARNOLD
+    mx::GenContext _genContextArnold;
+#endif
 
     // Unit registry
     mx::UnitConverterRegistryPtr _unitRegistry;


### PR DESCRIPTION
Fixed #1126 
- Add option in MaterialXView to output Arnold target OSL code via the "A" key. e.g.
![image](https://user-images.githubusercontent.com/14275104/108869558-4fa2ab80-75c5-11eb-82c8-6db8c009d32c.png)
- Add in test graph for issue.

Test Results:
[feb_23_2021_tests.pdf](https://github.com/autodesk-forks/MaterialX/files/6030859/feb_23_2021_tests.pdf)
