### PR TITLE
Add utility to check for valid MaterialX namespace.

### DIFF
--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -55,6 +55,11 @@ bool isValidName(const string& name)
     return it == name.end();
 }
 
+bool isValidNamespace(const string& name)
+{
+    return isValidName(name) && name.find(':') == std::string::npos;
+}
+
 string incrementName(const string& name)
 {
     size_t split = name.length();

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -29,6 +29,9 @@ MX_CORE_API string createValidName(string name, char replaceChar = '_');
 /// Return true if the given string is a valid MaterialX name.
 MX_CORE_API bool isValidName(const string& name);
 
+/// Return true if the given string is a valid MaterialX namespace.
+bool isValidNamespace(const string& name);
+
 /// Increment the numeric suffix of a name
 MX_CORE_API string incrementName(const string& name);
 

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -30,7 +30,7 @@ MX_CORE_API string createValidName(string name, char replaceChar = '_');
 MX_CORE_API bool isValidName(const string& name);
 
 /// Return true if the given string is a valid MaterialX namespace.
-bool isValidNamespace(const string& name);
+MX_CORE_API bool isValidNamespace(const string& name);
 
 /// Increment the numeric suffix of a name
 MX_CORE_API string incrementName(const string& name);


### PR DESCRIPTION
The code checking for valid namespace is moved from the Compound publishing dialog to the MaterialX Utilities.