### PR TITLE
Runtime token support

### DIFF
--- a/source/MaterialXRuntime/Private/PvtPort.cpp
+++ b/source/MaterialXRuntime/Private/PvtPort.cpp
@@ -39,6 +39,7 @@ PvtInput::PvtInput(const RtIdentifier& name, const RtIdentifier& type, uint32_t 
 
 bool PvtInput::isConnectable(const PvtOutput* output) const
 {
+    // TODO : Tokens are not connectable for now.
     if (isToken() || output->isToken())
     {
         return false;

--- a/source/MaterialXRuntime/Private/PvtPort.cpp
+++ b/source/MaterialXRuntime/Private/PvtPort.cpp
@@ -39,6 +39,11 @@ PvtInput::PvtInput(const RtIdentifier& name, const RtIdentifier& type, uint32_t 
 
 bool PvtInput::isConnectable(const PvtOutput* output) const
 {
+    if (isToken() || output->isToken())
+    {
+        return false;
+    }
+
     // We cannot connect to ourselves.
     if (_parent == output->_parent)
     {

--- a/source/MaterialXRuntime/Private/PvtPort.h
+++ b/source/MaterialXRuntime/Private/PvtPort.h
@@ -168,6 +168,12 @@ public:
 
     bool isUIVisible() const
     {
+        // For now since connections require ports to be created and hence visible
+        // always assume a connection means visible.
+        if (isConnected())
+        {
+            return false;
+        }
         const RtTypedValue* attr = getAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
         return attr ? attr->asBool() : false;
     }

--- a/source/MaterialXRuntime/Private/PvtPort.h
+++ b/source/MaterialXRuntime/Private/PvtPort.h
@@ -13,6 +13,7 @@
 #include <MaterialXRuntime/RtValue.h>
 #include <MaterialXRuntime/RtTypeDef.h>
 #include <MaterialXRuntime/RtTraversal.h>
+#include <MaterialXRuntime/Identifiers.h>
 
 /// @file
 /// TODO: Docs
@@ -163,6 +164,18 @@ public:
         {
             _flags &= ~RtPortFlag::TOKEN;
         }
+    }
+
+    bool isUIVisible() const
+    {
+        const RtTypedValue* attr = getAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+        return attr ? attr->asBool() : false;
+    }
+
+    void setIsUIVisible(bool val)
+    {
+        RtTypedValue* attr = createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+        attr->asBool() = val;
     }
 
     bool isConnected() const

--- a/source/MaterialXRuntime/Private/PvtPort.h
+++ b/source/MaterialXRuntime/Private/PvtPort.h
@@ -107,6 +107,23 @@ public:
         attr->asIdentifier() = unit;
     }
 
+    bool isToken() const
+    {
+        return (_flags & RtPortFlag::TOKEN) != 0;
+    }
+
+    void setIsToken(bool val)
+    {
+        if (val)
+        {
+            _flags |= RtPortFlag::TOKEN;
+        }
+        else
+        {
+            _flags &= ~RtPortFlag::TOKEN;
+        }
+    }
+
     static const RtIdentifier DEFAULT_OUTPUT_NAME;
     static const RtIdentifier COLOR_SPACE;
     static const RtIdentifier UNIT;
@@ -146,23 +163,6 @@ public:
         else
         {
             _flags &= ~RtPortFlag::UNIFORM;
-        }
-    }
-
-    bool isToken() const
-    {
-        return (_flags & RtPortFlag::TOKEN) != 0;
-    }
-
-    void setIsToken(bool val)
-    {
-        if (val)
-        {
-            _flags |= RtPortFlag::TOKEN;
-        }
-        else
-        {
-            _flags &= ~RtPortFlag::TOKEN;
         }
     }
 

--- a/source/MaterialXRuntime/Private/PvtPort.h
+++ b/source/MaterialXRuntime/Private/PvtPort.h
@@ -172,10 +172,10 @@ public:
         // always assume a connection means visible.
         if (isConnected())
         {
-            return false;
+            return true;
         }
         const RtTypedValue* attr = getAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-        return attr ? attr->asBool() : false;
+        return attr ? attr->asBool() : true;
     }
 
     void setIsUIVisible(bool val)

--- a/source/MaterialXRuntime/Private/PvtPort.h
+++ b/source/MaterialXRuntime/Private/PvtPort.h
@@ -148,6 +148,23 @@ public:
         }
     }
 
+    bool isToken() const
+    {
+        return (_flags & RtPortFlag::TOKEN) != 0;
+    }
+
+    void setIsToken(bool val)
+    {
+        if (val)
+        {
+            _flags |= RtPortFlag::TOKEN;
+        }
+        else
+        {
+            _flags &= ~RtPortFlag::TOKEN;
+        }
+    }
+
     bool isConnected() const
     {
         return _connection != nullptr;

--- a/source/MaterialXRuntime/RtConnectableApi.cpp
+++ b/source/MaterialXRuntime/RtConnectableApi.cpp
@@ -16,6 +16,12 @@ namespace
 
 bool RtConnectableApi::acceptConnection(const RtInput& input, const RtOutput& output) const
 {
+    // TODO: Tokens are not currently considered to be connectable
+    if (input.isToken())
+    {
+        return false;
+    }
+
     // Default implementation checks if the types are matching.
     //
     // TODO: Check if the data types are compatible/castable

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -204,10 +204,7 @@ namespace
             {
                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                 port = schema.createInput(portName, portType, flags);
-                RtTypedValue* attr = port.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                bool& boolValue = attr->asBool();
-                boolValue = false;
-
+                elem->setAttribute("uivisible", "false");
             }
 
             if (port)

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -204,7 +204,6 @@ namespace
             {
                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                 port = schema.createInput(portName, portType, flags);
-                //port.setIsUIVisible(false);
             }
 
             if (port)

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -500,8 +500,8 @@ namespace
                             {
                                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                                 input = nodegraph.createInput(socketName, inputType, flags);
-                                RtTypedValue* attr = input.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                                attr->asBool() = false;
+                                //RtTypedValue* attr = input.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+                                //attr->asBool() = false;
                             }
                             else
                             {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -493,16 +493,8 @@ namespace
                         {
                             const RtIdentifier inputType(elem->getType());
 
-                            RtInput input = RtInput();
-                            if (elem->isA<Token>())
-                            {
-                                const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
-                                input = nodegraph.createInput(socketName, inputType, flags);
-                            }
-                            else
-                            {
-                                input = nodegraph.createInput(socketName, inputType);
-                            }
+                            const uint32_t flags = elem->isA<Token>() ? RtPortFlag::UNIFORM | RtPortFlag::TOKEN : 0;
+                            RtInput input = nodegraph.createInput(socketName, inputType, flags);
                             socket = nodegraph.getInputSocket(input.getName());
 
                             // Set the input value

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -204,8 +204,7 @@ namespace
             {
                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                 port = schema.createInput(portName, portType, flags);
-                RtTypedValue* attr = port.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                attr->asBool() = false;
+                //port.setIsUIVisible(false);
             }
 
             if (port)
@@ -500,8 +499,7 @@ namespace
                             {
                                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                                 input = nodegraph.createInput(socketName, inputType, flags);
-                                //RtTypedValue* attr = input.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                                //attr->asBool() = false;
+                                //port.setIsUIVisible(false);
                             }
                             else
                             {
@@ -969,10 +967,8 @@ namespace
             RtInput input = node.getInput(i);
             if (input)
             {
-                const RtTypedValue* uiVisible1 = input.getAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                const RtTypedValue* uiVisible2 = nodedefInput.getAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
-                const bool uiHidden1 = uiVisible1 && !uiVisible1->asBool();
-                const bool uiHidden2 = uiVisible2 && !uiVisible2->asBool();
+                const bool uiHidden1 = input.isUIVisible();
+                const bool uiHidden2 = nodedefInput.isUIVisible();
                 const bool writeUiVisibleData = uiHidden1 != uiHidden2;
 
                 // Write input if it's connected or different from default value.

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -204,6 +204,10 @@ namespace
             {
                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                 port = schema.createInput(portName, portType, flags);
+                RtTypedValue* attr = port.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+                bool& boolValue = attr->asBool();
+                boolValue = false;
+
             }
 
             if (port)

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -204,7 +204,8 @@ namespace
             {
                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                 port = schema.createInput(portName, portType, flags);
-                elem->setAttribute("uivisible", "false");
+                RtTypedValue* attr = port.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+                attr->asBool() = false;
             }
 
             if (port)
@@ -493,7 +494,19 @@ namespace
                         if (!socket)
                         {
                             const RtIdentifier inputType(elem->getType());
-                            RtInput input = nodegraph.createInput(socketName, inputType);
+
+                            RtInput input = RtInput();
+                            if (elem->isA<Token>())
+                            {
+                                const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
+                                input = nodegraph.createInput(socketName, inputType, flags);
+                                RtTypedValue* attr = input.createAttribute(Identifiers::UIVISIBLE, RtType::BOOLEAN);
+                                attr->asBool() = false;
+                            }
+                            else
+                            {
+                                input = nodegraph.createInput(socketName, inputType);
+                            }
                             socket = nodegraph.getInputSocket(input.getName());
 
                             // Set the input value

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -499,7 +499,6 @@ namespace
                             {
                                 const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
                                 input = nodegraph.createInput(socketName, inputType, flags);
-                                //port.setIsUIVisible(false);
                             }
                             else
                             {

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -200,6 +200,11 @@ namespace
                 const uint32_t flags = elem->asA<Input>()->getIsUniform() ? RtPortFlag::UNIFORM : 0;
                 port = schema.createInput(portName, portType, flags);
             }
+            else if (elem->isA<Token>())
+            {
+                const uint32_t flags = RtPortFlag::UNIFORM | RtPortFlag::TOKEN;
+                port = schema.createInput(portName, portType, flags);
+            }
 
             if (port)
             {
@@ -901,7 +906,16 @@ namespace
         for (PvtObject* obj : src->getInputs())
         {
             const PvtInput* input = obj->asA<PvtInput>();
-            ValueElementPtr destPort = destNodeDef->addInput(input->getName().str(), input->getType().str());
+            ValueElementPtr destPort = nullptr;
+            if (input->isToken())
+            {
+                destPort = destNodeDef->addToken(input->getName().str());
+                destPort->setType(input->getType().str());
+            }
+            else
+            {
+                destPort = destNodeDef->addInput(input->getName().str(), input->getType().str());
+            }
             if (input->isUniform())
             {
                 destPort->setIsUniform(true);
@@ -955,7 +969,15 @@ namespace
                     ValueElementPtr valueElem;
                     if (input.isUniform())
                     {
-                        valueElem = destNode->addInput(input.getName().str(), input.getType().str());
+                        if (input.isToken())
+                        {
+                            valueElem = destNode->addToken(input.getName().str());
+                            valueElem->setType(input.getType().str());
+                        }
+                        else
+                        {
+                            valueElem = destNode->addInput(input.getName().str(), input.getType().str());
+                        }
                         valueElem->setIsUniform(true);
                         if (input.isConnected())
                         {
@@ -1049,7 +1071,15 @@ namespace
                 ValueElementPtr v = nullptr;
                 if (nodegraphInput.isUniform())
                 {
-                    v = destNodeGraph->addInput(nodegraphInput.getName().str(), nodegraphInput.getType().str());
+                    if (nodegraphInput.isToken())
+                    {
+                        v = destNodeGraph->addToken(nodegraphInput.getName().str());
+                        v->setType(nodegraphInput.getType().str());
+                    }
+                    else
+                    {
+                        v = destNodeGraph->addInput(nodegraphInput.getName().str(), nodegraphInput.getType().str());
+                    }
                     v->setIsUniform(true);
                 }
                 else

--- a/source/MaterialXRuntime/RtPort.cpp
+++ b/source/MaterialXRuntime/RtPort.cpp
@@ -108,6 +108,16 @@ void RtInput::setIsToken(bool uniform)
     hnd()->asA<PvtInput>()->setIsToken(uniform);
 }
 
+bool RtInput::isUIVisible() const
+{
+    return hnd()->asA<PvtInput>()->isUIVisible();
+}
+
+void RtInput::setIsUIVisible(bool val)
+{
+    hnd()->asA<PvtInput>()->setIsUIVisible(val);
+}
+
 bool RtInput::isConnected() const
 {
     return hnd()->asA<PvtInput>()->isConnected();

--- a/source/MaterialXRuntime/RtPort.cpp
+++ b/source/MaterialXRuntime/RtPort.cpp
@@ -85,8 +85,6 @@ bool RtPort::isToken() const
 
 void RtPort::setIsToken(bool uniform)
 {
-    // Tokens are always uniforms
-    //hnd()->asA<PvtPort>()->setUniform(uniform);
     hnd()->asA<PvtPort>()->setIsToken(uniform);
 }
 

--- a/source/MaterialXRuntime/RtPort.cpp
+++ b/source/MaterialXRuntime/RtPort.cpp
@@ -78,6 +78,18 @@ void RtPort::setUnitType(const RtIdentifier& unit)
     return hnd()->asA<PvtPort>()->setUnitType(unit);
 }
 
+bool RtPort::isToken() const
+{
+    return hnd()->asA<PvtInput>()->isToken();
+}
+
+void RtPort::setIsToken(bool uniform)
+{
+    // Tokens are always uniforms
+    //hnd()->asA<PvtPort>()->setUniform(uniform);
+    hnd()->asA<PvtPort>()->setIsToken(uniform);
+}
+
 
 RT_DEFINE_RUNTIME_OBJECT(RtInput, RtObjType::INPUT, "RtInput")
 
@@ -94,18 +106,6 @@ bool RtInput::isUniform() const
 void RtInput::setUniform(bool uniform)
 {
     hnd()->asA<PvtInput>()->setUniform(uniform);
-}
-
-bool RtInput::isToken() const
-{
-    return hnd()->asA<PvtInput>()->isToken();
-}
-
-void RtInput::setIsToken(bool uniform)
-{
-    // Tokens are always uniforms
-    hnd()->asA<PvtInput>()->setUniform(uniform);
-    hnd()->asA<PvtInput>()->setIsToken(uniform);
 }
 
 bool RtInput::isUIVisible() const

--- a/source/MaterialXRuntime/RtPort.cpp
+++ b/source/MaterialXRuntime/RtPort.cpp
@@ -80,7 +80,7 @@ void RtPort::setUnitType(const RtIdentifier& unit)
 
 bool RtPort::isToken() const
 {
-    return hnd()->asA<PvtInput>()->isToken();
+    return hnd()->asA<PvtPort>()->isToken();
 }
 
 void RtPort::setIsToken(bool uniform)

--- a/source/MaterialXRuntime/RtPort.cpp
+++ b/source/MaterialXRuntime/RtPort.cpp
@@ -96,6 +96,18 @@ void RtInput::setUniform(bool uniform)
     hnd()->asA<PvtInput>()->setUniform(uniform);
 }
 
+bool RtInput::isToken() const
+{
+    return hnd()->asA<PvtInput>()->isToken();
+}
+
+void RtInput::setIsToken(bool uniform)
+{
+    // Tokens are always uniforms
+    hnd()->asA<PvtInput>()->setUniform(uniform);
+    hnd()->asA<PvtInput>()->setIsToken(uniform);
+}
+
 bool RtInput::isConnected() const
 {
     return hnd()->asA<PvtInput>()->isConnected();

--- a/source/MaterialXRuntime/RtPort.h
+++ b/source/MaterialXRuntime/RtPort.h
@@ -83,6 +83,12 @@ public:
 
     /// Set the unit type for this port.
     void setUnitType(const RtIdentifier& unit);
+
+    /// Return true if this input is a token.
+    bool isToken() const;
+
+    /// Sets the input to be a token or not a token
+    void setIsToken(bool val);
 };
 
 
@@ -105,12 +111,6 @@ public:
 
     /// Sets the input to be a uniform or not a uniform
     void setUniform(bool uniform);
-
-    /// Return true if this input is a token.
-    bool isToken() const;
-
-    /// Sets the input to be a token or not a token
-    void setIsToken(bool val);
 
     /// Return true if this input should be visible in the UI.
     bool isUIVisible() const;

--- a/source/MaterialXRuntime/RtPort.h
+++ b/source/MaterialXRuntime/RtPort.h
@@ -29,6 +29,9 @@ public:
 
     /// Port is a nodegraph internal socket.
     static const uint32_t SOCKET      = 0x00000002;
+
+    /// Port holds a token
+    static const uint32_t TOKEN       = 0x00000004;
 };
 
 /// @class RtPort
@@ -102,6 +105,12 @@ public:
 
     /// Sets the input to be a uniform or not a uniform
     void setUniform(bool uniform);
+
+    /// Return true if this input is a token.
+    bool isToken() const;
+
+    /// Sets the input to be a token or not a token
+    void setIsToken(bool val);
 
     /// Return true if this input is connected.
     bool isConnected() const;

--- a/source/MaterialXRuntime/RtPort.h
+++ b/source/MaterialXRuntime/RtPort.h
@@ -112,6 +112,12 @@ public:
     /// Sets the input to be a token or not a token
     void setIsToken(bool val);
 
+    /// Return true if this input should be visible in the UI.
+    bool isUIVisible() const;
+
+    /// Sets the input's visibilit in the UI.
+    void setIsUIVisible(bool val);
+
     /// Return true if this input is connected.
     bool isConnected() const;
 

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -189,11 +189,16 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
     for (RtInput input : nodegraph.getInputs())
     {
         RtInput nodedefInput = nodedef.createInput(input.getName(), input.getType());
-        nodedefInput.setUniform(input.isUniform());
+        PvtObject *src = PvtObject::cast(input);
+        for (const RtIdentifier& name : src->getAttributeNames())
+        {
+            const RtTypedValue* srcAttr = src->getAttribute(name);
+            RtTypedValue* destAttr = nodedefInput.createAttribute(name, srcAttr->getType());
+            RtValue::copy(srcAttr->getType(), srcAttr->getValue(), destAttr->getValue());
+        }
+        nodedefInput.setIsToken(input.isToken());
         RtValue::copy(input.getType(), input.getValue(), nodedefInput.getValue());
     }
-
-    // TODO : Add support for tokens
 
     // Add an output per nodegraph output
     for (RtOutput output : nodegraph.getOutputs())

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -1303,6 +1303,7 @@ TEST_CASE("Runtime: FileIo NodeGraph", "[runtime]")
     graph.createInput(TOKEN1, mx::RtType::FLOAT, mx::RtPortFlag::UNIFORM | mx::RtPortFlag::TOKEN);
     graph.createOutput(OUT, mx::RtType::FLOAT);
     mx::RtInput graphIn = graph.getInput(IN);
+    REQUIRE(graphIn.isUIVisible());
     graphIn.setIsUIVisible(false);
     REQUIRE(!graphIn.isUIVisible());
     mx::RtInput graphToken = graph.getInput(TOKEN1);

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -80,7 +80,7 @@ namespace
         }
     };
 
-    // Commonly used tokens.
+    // Commonly used identifiers.
     const mx::RtIdentifier X("x");
     const mx::RtIdentifier Y("y");
     const mx::RtIdentifier Z("z");
@@ -95,6 +95,7 @@ namespace
     const mx::RtIdentifier IN3("in3");
     const mx::RtIdentifier OUT("out");
     const mx::RtIdentifier IN("in");
+    const mx::RtIdentifier TOKEN1("token1");
     const mx::RtIdentifier REFLECTIVITY("reflectivity");
     const mx::RtIdentifier SURFACESHADER("surfaceshader");
     const mx::RtIdentifier UIFOLDER("uifolder");
@@ -156,7 +157,7 @@ TEST_CASE("Runtime: Material Element Upgrade", "[runtime]")
     }
 }
 
-TEST_CASE("Runtime: Token", "[runtime]")
+TEST_CASE("Runtime: Identifiers", "[runtime]")
 {
     mx::RtIdentifier tok1("hej");
     mx::RtIdentifier tok2("hey");
@@ -1299,20 +1300,35 @@ TEST_CASE("Runtime: FileIo NodeGraph", "[runtime]")
     // Create a nodegraph.
     mx::RtNodeGraph graph = stage->createPrim(mx::RtNodeGraph::typeName());
     graph.createInput(IN, mx::RtType::FLOAT);
+    graph.createInput(TOKEN1, mx::RtType::FLOAT, mx::RtPortFlag::UNIFORM | mx::RtPortFlag::TOKEN);
     graph.createOutput(OUT, mx::RtType::FLOAT);
     mx::RtInput graphIn = graph.getInput(IN);
+    graphIn.setIsUIVisible(false);
+    REQUIRE(!graphIn.isUIVisible());
+    mx::RtInput graphToken = graph.getInput(TOKEN1);
+    REQUIRE(graphToken.isUniform());
     mx::RtOutput graphOut = graph.getOutput(OUT);
     mx::RtOutput graphInSocket = graph.getInputSocket(IN);
+    mx::RtOutput graphTokenSocket = graph.getInputSocket(TOKEN1);
     mx::RtInput graphOutSocket = graph.getOutputSocket(OUT);
     REQUIRE(graphIn);
+    REQUIRE(graphToken);
     REQUIRE(graphOut);
     REQUIRE(graphInSocket);
+    REQUIRE(graphTokenSocket);
     REQUIRE(graphOutSocket);
 
     // Add nodes to the graph.
     const mx::RtIdentifier ADD_FLOAT_NODEDEF("ND_add_float");
     mx::RtNode add1 = stage->createPrim(graph.getPath(), NONAME, ADD_FLOAT_NODEDEF);
     mx::RtNode add2 = stage->createPrim(graph.getPath(), NONAME, ADD_FLOAT_NODEDEF);
+    try {
+        graphTokenSocket.connect(add1.getInput(IN1));
+    }
+    catch (mx::Exception&)
+    {
+    }
+    REQUIRE(!graphTokenSocket.isConnected());
     graphInSocket.connect(add1.getInput(IN1));
     add1.getOutput(OUT).connect(add2.getInput(IN1));
     add2.getOutput(OUT).connect(graphOutSocket);


### PR DESCRIPTION
Update #1159

Add in support for `<token>` as a runtime "input" which is marked as a token.

Example nodegraph with token called `mytoken` which is marked as non-visible.
```
<?xml version="1.0"?>
<materialx version="1.38">
  <nodegraph name="Tokenized_graph" xpos="1044.25" ypos="852.077" >
    <token name="mytoken" type="color3" value="1, 1, 1" uivisible="false" uiname="My Token"/>
    <input name="value" type="color3" value="0, 0, 0" uivisible="false"/>
    <constant name="constant" type="color3" xpos="-136.498" ypos="-120.44">
      <input name="value" type="color3" interfacename="value" value="0, 0, 0" uivisible="true" />
    </constant>
    <output name="out" type="color3" nodename="constant" />
  </nodegraph>
  <collection name="defaultCollection" includecollection="" includegeom="/*" xpos="315" ypos="229" />
</materialx>
```

Would look like this graphically:
![image](https://user-images.githubusercontent.com/14275104/113314719-98dbce80-92da-11eb-93b5-30dda42f0205.png)

With the contents looking like this (token in "neon pink").
![image](https://user-images.githubusercontent.com/14275104/113340569-0e0acc00-92fa-11eb-96f0-c6e59a9fafc9.png)

Based on the current specification `<token>` elements are not connectable.

Unit test will produce this file:
```
<?xml version="1.0"?>
<materialx version="1.38">
  <nodegraph name="nodegraph1">
    <input name="in" type="float" value="0" />
    <token name="token1" type="float" uniform="true" value="0" />
    <add name="add" type="float">
      <input name="in1" type="float" interfacename="in" value="0" />
    </add>
    <add name="add1" type="float">
      <input name="in1" type="float" nodename="add" />
    </add>
    <add name="add2" type="float" />
    <output name="out" type="float" nodename="add1" />
  </nodegraph>
  <add name="add" type="float">
    <input name="in1" type="float" nodegraph="nodegraph1" />
  </add>
</materialx>
```