### PR TITLE
Support legacy Arnold "context" hint on shaderref upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,9 @@ else()
 endif()
 
 # Add core subdirectories
+if (MATERIALX_BUILD_GEN_ARNOLD)
+    add_definitions(-DSUPPORT_ARNOLD_CONTEXT_STRING)
+endif()
 add_subdirectory(source/MaterialXCore)
 add_subdirectory(source/MaterialXFormat)
 

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -24,10 +24,6 @@ NodeDefPtr getShaderNodeDef(ElementPtr shaderRef)
         string nodeDefString = shaderRef->getAttribute(NodeDef::NODE_DEF_ATTRIBUTE);
         return shaderRef->resolveRootNameReference<NodeDef>(nodeDefString);
     }
-    {
-        string nodeDefString = shaderRef->getAttribute(NodeDef::NODE_DEF_ATTRIBUTE);
-        return shaderRef->resolveRootNameReference<NodeDef>(nodeDefString);
-    }
     if (shaderRef->hasAttribute(NodeDef::NODE_ATTRIBUTE))
     {
         string nodeString = shaderRef->getAttribute(NodeDef::NODE_ATTRIBUTE);

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -9,8 +9,6 @@
 
 #include <mutex>
 
-#include <iostream>
-
 namespace MaterialX
 {
 
@@ -983,8 +981,6 @@ void Document::upgradeVersion()
                 if (!contextString.empty())
                 {
                     shaderNodeType = contextString;
-                    std::cout << "Use \"context\" attribute: " + shaderNodeType << 
-                        " for shaderref: " + shaderRef->getName() << std::endl;
                 }
                 else
 #endif

--- a/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
+++ b/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
@@ -16,29 +16,28 @@
 
 namespace mx = MaterialX;
 
-TEST_CASE("GenShader: Arnold Implementation Check", "[arnold_context]")
+TEST_CASE("Arnold context semantic test", "[arnold_context]")
 {
     const std::string testMaterial = {
     "<?xml version=\"1.0\"?>\n"
     "<materialx version=\"1.36\">\n"
     "<material name = \"test_material\">\n"
-        "<shaderref name = \"simple_srf1\" node = \"noise\" context = \"shaderNode\">\n"
-        "<bindinput name = \"octaves\" type = \"int\" value = \"12\" / >\n"
-        "<bindinput name = \"distortion\" type = \"float\" value = \"6\" / >\n"
-        "<bindinput name = \"lacunarity\" type = \"float\" value = \"2\" / >\n"
-        "<bindinput name = \"amplitude\" type = \"float\" value = \"1\" / >\n"
-        "<bindinput name = \"color1\" type = \"color3\" value = \"1, 1, 0\" / >\n"
-        "<bindinput name = \"color2\" type = \"color3\" value = \"0.9, 0.1, 0\" / >\n"
-        "< / shaderref>\n"
-
+        "<shaderref name = \"simple_srf1\" node = \"noise\" context = \"surfaceshader\">\n"
+        "<bindinput name = \"octaves\" type = \"int\" value = \"12\" />\n"
+        "<bindinput name = \"distortion\" type = \"float\" value = \"6\" />\n"
+        "<bindinput name = \"lacunarity\" type = \"float\" value = \"2\" />\n"
+        "<bindinput name = \"amplitude\" type = \"float\" value = \"1\" />\n"
+        "<bindinput name = \"color1\" type = \"color3\" value = \"1, 1, 0\" />\n"
+        "<bindinput name = \"color2\" type = \"color3\" value = \"0.9, 0.1, 0\" />\n"
+        "</shaderref>\n"
         "<shaderref name = \"simple_disp\" node = \"noise\" context = \"displacementshader\">\n"
-        "<bindinput name = \"octaves\" type = \"int\" value = \"8\" / >\n"
-        "<bindinput name = \"distortion\" type = \"float\" value = \"3\" / >\n"
-        "<bindinput name = \"lacunarity\" type = \"float\" value = \"4\" / >\n"
-        "<bindinput name = \"amplitude\" type = \"float\" value = \"1\" / >\n"
-        "<bindinput name = \"color1\" type = \"color3\" value = \"0, 0, 0\" / >\n"
-        "<bindinput name = \"color2\" type = \"color3\" value = \"1, 1, 1\" / >\n"
-        "</ shaderref>\n"
+        "<bindinput name = \"octaves\" type = \"int\" value = \"8\" />\n"
+        "<bindinput name = \"distortion\" type = \"float\" value = \"3\" />\n"
+        "<bindinput name = \"lacunarity\" type = \"float\" value = \"4\" />\n"
+        "<bindinput name = \"amplitude\" type = \"float\" value = \"1\" />\n"
+        "<bindinput name = \"color1\" type = \"color3\" value = \"0, 0, 0\" />\n"
+        "<bindinput name = \"color2\" type = \"color3\" value = \"1, 1, 1\" />\n"
+        "</shaderref>\n"
     "</material>\n"
      "</materialx>\n"
     };
@@ -50,23 +49,23 @@ TEST_CASE("GenShader: Arnold Implementation Check", "[arnold_context]")
     // Check that the "context" attribute was recognized and the appropriate
     // shader nodes created
     mx::NodePtr shaderNode= doc->getNode("simple_srf1");
-    REQUIRE((shaderNode && shaderNode->getType() == mx::SURFACE_SHADER_TYPE_STRING));
+    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::SURFACE_SHADER_TYPE_STRING));
     shaderNode = doc->getNode("simple_srf2");    
-    REQUIRE((shaderNode && shaderNode->getType() == mx::DISPLACEMENT_SHADER_TYPE_STRING));
+    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
     shaderNode = doc->getNode("simple_disp");
-    REQUIRE((shaderNode && shaderNode->getType() == mx::SURFACE_SHADER_TYPE_STRING));
+    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::SURFACE_SHADER_TYPE_STRING));
     shaderNode = doc->getNode("simple_disp2");
-    REQUIRE((shaderNode && shaderNode->getType() == mx::DISPLACEMENT_SHADER_TYPE_STRING));
+    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 
     mx::NodePtr materialNode = doc->getNode("test_material");
     mx::InputPtr input = materialNode->getInput(mx::DISPLACEMENT_SHADER_TYPE_STRING);
-    REQUIRE((input && input->getAttribute("nodename") == "simple_disp"));
-    REQUIRE((input && input->getAttribute("type") == mx::DISPLACEMENT_SHADER_TYPE_STRING));
+    REQUIRE((input && input->getAttribute(mx::PortElement::NODE_NAME_ATTRIBUTE) == "simple_disp"));
+    REQUIRE((input && input->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 
     materialNode = doc->getNode("test_material2");
     input = materialNode->getInput(mx::DISPLACEMENT_SHADER_TYPE_STRING);
-    REQUIRE((input && input->getAttribute("nodename") == "simple_disp2"));
-    REQUIRE((input && input->getAttribute("type") == mx::DISPLACEMENT_SHADER_TYPE_STRING));
+    REQUIRE((input && input->getAttribute(mx::PortElement::NODE_NAME_ATTRIBUTE) == "simple_disp2"));
+    REQUIRE((input && input->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 }
 
 TEST_CASE("GenShader: Arnold Implementation Check", "[genosl]")

--- a/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
+++ b/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
@@ -16,6 +16,7 @@
 
 namespace mx = MaterialX;
 
+#ifdef SUPPORT_ARNOLD_CONTEXT_STRING
 TEST_CASE("Arnold context semantic test", "[arnold_context]")
 {
     const std::string testMaterial = {
@@ -67,6 +68,7 @@ TEST_CASE("Arnold context semantic test", "[arnold_context]")
     REQUIRE((input && input->getAttribute(mx::PortElement::NODE_NAME_ATTRIBUTE) == "simple_disp2"));
     REQUIRE((input && input->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 }
+#endif
 
 TEST_CASE("GenShader: Arnold Implementation Check", "[genosl]")
 {

--- a/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
+++ b/source/MaterialXTest/MaterialXGenArnold/GenArnold.cpp
@@ -51,21 +51,12 @@ TEST_CASE("Arnold context semantic test", "[arnold_context]")
     // shader nodes created
     mx::NodePtr shaderNode= doc->getNode("simple_srf1");
     REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::SURFACE_SHADER_TYPE_STRING));
-    shaderNode = doc->getNode("simple_srf2");    
-    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
     shaderNode = doc->getNode("simple_disp");
-    REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::SURFACE_SHADER_TYPE_STRING));
-    shaderNode = doc->getNode("simple_disp2");
     REQUIRE((shaderNode->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 
     mx::NodePtr materialNode = doc->getNode("test_material");
     mx::InputPtr input = materialNode->getInput(mx::DISPLACEMENT_SHADER_TYPE_STRING);
     REQUIRE((input && input->getAttribute(mx::PortElement::NODE_NAME_ATTRIBUTE) == "simple_disp"));
-    REQUIRE((input && input->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
-
-    materialNode = doc->getNode("test_material2");
-    input = materialNode->getInput(mx::DISPLACEMENT_SHADER_TYPE_STRING);
-    REQUIRE((input && input->getAttribute(mx::PortElement::NODE_NAME_ATTRIBUTE) == "simple_disp2"));
     REQUIRE((input && input->getAttribute(mx::TypedElement::TYPE_ATTRIBUTE) == mx::DISPLACEMENT_SHADER_TYPE_STRING));
 }
 #endif


### PR DESCRIPTION
Update #1150 

Add in special Arnold "context" support when upgrading "shaderrefs". 
Use as the type to create instead of checing the regular node, nodedef attributes.

This will only be enabled for builds with the build flag `MATERIALX_BUILD_GEN_ARNOLD` set.

Test case added wit this test as input:
```
<?xml version="1.0"?>
<materialx version="1.36">

   <material name="test_material">
      <shaderref name="simple_srf1" node="noise" context="surfaceshader">
         <bindinput name="octaves" type="int" value="12" />
         <bindinput name="distortion" type="float" value="6" />
         <bindinput name="lacunarity" type="float" value="2" />
         <bindinput name="amplitude" type="float" value="1" />
         <bindinput name="color1" type="color3" value="1, 1, 0" />
         <bindinput name="color2" type="color3" value="0.9, 0.1, 0" />
      </shaderref>

      <shaderref name="simple_disp" node="noise" context="displacementshader">
         <bindinput name="octaves" type="int" value="8" />
         <bindinput name="distortion" type="float" value="3" />
         <bindinput name="lacunarity" type="float" value="4" />
         <bindinput name="amplitude" type="float" value="1" />
         <bindinput name="color1" type="color3" value="0, 0, 0" />
         <bindinput name="color2" type="color3" value="1, 1, 1" />
      </shaderref>
   </material>

   <material name="test_material2">
      <shaderref name="simple_srf2" node="standard_surface">
         <bindinput name="base_color" type="color3" value="0, 1, 0" />
         <bindinput name="base" type="float" value="0.8" />
      </shaderref>

      <shaderref name="simple_disp" node="image" context="displacementshader">
         <bindinput name="filename" type="string" value="wheel.tx" />
      </shaderref>
   </material>

</materialx>
```
The expected output is:
```
<?xml version="1.0"?>
<materialx version="1.38">
  <noise name="simple_srf1" type="surfaceshader">
    <input name="octaves" type="int" value="12" />
    <input name="distortion" type="float" value="6" />
    <input name="lacunarity" type="float" value="2" />
    <input name="amplitude" type="float" value="1" />
    <input name="color1" type="color3" value="1, 1, 0" />
    <input name="color2" type="color3" value="0.9, 0.1, 0" />
  </noise>
   <noise name="simple_disp" type="displacementshader">
      <input name="octaves" type="int" value="8" />
      <input name="distortion" type="float" value="3" />
      <input name="lacunarity" type="float" value="4" />
      <input name="amplitude" type="float" value="1" />
      <input name="color1" type="color3" value="0, 0, 0" />
      <input name="color2" type="color3" value="1, 1, 1" />
   </noise>
   <surfacematerial name="test_material" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="simple_srf1" />
    <input name="displacementshader" type="displacementshader" nodename="simple_disp" />
  </surfacematerial>
      
  <standard_surface name="simple_srf2" type="surfaceshader">
    <input name="base_color" type="color3" value="0, 1, 0" />
    <input name="base" type="float" value="0.8" />
  </standard_surface>
   <image name="simple_disp2" type="displacementshader">
      <input name="filename" type="string" value="wheel.tx" />
   </image>
   <surfacematerial name="test_material2" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="simple_srf2" />
    <input name="displacementshader" type="displacementshader" nodename="simple_disp2" />
  </surfacematerial>
</materialx>
```