### PR TITLE
Add type checks for RtTypedValue access in debug builds.

### DIFF
--- a/source/MaterialXRuntime/Library.h
+++ b/source/MaterialXRuntime/Library.h
@@ -51,6 +51,14 @@ public:
     using Exception::Exception;
 };
 
+/// @class ExceptionRuntimeTypeError
+/// An exception that is thrown when a type incompatibility error occur.
+class ExceptionRuntimeTypeError : public ExceptionRuntimeError
+{
+public:
+    using ExceptionRuntimeError::ExceptionRuntimeError;
+};
+
 /// A custom reinterpret cast function. To be used when casting between
 /// different interpretations of the same bits. This is a safer way to
 /// re-interpret the bits. The standard method of casting the address may

--- a/source/MaterialXRuntime/Private/PvtObject.h
+++ b/source/MaterialXRuntime/Private/PvtObject.h
@@ -84,7 +84,7 @@ public:
         }
         if (!isCompatible(T::classType()))
         {
-            throw ExceptionRuntimeError("Types are incompatible for type cast, '" + getName().str() + "' is not a '" + T::className().str() + "'");
+            throw ExceptionRuntimeTypeError("Types are incompatible for type cast, '" + getName().str() + "' is not a '" + T::className().str() + "'");
         }
 // #endif
         return static_cast<T*>(this);

--- a/source/MaterialXRuntime/RtType.cpp
+++ b/source/MaterialXRuntime/RtType.cpp
@@ -1,0 +1,42 @@
+//
+// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRuntime/RtType.h>
+
+namespace MaterialX
+{
+
+const RtIdentifier RtType::BOOLEAN("boolean");
+const RtIdentifier RtType::INTEGER("integer");
+const RtIdentifier RtType::FLOAT("float");
+const RtIdentifier RtType::VECTOR2("vector2");
+const RtIdentifier RtType::VECTOR3("vector3");
+const RtIdentifier RtType::VECTOR4("vector4");
+const RtIdentifier RtType::COLOR3("color3");
+const RtIdentifier RtType::COLOR4("color4");
+const RtIdentifier RtType::MATRIX33("matrix33");
+const RtIdentifier RtType::MATRIX44("matrix44");
+const RtIdentifier RtType::IDENTIFIER("identifier");
+const RtIdentifier RtType::STRING("string");
+const RtIdentifier RtType::FILENAME("filename");
+const RtIdentifier RtType::INTEGERARRAY("integerarray");
+const RtIdentifier RtType::FLOATARRAY("floatarray");
+const RtIdentifier RtType::COLOR3ARRAY("color3array");
+const RtIdentifier RtType::COLOR4ARRAY("color4array");
+const RtIdentifier RtType::VECTOR2ARRAY("vector2array");
+const RtIdentifier RtType::VECTOR3ARRAY("vector3array");
+const RtIdentifier RtType::VECTOR4ARRAY("vector4array");
+const RtIdentifier RtType::STRINGARRAY("stringarray");
+const RtIdentifier RtType::BSDF("BSDF");
+const RtIdentifier RtType::EDF("EDF");
+const RtIdentifier RtType::VDF("VDF");
+const RtIdentifier RtType::SURFACESHADER("surfaceshader");
+const RtIdentifier RtType::VOLUMESHADER("volumeshader");
+const RtIdentifier RtType::DISPLACEMENTSHADER("displacementshader");
+const RtIdentifier RtType::LIGHTSHADER("lightshader");
+const RtIdentifier RtType::MATERIAL("material");
+const RtIdentifier RtType::AUTO("auto");
+
+}

--- a/source/MaterialXRuntime/RtType.h
+++ b/source/MaterialXRuntime/RtType.h
@@ -1,0 +1,56 @@
+//
+// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_RTTYPE_H
+#define MATERIALX_RTTYPE_H
+
+/// @file
+/// Identifiers for runtime data types.
+
+#include <MaterialXRuntime/Library.h>
+#include <MaterialXRuntime/RtIdentifier.h>
+
+namespace MaterialX
+{
+
+/// Class holding identifiers for the built in data types.
+class RtType
+{
+public:
+    static const RtIdentifier BOOLEAN;
+    static const RtIdentifier INTEGER;
+    static const RtIdentifier FLOAT;
+    static const RtIdentifier VECTOR2;
+    static const RtIdentifier VECTOR3;
+    static const RtIdentifier VECTOR4;
+    static const RtIdentifier COLOR3;
+    static const RtIdentifier COLOR4;
+    static const RtIdentifier MATRIX33;
+    static const RtIdentifier MATRIX44;
+    static const RtIdentifier IDENTIFIER;
+    static const RtIdentifier STRING;
+    static const RtIdentifier FILENAME;
+    static const RtIdentifier INTEGERARRAY;
+    static const RtIdentifier FLOATARRAY;
+    static const RtIdentifier COLOR3ARRAY;
+    static const RtIdentifier COLOR4ARRAY;
+    static const RtIdentifier VECTOR2ARRAY;
+    static const RtIdentifier VECTOR3ARRAY;
+    static const RtIdentifier VECTOR4ARRAY;
+    static const RtIdentifier STRINGARRAY;
+    static const RtIdentifier BSDF;
+    static const RtIdentifier EDF;
+    static const RtIdentifier VDF;
+    static const RtIdentifier SURFACESHADER;
+    static const RtIdentifier VOLUMESHADER;
+    static const RtIdentifier DISPLACEMENTSHADER;
+    static const RtIdentifier LIGHTSHADER;
+    static const RtIdentifier MATERIAL;
+    static const RtIdentifier AUTO;
+};
+
+} // namespace MaterialX
+
+#endif

--- a/source/MaterialXRuntime/RtTypeDef.cpp
+++ b/source/MaterialXRuntime/RtTypeDef.cpp
@@ -10,37 +10,6 @@
 namespace MaterialX
 {
 
-const RtIdentifier RtType::BOOLEAN("boolean");
-const RtIdentifier RtType::INTEGER("integer");
-const RtIdentifier RtType::FLOAT("float");
-const RtIdentifier RtType::VECTOR2("vector2");
-const RtIdentifier RtType::VECTOR3("vector3");
-const RtIdentifier RtType::VECTOR4("vector4");
-const RtIdentifier RtType::COLOR3("color3");
-const RtIdentifier RtType::COLOR4("color4");
-const RtIdentifier RtType::MATRIX33("matrix33");
-const RtIdentifier RtType::MATRIX44("matrix44");
-const RtIdentifier RtType::IDENTIFIER("identifier");
-const RtIdentifier RtType::STRING("string");
-const RtIdentifier RtType::FILENAME("filename");
-const RtIdentifier RtType::INTEGERARRAY("integerarray");
-const RtIdentifier RtType::FLOATARRAY("floatarray");
-const RtIdentifier RtType::COLOR3ARRAY("color3array");
-const RtIdentifier RtType::COLOR4ARRAY("color4array");
-const RtIdentifier RtType::VECTOR2ARRAY("vector2array");
-const RtIdentifier RtType::VECTOR3ARRAY("vector3array");
-const RtIdentifier RtType::VECTOR4ARRAY("vector4array");
-const RtIdentifier RtType::STRINGARRAY("stringarray");
-const RtIdentifier RtType::BSDF("BSDF");
-const RtIdentifier RtType::EDF("EDF");
-const RtIdentifier RtType::VDF("VDF");
-const RtIdentifier RtType::SURFACESHADER("surfaceshader");
-const RtIdentifier RtType::VOLUMESHADER("volumeshader");
-const RtIdentifier RtType::DISPLACEMENTSHADER("displacementshader");
-const RtIdentifier RtType::LIGHTSHADER("lightshader");
-const RtIdentifier RtType::MATERIAL("material");
-const RtIdentifier RtType::AUTO("auto");
-
 const RtIdentifier RtTypeDef::BASETYPE_NONE("none");
 const RtIdentifier RtTypeDef::BASETYPE_BOOLEAN("boolean");
 const RtIdentifier RtTypeDef::BASETYPE_FLOAT("float");

--- a/source/MaterialXRuntime/RtTypeDef.h
+++ b/source/MaterialXRuntime/RtTypeDef.h
@@ -16,56 +16,20 @@
 namespace MaterialX
 {
 
-/// Class holding identifiers for the built in data types.
-class RtType
-{
-public:
-    static const RtIdentifier BOOLEAN;
-    static const RtIdentifier INTEGER;
-    static const RtIdentifier FLOAT;
-    static const RtIdentifier VECTOR2;
-    static const RtIdentifier VECTOR3;
-    static const RtIdentifier VECTOR4;
-    static const RtIdentifier COLOR3;
-    static const RtIdentifier COLOR4;
-    static const RtIdentifier MATRIX33;
-    static const RtIdentifier MATRIX44;
-    static const RtIdentifier IDENTIFIER;
-    static const RtIdentifier STRING;
-    static const RtIdentifier FILENAME;
-    static const RtIdentifier INTEGERARRAY;
-    static const RtIdentifier FLOATARRAY;
-    static const RtIdentifier COLOR3ARRAY;
-    static const RtIdentifier COLOR4ARRAY;
-    static const RtIdentifier VECTOR2ARRAY;
-    static const RtIdentifier VECTOR3ARRAY;
-    static const RtIdentifier VECTOR4ARRAY;
-    static const RtIdentifier STRINGARRAY;
-    static const RtIdentifier BSDF;
-    static const RtIdentifier EDF;
-    static const RtIdentifier VDF;
-    static const RtIdentifier SURFACESHADER;
-    static const RtIdentifier VOLUMESHADER;
-    static const RtIdentifier DISPLACEMENTSHADER;
-    static const RtIdentifier LIGHTSHADER;
-    static const RtIdentifier MATERIAL;
-    static const RtIdentifier AUTO;
-};
-
 /// Function type for creating a value of a specific data type.
-using RtValueCreateFunc = std::function<RtValue(RtPrim & owner)>;
+using RtValueCreateFunc = std::function<RtValue(RtPrim& owner)>;
 
 /// Function type for copying a value of a specific data type.
-using RtValueCopyFunc = std::function<void(const RtValue & src, RtValue & dest)>;
+using RtValueCopyFunc = std::function<void(const RtValue& src, RtValue& dest)>;
 
 /// Function type for comparing two values for equality.
-using RtValueCompareFunc = std::function<bool(const RtValue & a, const RtValue & b)>;
+using RtValueCompareFunc = std::function<bool(const RtValue& a, const RtValue& b)>;
 
 /// Function type for converting a value of a specific data type.
-using RtValueToStringFunc = std::function<void(const RtValue & src, string & dest)>;
+using RtValueToStringFunc = std::function<void(const RtValue& src, string& dest)>;
 
 /// Function type for converting a value of a specific data type.
-using RtValueFromStringFunc = std::function<void(const string & src, RtValue & dest)>;
+using RtValueFromStringFunc = std::function<void(const string& src, RtValue& dest)>;
 
 /// @struct RtValueFuncs
 /// Struct holding functions for creation and conversion

--- a/source/MaterialXRuntime/RtValue.h
+++ b/source/MaterialXRuntime/RtValue.h
@@ -10,7 +10,7 @@
 /// TODO: Docs
 
 #include <MaterialXRuntime/Library.h>
-#include <MaterialXRuntime/RtIdentifier.h>
+#include <MaterialXRuntime/RtType.h>
 
 #include <MaterialXCore/Types.h>
 
@@ -38,7 +38,6 @@ public:
     explicit RtValue(const Vector3& v) { asVector3() = v; }
     explicit RtValue(const Vector4& v) { asVector4() = v; }
     explicit RtValue(const RtIdentifier& v) { asIdentifier() = v; }
-    explicit RtValue(void* v) { asPtr() = v; }
 
     /// Explicit value constructor for large values.
     /// Allocated data is managed by the given prim.
@@ -143,17 +142,6 @@ public:
     RtIdentifier& asIdentifier()
     {
         return *_reinterpret_cast<RtIdentifier*>(&_data);
-    }
-
-    /// Return const pointer.
-    void* const& asPtr() const
-    {
-        return *_reinterpret_cast<void* const*>(&_data);
-    }
-    /// Return reference to pointer.
-    void*& asPtr()
-    {
-        return *_reinterpret_cast<void**>(&_data);
     }
 
     /// Return Matrix33 value.
@@ -288,143 +276,276 @@ public:
     /// Return bool value.
     const bool& asBool() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::BOOLEAN)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::BOOLEAN.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value .asBool();
     }
     /// Return reference to bool value.
     bool& asBool()
     {
+#ifndef NDEBUG
+        if (_type != RtType::BOOLEAN)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::BOOLEAN.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asBool();
     }
 
     /// Return int value.
     int asInt() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::INTEGER)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::INTEGER.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asInt();
     }
     /// Return reference to int value.
     int& asInt()
     {
+#ifndef NDEBUG
+        if (_type != RtType::INTEGER)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::INTEGER.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asInt();
     }
 
     /// Return float value.
     float asFloat() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::FLOAT)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::FLOAT.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asFloat();
     }
     /// Return reference to float value.
     float& asFloat()
     {
+#ifndef NDEBUG
+        if (_type != RtType::FLOAT)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::FLOAT.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asFloat();
     }
 
     /// Return Color3 value.
     const Color3& asColor3() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::COLOR3)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::COLOR3.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asColor3();
     }
     /// Return reference to Color3 value.
     Color3& asColor3()
     {
+#ifndef NDEBUG
+        if (_type != RtType::COLOR3)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::COLOR3.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asColor3();
     }
 
     /// Return Color4 value.
     const Color4& asColor4() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::COLOR4)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::COLOR4.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asColor4();
     }
     /// Return reference to Color4 value.
     Color4& asColor4()
     {
+#ifndef NDEBUG
+        if (_type != RtType::COLOR4)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::COLOR4.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asColor4();
     }
 
     /// Return Vector2 value.
     const Vector2& asVector2() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR2)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR2.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector2();
     }
     /// Return reference to Vector2 value.
     Vector2& asVector2()
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR2)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR2.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector2();
     }
 
     /// Return Vector3 value.
     const Vector3& asVector3() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR3)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR3.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector3();
     }
     /// Return reference to Vector3 value.
     Vector3& asVector3()
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR3)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR3.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector3();
     }
 
     /// Return Vector4 value.
     const Vector4& asVector4() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR4)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR4.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector4();
     }
     /// Return reference to Vector4 value.
     Vector4& asVector4()
     {
+#ifndef NDEBUG
+        if (_type != RtType::VECTOR4)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::VECTOR4.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asVector4();
     }
 
     /// Return identifier value.
     const RtIdentifier& asIdentifier() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::IDENTIFIER)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::IDENTIFIER.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asIdentifier();
     }
     /// Return reference to identifier value.
     RtIdentifier& asIdentifier()
     {
+#ifndef NDEBUG
+        if (_type != RtType::IDENTIFIER)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::IDENTIFIER.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asIdentifier();
-    }
-
-    /// Return const pointer.
-    void* const& asPtr() const
-    {
-        return _value.asPtr();
-    }
-    /// Return reference to pointer.
-    void*& asPtr()
-    {
-        return _value.asPtr();
     }
 
     /// Return Matrix33 value.
     const Matrix33& asMatrix33() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::MATRIX33)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::MATRIX33.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asMatrix33();
     }
     /// Return reference to Matrix33 value.
     Matrix33& asMatrix33()
     {
+#ifndef NDEBUG
+        if (_type != RtType::MATRIX33)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::MATRIX33.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asMatrix33();
     }
 
     /// Return Matrix44 value.
     const Matrix44& asMatrix44() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::MATRIX44)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::MATRIX44.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asMatrix44();
     }
     /// Return reference to Matrix44 value.
     Matrix44& asMatrix44()
     {
+#ifndef NDEBUG
+        if (_type != RtType::MATRIX44)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::MATRIX44.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asMatrix44();
     }
 
     /// Return string value.
     const string& asString() const
     {
+#ifndef NDEBUG
+        if (_type != RtType::STRING)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::STRING.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asString();
     }
     /// Return reference to string value.
     string& asString()
     {
+#ifndef NDEBUG
+        if (_type != RtType::STRING)
+        {
+            throw ExceptionRuntimeTypeError("Referencing a value as '" + RtType::STRING.str() + "' when the value is in fact a '" + _type.str() + "'");
+        }
+#endif
         return _value.asString();
     }
 

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -221,12 +221,6 @@ TEST_CASE("Runtime: Values", "[runtime]")
     mx::RtValue v4 = vector4;
     REQUIRE(v4.asVector4()[0] == 4.0f);
 
-    mx::RtValue ptr;
-    ptr.asPtr() = &vector4;
-    REQUIRE(ptr.asPtr() == &vector4);
-    ptr.clear();
-    REQUIRE(ptr.asPtr() == (void*)0);
-
     // Test creating large values.
     // An stage is needed to take ownership of allocated data.
     mx::RtStagePtr stage = api->createStage(MAIN);
@@ -241,6 +235,15 @@ TEST_CASE("Runtime: Values", "[runtime]")
     REQUIRE(mtx33.asMatrix33().isEquivalent(testmatrix, 1e-6f));
     mtx33.asMatrix33()[0][0] = 42.0f;
     REQUIRE(!mtx33.asMatrix33().isEquivalent(testmatrix, 1e-6f));
+
+#ifndef NDEBUG
+    // Test referencing a typed value with the wrong type.
+    // Should throw in debug builds where type check is done.
+    mx::RtTypedValue tval(mx::RtType::COLOR3, color3);
+    REQUIRE_THROWS(tval.asBool());
+    REQUIRE_THROWS(tval.asString());
+    REQUIRE_NOTHROW(tval.asColor3());
+#endif
 
     // Test unmarshalling values from string representations.
     // For small values (<=16byts) the same value instance can be reused
@@ -2461,7 +2464,7 @@ TEST_CASE("Runtime: Commands", "[runtime]")
     mx::RtCommand::setAttributeFromString(foo, metadata, metadataValue, attrResult);
     REQUIRE(attrResult);
     REQUIRE(foo.getAttribute(metadata));
-    REQUIRE(foo.getAttribute(metadata)->asIdentifier() == metadataValue);
+    REQUIRE(foo.getAttribute(metadata)->asString() == metadataValue);
     REQUIRE(setAttributeCount == 1);
     REQUIRE(removeAttributeCount == 0);
 
@@ -2474,7 +2477,7 @@ TEST_CASE("Runtime: Commands", "[runtime]")
     mx::RtCommand::redo(result);
     REQUIRE(result);
     REQUIRE(foo.getAttribute(metadata));
-    REQUIRE(foo.getAttribute(metadata)->asIdentifier() == metadataValue);
+    REQUIRE(foo.getAttribute(metadata)->asString() == metadataValue);
     REQUIRE(setAttributeCount == 2);
     REQUIRE(removeAttributeCount == 1);
 


### PR DESCRIPTION
Add type checks to find issues with value types mismatching. Only enabled in debug builds to avoid a performance cost in release builds, but bugs can be found in debug builds.