### PR TITLE
Add u/v addressmode intefaces to adsk image nodes

### DIFF
--- a/libraries/adsk/adsklib/adsklib_defs.mtlx
+++ b/libraries/adsk/adsklib/adsklib_defs.mtlx
@@ -59,6 +59,8 @@
     <!-- remap -->
     <input name="outlow"  type="float" value="0.0" />
     <input name="outhigh" type="float" value="1.0" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="float" />
   </nodedef>
 
@@ -75,6 +77,8 @@
     <input name="rotation_angle" type="float" value="0" unittype="angle" />
     <!-- normal scale -->
     <input name="normal_scale" type="float" value="1.0" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -87,6 +91,8 @@
     <input name="uv_scale" type="vector2" value="1.0, 1.0" />
     <input name="rotation_angle" type="float" value="0" unittype="angle" />
     <input name="depth" type="float" unittype="distance" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="vector3" />
   </nodedef>
   

--- a/libraries/adsk/adsklib/adsklib_defs.mtlx
+++ b/libraries/adsk/adsklib/adsklib_defs.mtlx
@@ -21,7 +21,8 @@
     <input name="rgbamount" type="float" value="1.0" />
     <!-- invert -->
     <input name="invert" type="boolean" value="false" />
-
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="color3"/>
   </nodedef>
 
@@ -39,6 +40,8 @@
     <input name="rgbamount" type="float" value="1.0" />
     <!-- invert -->
     <input name="invert" type="boolean" value="false" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>    
     <output name="out" type="float" />
   </nodedef>
 

--- a/libraries/adsk/adsklib/adsklib_ng.mtlx
+++ b/libraries/adsk/adsklib/adsklib_ng.mtlx
@@ -37,8 +37,8 @@
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
 
@@ -93,8 +93,8 @@
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
 
@@ -155,8 +155,8 @@
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
 
@@ -228,8 +228,8 @@
     </place2d>
     <image name="b_image" type="vector3" >
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
 
@@ -282,8 +282,8 @@
     </place2d>
     <image name="b_image" type="color3" >
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
     <extract name="extract1" type="float">	

--- a/source/MaterialXContrib/libraries/adsk/adsklib/adsklib_tr_ng.mtlx
+++ b/source/MaterialXContrib/libraries/adsk/adsklib/adsklib_tr_ng.mtlx
@@ -29,6 +29,8 @@
     <input name="rotation_angle" type="float" value="0" unittype="angle" />
     <!-- normal scale -->
     <input name="normal_scale" type="float" value="1.0" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -38,8 +40,8 @@
     <texcoord name="texcoord1" type="vector2" />
     <image name="b_image" type="vector3" >
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="texcoord1" />
     </image>
 
@@ -71,6 +73,8 @@
     <input name="uv_scale" type="vector2" value="1.0, 1.0" />
     <input name="rotation_angle" type="float" value="0" unittype="angle" />
     <input name="depth" type="float" unittype="distance" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -79,8 +83,8 @@
     <texcoord name="texcoord1" type="vector2" />
     <image name="b_image" type="float" >
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="texcoord1" />
     </image>
     <heighttonormal name="impl_heighttonormalmap" type="vector3">
@@ -113,6 +117,8 @@
     <input name="rgbamount" type="float" value="1.0" />
     <!-- invert -->
     <input name="invert" type="boolean" value="false" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="float" />
 </nodedef>
 
@@ -120,8 +126,8 @@
     <texcoord name="texcoord1" type="vector2" />
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="texcoord1" />
     </image>
 
@@ -170,6 +176,8 @@
     <input name="rgbamount" type="float" value="1.0" />
     <!-- invert -->
     <input name="invert" type="boolean" value="false" />
+    <input name="uaddressmode" type="string" value="periodic"/>
+    <input name="vaddressmode" type="string" value="periodic"/>
     <output name="out" type="color3"/>
 </nodedef>
 
@@ -177,8 +185,8 @@
     <texcoord name="texcoord1" type="vector2" />
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
-      <input name="uaddressmode" type="string" value="periodic" />
-      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="uaddressmode" type="string" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" interfacename="vaddressmode" />
       <input name="texcoord" type="vector2" nodename="texcoord1" />
     </image>
 


### PR DESCRIPTION
The image samples defaults to "periodic". Expose this into adsk:bitmap, adsk:normal_map and adsk:height_map for user configuration.