### PR TITLE
MDL texture lookup code generation fixes.

### DIFF
--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -287,14 +287,6 @@ string MdlShaderGenerator::getUpstreamResult(const ShaderInput* input, GenContex
 {
     const ShaderOutput* upstreamOutput = input->getConnection();
 
-    // TODO: This is a temporary fix for Iray.
-    // File texture constructors with a filename set are emitted inline "by value".
-    if (upstreamOutput && upstreamOutput->getType() == Type::FILENAME &&
-        upstreamOutput->getValue() && !upstreamOutput->getValue()->getValueString().empty())
-    {
-        return _syntax->getValue(upstreamOutput->getType(), *upstreamOutput->getValue());
-    }
-
     if (!upstreamOutput || upstreamOutput->getNode()->isAGraph())
     {
         return ShaderGenerator::getUpstreamResult(input, context);
@@ -547,14 +539,6 @@ void MdlShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
     for (size_t i = 0; i < inputs.size(); ++i)
     {
         const ShaderPort* input = inputs[i];
-
-        // TODO: This is a temporary fix for Iray.
-        // File texture constructors with a filename set must be emitted inside the shader body.
-        // They will be emitted inline "by value", see MdlShaderGenerator::getUpstreamResult().
-        if (input->getType() == Type::FILENAME && input->getValue() && !input->getValue()->getValueString().empty())
-        {
-            continue;
-        }
 
         const string& qualifier = input->isUniform() || input->getType()==Type::FILENAME ? uniformPrefix : EMPTY_STRING;
         const string& type = _syntax->getTypeName(input->getType());

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -40,7 +40,7 @@ class MdlFilenameTypeSyntax : public ScalarTypeSyntax
         const string outputValue = value.getValueString();
         if (outputValue.empty() || outputValue == "/")
         {
-            return getDefaultValue();
+            return getDefaultValue(true);
         }
 
         string pathSeparator("");

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -37,13 +37,19 @@ class MdlFilenameTypeSyntax : public ScalarTypeSyntax
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
+        const string outputValue = value.getValueString();
+        if (outputValue.empty() || outputValue == "/")
+        {
+            return getDefaultValue();
+        }
+
         string pathSeparator("");
-        FilePath path(value.getValueString());
+        FilePath path(outputValue);
         if (!path.isAbsolute())
         {
             pathSeparator = "/";
         }
-        return getName() + "(\"" + pathSeparator + value.getValueString() + "\", tex::gamma_linear)";
+        return getName() + "(\"" + pathSeparator + outputValue + "\", tex::gamma_linear)";
     }
 };
 


### PR DESCRIPTION
## Issues Addressed

Fixes #1145 
- Fixes erroneous generation of a texture_2d() reference with "/" as an argument when no value is specified such as for input arguments.

Fixes #1146
- Remove workaround of making texture_2d() lookups inlined.

## Sample fix. For [standard_surface_brass_tiled.mtlx](https://github.com/materialx/MaterialX/blob/main/resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx).

The corrected input looks like this;
```
mdl 1.6;

using mx = materialx;
import ::df::*;
import ::base::*;
import ::math::*;
import ::state::*;
import ::anno::*;
import ::tex::*;
import ::mx::swizzle::*;
import ::mx::cm::*;
using ::mx::core import *;
using ::mx::stdlib import *;
using ::mx::pbrlib import *;
using ::mx::sampling import *;

float NG_tiledimage_float
(
    uniform texture_2d file = texture_2d(),
    float default1 = 0,
    float2 texcoord = float2(0.0),
    float2 uvtiling = float2(1, 1),
    float2 uvoffset = float2(0, 0),
    float2 realworldimagesize = float2(1, 1),
    float2 realworldtilesize = float2(1, 1),
    uniform mx_filterlookup_type filtertype = mx_filterlookup_type_linear,
    uniform string framerange = "",
    uniform int frameoffset = 0,
    uniform mx_addressmode_type frameendaction = mx_addressmode_type_constant
)
{
    float2 N_mult_float_out = texcoord * uvtiling;
    float2 N_sub_float_out = N_mult_float_out - uvoffset;
    float2 N_divtilesize_float_out = N_sub_float_out / realworldimagesize;
    float2 N_multtilesize_float_out = N_divtilesize_float_out * realworldtilesize;
    float N_img_float_out = mx::stdlib::mx_image_float(file, "", default1, N_multtilesize_float_out, mx_addressmode_type_periodic, mx_addressmode_type_periodic, filtertype, framerange, frameoffset, frameendaction);
    return N_img_float_out;
}

color NG_tiledimage_color3
(
    uniform texture_2d file = texture_2d(),
    color default1 = color(0, 0, 0),
    float2 texcoord = float2(0.0),
    float2 uvtiling = float2(1, 1),
    float2 uvoffset = float2(0, 0),
    float2 realworldimagesize = float2(1, 1),
    float2 realworldtilesize = float2(1, 1),
    uniform mx_filterlookup_type filtertype = mx_filterlookup_type_linear,
    uniform string framerange = "",
    uniform int frameoffset = 0,
    uniform mx_addressmode_type frameendaction = mx_addressmode_type_constant
)
{
    float2 N_mult_color3_out = texcoord * uvtiling;
    float2 N_sub_color3_out = N_mult_color3_out - uvoffset;
    float2 N_divtilesize_color3_out = N_sub_color3_out / realworldimagesize;
    float2 N_multtilesize_color3_out = N_divtilesize_color3_out * realworldtilesize;
    color N_img_color3_out = mx::stdlib::mx_image_color3(file, "", default1, N_multtilesize_color3_out, mx_addressmode_type_periodic, mx_addressmode_type_periodic, filtertype, framerange, frameoffset, frameendaction);
    return N_img_color3_out;
}

material IMPL_standard_surface_surfaceshader
(
    float base = 1,
    color base_color = color(0.8, 0.8, 0.8),
    float diffuse_roughness = 0,
    float metalness = 0,
    float specular = 1,
    color specular_color = color(1, 1, 1),
    float specular_roughness = 0.2,
    uniform float specular_IOR = 1.5,
    float specular_anisotropy = 0,
    float specular_rotation = 0,
    float transmission = 0,
    color transmission_color = color(1, 1, 1),
    float transmission_depth = 0,
    color transmission_scatter = color(0, 0, 0),
    float transmission_scatter_anisotropy = 0,
    float transmission_dispersion = 0,
    float transmission_extra_roughness = 0,
    float subsurface = 0,
    color subsurface_color = color(1, 1, 1),
    color subsurface_radius = color(1, 1, 1),
    float subsurface_scale = 1,
    float subsurface_anisotropy = 0,
    float sheen = 0,
    color sheen_color = color(1, 1, 1),
    float sheen_roughness = 0.3,
    float coat = 0,
    color coat_color = color(1, 1, 1),
    float coat_roughness = 0.1,
    float coat_anisotropy = 0,
    float coat_rotation = 0,
    float coat_IOR = 1.5,
    float3 coat_normal = float3(0.0),
    float coat_affect_color = 0,
    float coat_affect_roughness = 0,
    float thin_film_thickness = 0,
    float thin_film_IOR = 1.5,
    float emission = 0,
    color emission_color = color(1, 1, 1),
    color opacity = color(1, 1, 1),
    bool thin_walled = false,
    float3 normal = float3(0.0),
    float3 tangent = float3(0.0)
)
 = let
{
    color emission_weight_out = emission_color * emission;
    color metal_reflectivity_out = base_color * base;
    float coat_tangent_rotate_degree_out = coat_rotation * 360;
    float2 coat_roughness_vector_out = mx::pbrlib::mx_roughness_anisotropy(mxp_roughness:coat_roughness, mxp_anisotropy:coat_anisotropy);
    float3 subsurface_radius_vector_out = float3(float3(subsurface_radius).x, float3(subsurface_radius).y, float3(subsurface_radius).z);
    color opacity_luminance_out = mx::stdlib::mx_luminance_color3(opacity);
    color coat_emission_attenuation_out = math::lerp(color(1, 1, 1), coat_color, coat);
    color metal_edgecolor_out = specular_color * specular;
    float coat_affect_roughness_multiply1_out = coat_affect_roughness * coat;
    float subsurface_selector_out = float(thin_walled);
    float tangent_rotate_degree_out = specular_rotation * 360;
    float coat_clamped_out = math::clamp(coat, 0, 1);
    color coat_attenuation_out = math::lerp(color(1, 1, 1), coat_color, coat);
    float3 coat_tangent_rotate_out = mx::stdlib::mx_rotate3d_vector3(mxp_in:tangent, mxp_amount:coat_tangent_rotate_degree_out, mxp_axis:coat_normal);
    float3 subsurface_radius_scaled_out = subsurface_radius_vector_out * subsurface_scale;
    float opacity_luminance_r_out = float3(opacity_luminance_out).x;
    color emission_weight_attenuated_out = emission_weight_out * coat_emission_attenuation_out;
    mx::pbrlib::mx_artistic_ior__result artistic_ior_result = mx::pbrlib::mx_artistic_ior(mxp_reflectivity:metal_reflectivity_out, mxp_edge_color:metal_edgecolor_out);
    float coat_affect_roughness_multiply2_out = coat_affect_roughness_multiply1_out * coat_roughness;
    float3 tangent_rotate_out = mx::stdlib::mx_rotate3d_vector3(mxp_in:tangent, mxp_amount:tangent_rotate_degree_out, mxp_axis:normal);
    float coat_gamma_multiply_out = coat_clamped_out * coat_affect_color;
    float3 coat_tangent_rotate_normalize_out = math::normalize(coat_tangent_rotate_out);
    material emission_edf_out = mx::pbrlib::mx_uniform_edf(mxp_color:emission_weight_attenuated_out);
    float coat_affected_roughness_out = math::lerp(specular_roughness, 1, coat_affect_roughness_multiply2_out);
    float3 tangent_rotate_normalize_out = math::normalize(tangent_rotate_out);
    float coat_gamma_out = coat_gamma_multiply_out + 1;
    float3 coat_tangent_out = mx::stdlib::mx_ifgreater_vector3(coat_anisotropy, 0, coat_tangent_rotate_normalize_out, tangent);
    float2 main_roughness_out = mx::pbrlib::mx_roughness_anisotropy(mxp_roughness:coat_affected_roughness_out, mxp_anisotropy:specular_anisotropy);
    float3 main_tangent_out = mx::stdlib::mx_ifgreater_vector3(specular_anisotropy, 0, tangent_rotate_normalize_out, tangent);
    color coat_affected_subsurface_color_out = math::pow(subsurface_color, coat_gamma_out);
    color coat_affected_diffuse_color_out = math::pow(base_color, coat_gamma_out);
    material metal_bsdf_out = mx::pbrlib::mx_conductor_bsdf(mxp_weight:1, mxp_ior:artistic_ior_result.mxp_ior, mxp_extinction:artistic_ior_result.mxp_extinction, mxp_roughness:main_roughness_out, mxp_normal:normal, mxp_tangent:main_tangent_out);
    material transmission_bsdf_out = mx::pbrlib::mx_dielectric_bsdf(mxp_weight:1, mxp_tint:transmission_color, mxp_ior:specular_IOR, mxp_roughness:main_roughness_out, mxp_normal:normal, mxp_tangent:main_tangent_out, mxp_scatter_mode:mx_scatter_mode_T, mxp_base:material());
    material translucent_bsdf_out = mx::pbrlib::mx_translucent_bsdf(mxp_weight:1, mxp_color:coat_affected_subsurface_color_out, mxp_normal:normal);
    material subsurface_bsdf_out = mx::pbrlib::mx_subsurface_bsdf(mxp_weight:1, mxp_color:coat_affected_subsurface_color_out, mxp_radius:subsurface_radius_scaled_out, mxp_anisotropy:subsurface_anisotropy, mxp_normal:normal);
    material diffuse_bsdf_out = mx::pbrlib::mx_oren_nayar_diffuse_bsdf(mxp_weight:base, mxp_color:coat_affected_diffuse_color_out, mxp_roughness:diffuse_roughness, mxp_normal:normal);
    material selected_subsurface_bsdf_out = mx::pbrlib::mx_mix_bsdf(mxp_fg:translucent_bsdf_out, mxp_bg:subsurface_bsdf_out, mxp_mix:subsurface_selector_out);
    material subsurface_mix_out = mx::pbrlib::mx_mix_bsdf(mxp_fg:selected_subsurface_bsdf_out, mxp_bg:diffuse_bsdf_out, mxp_mix:subsurface);
    material sheen_layer_out = mx::pbrlib::mx_sheen_bsdf(mxp_weight:sheen, mxp_color:sheen_color, mxp_roughness:sheen_roughness, mxp_normal:normal, mxp_base:subsurface_mix_out);
    material transmission_mix_out = mx::pbrlib::mx_mix_bsdf(mxp_fg:transmission_bsdf_out, mxp_bg:sheen_layer_out, mxp_mix:transmission);
    material specular_layer_out = mx::pbrlib::mx_dielectric_bsdf(mxp_weight:specular, mxp_tint:specular_color, mxp_ior:specular_IOR, mxp_roughness:main_roughness_out, mxp_normal:normal, mxp_tangent:main_tangent_out, mxp_scatter_mode:mx_scatter_mode_R, mxp_base:transmission_mix_out);
    material specular_layer_with_thin_film_out = mx::pbrlib::mx_thin_film_bsdf(mxp_thickness:thin_film_thickness, mxp_ior:thin_film_IOR, mxp_base:specular_layer_out);
    material metalness_mix_out = mx::pbrlib::mx_mix_bsdf(mxp_fg:metal_bsdf_out, mxp_bg:specular_layer_with_thin_film_out, mxp_mix:metalness);
    material metalness_mix_attenuated_out = mx::pbrlib::mx_multiply_bsdf_color3(mxp_in1:metalness_mix_out, mxp_in2:coat_attenuation_out);
    material coat_layer_out = mx::pbrlib::mx_dielectric_bsdf(mxp_weight:coat, mxp_tint:color(1, 1, 1), mxp_ior:coat_IOR, mxp_roughness:coat_roughness_vector_out, mxp_normal:coat_normal, mxp_tangent:coat_tangent_out, mxp_scatter_mode:mx_scatter_mode_R, mxp_base:metalness_mix_attenuated_out);
    material shader_constructor_out = mx::pbrlib::mx_surface(coat_layer_out, emission_edf_out, opacity_luminance_r_out, specular_IOR);
}
in material(shader_constructor_out);

export material SR_brass1
(
    float base = 1,
    color base_color = color(1, 1, 1),
    float diffuse_roughness = 0,
    float metalness = 1,
    float specular = 0,
    color specular_color = color(1, 1, 1),
    uniform float specular_IOR = 1.5,
    float specular_anisotropy = 0,
    float specular_rotation = 0,
    float transmission = 0,
    color transmission_color = color(1, 1, 1),
    float transmission_depth = 0,
    color transmission_scatter = color(0, 0, 0),
    float transmission_scatter_anisotropy = 0,
    float transmission_dispersion = 0,
    float transmission_extra_roughness = 0,
    float subsurface = 0,
    color subsurface_color = color(1, 1, 1),
    color subsurface_radius = color(1, 1, 1),
    float subsurface_scale = 1,
    float subsurface_anisotropy = 0,
    float sheen = 0,
    color sheen_color = color(1, 1, 1),
    float sheen_roughness = 0.3,
    float coat = 1,
    float coat_anisotropy = 0,
    float coat_rotation = 0,
    float coat_IOR = 1.5,
    float coat_affect_color = 0,
    float coat_affect_roughness = 0,
    float thin_film_thickness = 0,
    float thin_film_IOR = 1.5,
    float emission = 0,
    color emission_color = color(1, 1, 1),
    color opacity = color(1, 1, 1),
    bool thin_walled = false,
    uniform mx_coordinatespace_type geomprop_Tworld_space = mx_coordinatespace_type_world,
    uniform int geomprop_Tworld_index = 0,
    uniform mx_coordinatespace_type geomprop_Nworld_space = mx_coordinatespace_type_world,
    uniform int geomprop_UV0_index = 0,
    uniform texture_2d image_roughness_file = texture_2d("/resources/Images/brass_roughness.jpg", tex::gamma_linear),
    float image_roughness_default = 0,
    float2 image_roughness_uvtiling = float2(1, 1),
    float2 image_roughness_uvoffset = float2(0, 0),
    float2 image_roughness_realworldimagesize = float2(1, 1),
    float2 image_roughness_realworldtilesize = float2(1, 1),
    uniform mx_filterlookup_type image_roughness_filtertype = mx_filterlookup_type_linear,
    uniform string image_roughness_framerange = "",
    uniform int image_roughness_frameoffset = 0,
    uniform mx_addressmode_type image_roughness_frameendaction = mx_addressmode_type_constant,
    uniform texture_2d image_color_file = texture_2d("/resources/Images/brass_color.jpg", tex::gamma_linear),
    color image_color_default = color(0, 0, 0),
    float2 image_color_uvtiling = float2(1, 1),
    float2 image_color_uvoffset = float2(0, 0),
    float2 image_color_realworldimagesize = float2(1, 1),
    float2 image_color_realworldtilesize = float2(1, 1),
    uniform mx_filterlookup_type image_color_filtertype = mx_filterlookup_type_linear,
    uniform string image_color_framerange = "",
    uniform int image_color_frameoffset = 0,
    uniform mx_addressmode_type image_color_frameendaction = mx_addressmode_type_constant
)
= let
{
    float3 geomprop_Tworld_out = mx::stdlib::mx_tangent_vector3(mxp_space:geomprop_Tworld_space, mxp_index:geomprop_Tworld_index);
    float3 geomprop_Nworld_out = mx::stdlib::mx_normal_vector3(mxp_space:geomprop_Nworld_space);
    float2 geomprop_UV0_out = mx::stdlib::mx_texcoord_vector2(mxp_index:geomprop_UV0_index);
    float image_roughness_out = NG_tiledimage_float(image_roughness_file, image_roughness_default, geomprop_UV0_out, image_roughness_uvtiling, image_roughness_uvoffset, image_roughness_realworldimagesize, image_roughness_realworldtilesize, image_roughness_filtertype, image_roughness_framerange, image_roughness_frameoffset, image_roughness_frameendaction);
    color image_color_out = NG_tiledimage_color3(image_color_file, image_color_default, geomprop_UV0_out, image_color_uvtiling, image_color_uvoffset, image_color_realworldimagesize, image_color_realworldtilesize, image_color_filtertype, image_color_framerange, image_color_frameoffset, image_color_frameendaction);
    color image_color_out_cm_out = mx::cm::mx_srgb_texture_to_linear_color3(image_color_out);
    material SR_brass1_out = IMPL_standard_surface_surfaceshader(base, base_color, diffuse_roughness, metalness, specular, specular_color, image_roughness_out, specular_IOR, specular_anisotropy, specular_rotation, transmission, transmission_color, transmission_depth, transmission_scatter, transmission_scatter_anisotropy, transmission_dispersion, transmission_extra_roughness, subsurface, subsurface_color, subsurface_radius, subsurface_scale, subsurface_anisotropy, sheen, sheen_color, sheen_roughness, coat, image_color_out_cm_out, image_roughness_out, coat_anisotropy, coat_rotation, coat_IOR, geomprop_Nworld_out, coat_affect_color, coat_affect_roughness, thin_film_thickness, thin_film_IOR, emission, emission_color, opacity, thin_walled, geomprop_Nworld_out, geomprop_Tworld_out);
    material finalOutput__ = SR_brass1_out;
}
in material(finalOutput__);

```

