### PR TITLE
JS Bindings: Conveniently bind functions with optional parameters

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsDocument.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsDocument.cpp
@@ -7,6 +7,8 @@
 namespace ems = emscripten;
 namespace mx = MaterialX;
 
+using stRef = const std::string&;
+
 extern "C"
 {
     EMSCRIPTEN_BINDINGS(document)
@@ -23,29 +25,29 @@ extern "C"
                           int size = referenced.size();
                           return arrayToVec((std::string *)&referenced, size);
                       }))
-            .function("addNodeGraph", &mx::Document::addNodeGraph)
+            BIND_CLASS_FUNC("addNodeGraph", mx::Document, addNodeGraph, 0, 1, stRef)
             .function("getNodeGraph", &mx::Document::getNodeGraph)
             .function("getNodeGraphs", &mx::Document::getNodeGraphs)
             .function("removeNodeGraph", &mx::Document::removeNodeGraph)
             .function("getMatchingPorts", &mx::Document::getMatchingPorts)
-            .function("addGeomInfo", &mx::Document::addGeomInfo)
+            BIND_CLASS_FUNC("addGeomInfo", mx::Document, addGeomInfo, 0, 2, stRef, stRef)
             .function("getGeomInfo", &mx::Document::getGeomInfo)
             .function("getGeomInfos", &mx::Document::getGeomInfos)
             .function("removeGeomInfo", &mx::Document::removeGeomInfo)
-            .function("getGeomPropValue", &mx::Document::getGeomPropValue)
+            BIND_CLASS_FUNC("getGeomPropValue", mx::Document, getGeomPropValue, 1, 2, stRef, stRef)
             .function("addGeomPropDef", &mx::Document::addGeomPropDef)
             .function("getGeomPropDef", &mx::Document::getGeomPropDef)
             .function("getGeomPropDefs", &mx::Document::getGeomPropDefs)
             .function("removeGeomPropDef", &mx::Document::removeGeomPropDef)
-            .function("addLook", &mx::Document::addLook)
+            BIND_CLASS_FUNC("addLook", mx::Document, addLook, 0, 1, stRef)
             .function("getLook", &mx::Document::getLook)
             .function("getLooks", &mx::Document::getLooks)
             .function("removeLook", &mx::Document::removeLook)
-            .function("addLookGroup", &mx::Document::addLookGroup)
+            BIND_CLASS_FUNC("addLookGroup", mx::Document, addLookGroup, 0, 1, stRef)
             .function("getLookGroup", &mx::Document::getLookGroup)
             .function("getLookGroups", &mx::Document::getLookGroups)
             .function("removeLookGroup", &mx::Document::removeLookGroup)
-            .function("addCollection", &mx::Document::addCollection)
+            BIND_CLASS_FUNC("addCollection", mx::Document, addCollection, 0, 1, stRef)
             .function("getCollection", &mx::Document::getCollection)
             .function("getCollections", &mx::Document::getCollections)
             .function("removeCollection", &mx::Document::removeCollection)
@@ -53,33 +55,23 @@ extern "C"
             .function("getTypeDef", &mx::Document::getTypeDef)
             .function("getTypeDefs", &mx::Document::getTypeDefs)
             .function("removeTypeDef", &mx::Document::removeTypeDef)
-            .function("addNodeDef", &mx::Document::addNodeDef)
-            .function("addNodeDefFromGraph", ems::optional_override([](mx::Document &self, 
-                                mx::NodeGraphPtr nodeGraph, std::string nodeDefName, std::string node,
-                                std::string version, bool isDefaultVersion, std::string nodeGroup, std::string newGraphName)
-                      {
-                          const std::string &nodeDefName1 = nodeDefName;
-                          const std::string &node1 = node;
-                          const std::string& version1 = version;
-                          const std::string &nodeGroup1 = nodeGroup;
-                          std::string &newGraphName1 = newGraphName;
-                          return self.addNodeDefFromGraph(nodeGraph, nodeDefName1, node1,
-                                                version1, isDefaultVersion, nodeGroup1, newGraphName1);
-                      }))
+            BIND_CLASS_FUNC("addNodeDef", mx::Document, addNodeDef, 0, 3, stRef, stRef, stRef)
+            BIND_CLASS_FUNC("addNodeDefFromGraph", mx::Document, addNodeDefFromGraph, 7, 8, const mx::NodeGraphPtr, 
+              stRef, stRef, stRef, bool, stRef, std::string, stRef)
             .function("getNodeDef", &mx::Document::getNodeDef)
             .function("getNodeDefs", &mx::Document::getNodeDefs)
             .function("removeNodeDef", &mx::Document::removeNodeDef)
             .function("getMatchingNodeDefs", &mx::Document::getMatchingNodeDefs)
             .function("getMatchingImplementations", &mx::Document::getMatchingImplementations)
-            .function("addPropertySet", &mx::Document::addPropertySet)
+            BIND_CLASS_FUNC("addPropertySet", mx::Document, addPropertySet, 0, 1, stRef)
             .function("getPropertySet", &mx::Document::getPropertySet)
             .function("getPropertySets", &mx::Document::getPropertySets)
             .function("removePropertySet", &mx::Document::removePropertySet)
-            .function("addVariantSet", &mx::Document::addVariantSet)
+            BIND_CLASS_FUNC("addVariantSet", mx::Document, addVariantSet, 0, 1, stRef)
             .function("getVariantSet", &mx::Document::getVariantSet)
             .function("getVariantSets", &mx::Document::getVariantSets)
             .function("removeVariantSet", &mx::Document::removeVariantSet)
-            .function("addImplementation", &mx::Document::addImplementation)
+            BIND_CLASS_FUNC("addImplementation", mx::Document, addImplementation, 0, 1, stRef)
             .function("getImplementation", &mx::Document::getImplementation)
             .function("getImplementations", &mx::Document::getImplementations)
             .function("removeImplementation", &mx::Document::removeImplementation)

--- a/source/JsMaterialX/JsMaterialXCore/JsDocument.js
+++ b/source/JsMaterialX/JsMaterialXCore/JsDocument.js
@@ -3,23 +3,6 @@ addWrapper(function(Module, api) {
     /** Setup the Document class */
     api.createDocument = wrapperFunction(Module.createDocument);
 
-    api.Document = wrapperFactory(Module.Document, {
-        addNodeGraph: [api.EMPTY_STRING],
-        getMatchingPorts: [REQUIRED],
-        addGeomInfo: [api.EMPTY_STRING, api.UNIVERSAL_GEOM_NAME],
-        getGeomPropValue: [REQUIRED, api.UNIVERSAL_GEOM_NAME],
-        addLook: [api.EMPTY_STRING],
-        addLookGroup: [api.EMPTY_STRING],
-        addCollection: [api.EMPTY_STRING],
-        getMatchingImplementations: [REQUIRED],
-        addPropertySet: [api.EMPTY_STRING],
-        addVariantSet: [api.EMPTY_STRING],
-        addTypeDef: [REQUIRED],
-        addNodeDef: [api.EMPTY_STRING, api.DEFAULT_TYPE_STRING, api.EMPTY_STRING],
-        getMatchingNodeDefs: [REQUIRED],
-        addImplementation: [api.EMPTY_STRING],
-        getGeomPropValue: [REQUIRED, api.UNIVERSAL_GEOM_NAME],
-        addNodeDefFromGraph: [REQUIRED, REQUIRED, REQUIRED, REQUIRED, REQUIRED, REQUIRED, REQUIRED, '']
-    });
+    api.Document = wrapperFactory(Module.Document);
 
 });

--- a/source/JsMaterialX/helpers.h
+++ b/source/JsMaterialX/helpers.h
@@ -1,3 +1,6 @@
+#ifndef JSMATERIALX_HELPERS_H
+#define JSMATERIALX_HELPERS_H
+
 #include <vector>
 
 template <class myClass>
@@ -6,3 +9,260 @@ std::vector<myClass> arrayToVec(myClass *arr, int size)
     std::vector<myClass> dest(arr, arr + size);
     return dest;
 }
+
+
+// Binding helpers
+
+/**
+ * Use this macro to conveniently create bindings for class member functions with optional parameters.
+ * @param JSNAME The name of the function in JavaScript, as a double-quoted string (e.g. "addNodeGraph").
+ * @param CLASSNAME The name (and scope) of the class that the member functions belongs to (e.g. mx::Document).
+ * @param FUNCNAME The name of the function to bind (e.g. addNodeGraph).
+ * @param MINARGS The minimal number of parameters that need to provided when calling the function (a.k.a # of required parameters).
+ * @param MAXARGS The total number of parameters that the function takes, including optional ones.
+ * @param ... The types of all parameters, as a comma-separated list (e.g. const std::string&, float, bool)
+ */
+#define BIND_CLASS_FUNC(JSNAME, CLASSNAME, FUNCNAME, MINARGS, MAXARGS, ...) \
+BIND_CLASS_FUNC_ ##MINARGS ## _ ##MAXARGS(JSNAME, CLASSNAME, FUNCNAME, __VA_ARGS__)
+
+#define BIND_CLASS_FUNC_8(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, TYPE4, TYPE5, TYPE6, TYPE7, TYPE8, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3, TYPE4 p4, TYPE5 p5, TYPE6 p6, TYPE7 p7, TYPE8 p8) { \
+    return self.FUNCNAME(p1, p2, p3, p4, p5, p6, p7, p8); \
+}))
+
+// 9 Macros for MAXARGS = 8
+#define BIND_CLASS_FUNC_8_8(...) \
+BIND_CLASS_FUNC_8(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_7_8(...) \
+BIND_CLASS_FUNC_8_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_7(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_6_8(...) \
+BIND_CLASS_FUNC_7_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_6(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_5_8(...) \
+BIND_CLASS_FUNC_6_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_5(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_4_8(...) \
+BIND_CLASS_FUNC_5_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_4(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_3_8(...) \
+BIND_CLASS_FUNC_4_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_8(...) \
+BIND_CLASS_FUNC_3_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_8(...) \
+BIND_CLASS_FUNC_2_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_8(...) \
+BIND_CLASS_FUNC_1_8(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_7(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, TYPE4, TYPE5, TYPE6, TYPE7, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3, TYPE4 p4, TYPE5 p5, TYPE6 p6, TYPE7 p7) { \
+    return self.FUNCNAME(p1, p2, p3, p4, p5, p6, p7); \
+}))
+
+// 8 Macros for MAXARGS = 7
+#define BIND_CLASS_FUNC_7_7(...) \
+BIND_CLASS_FUNC_7(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_6_7(...) \
+BIND_CLASS_FUNC_7_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_6(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_5_7(...) \
+BIND_CLASS_FUNC_6_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_5(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_4_7(...) \
+BIND_CLASS_FUNC_5_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_4(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_3_7(...) \
+BIND_CLASS_FUNC_4_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_7(...) \
+BIND_CLASS_FUNC_3_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_7(...) \
+BIND_CLASS_FUNC_2_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_7(...) \
+BIND_CLASS_FUNC_1_7(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_6(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, TYPE4, TYPE5, TYPE6, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3, TYPE4 p4, TYPE5 p5, TYPE6 p6) { \
+    return self.FUNCNAME(p1, p2, p3, p4, p5, p6); \
+}))
+
+// 7 Macros for MAXARGS = 6
+#define BIND_CLASS_FUNC_6_6(...) \
+BIND_CLASS_FUNC_6(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_5_6(...) \
+BIND_CLASS_FUNC_6_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_5(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_4_6(...) \
+BIND_CLASS_FUNC_5_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_4(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_3_6(...) \
+BIND_CLASS_FUNC_4_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_6(...) \
+BIND_CLASS_FUNC_3_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_6(...) \
+BIND_CLASS_FUNC_2_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_6(...) \
+BIND_CLASS_FUNC_1_6(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_5(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, TYPE4, TYPE5, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3, TYPE4 p4, TYPE5 p5) { \
+    return self.FUNCNAME(p1, p2, p3, p4, p5); \
+}))
+
+// 6 Macros for MAXARGS = 5
+#define BIND_CLASS_FUNC_5_5(...) \
+BIND_CLASS_FUNC_5(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_4_5(...) \
+BIND_CLASS_FUNC_5_5(__VA_ARGS__) \
+BIND_CLASS_FUNC_4(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_3_5(...) \
+BIND_CLASS_FUNC_4_5(__VA_ARGS__) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_5(...) \
+BIND_CLASS_FUNC_3_5(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_5(...) \
+BIND_CLASS_FUNC_2_5(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_5(...) \
+BIND_CLASS_FUNC_1_5(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_4(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, TYPE4, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3, TYPE4 p4) { \
+    return self.FUNCNAME(p1, p2, p3, p4); \
+}))
+
+// 5 Macros for MAXARGS = 4
+#define BIND_CLASS_FUNC_4_4(...) \
+BIND_CLASS_FUNC_4(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_3_4(...) \
+BIND_CLASS_FUNC_4_4(__VA_ARGS__) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_4(...) \
+BIND_CLASS_FUNC_3_4(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_4(...) \
+BIND_CLASS_FUNC_2_4(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_4(...) \
+BIND_CLASS_FUNC_1_4(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_3(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, TYPE3, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2, TYPE3 p3) { \
+    return self.FUNCNAME(p1, p2, p3); \
+}))
+
+// 4 Macros for MAXARGS = 3
+#define BIND_CLASS_FUNC_3_3(...) \
+BIND_CLASS_FUNC_3(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_2_3(...) \
+BIND_CLASS_FUNC_3_3(__VA_ARGS__) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_3(...) \
+BIND_CLASS_FUNC_2_3(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_3(...) \
+BIND_CLASS_FUNC_1_3(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_2(JSNAME, CLASSNAME, FUNCNAME, TYPE1, TYPE2, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, \
+  TYPE1 p1, TYPE2 p2) { \
+    return self.FUNCNAME(p1, p2); \
+}))
+
+// 3 Macros for MAXARGS = 2
+#define BIND_CLASS_FUNC_2_2(...) \
+BIND_CLASS_FUNC_2(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_1_2(...) \
+BIND_CLASS_FUNC_2_2(__VA_ARGS__) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_2(...) \
+BIND_CLASS_FUNC_1_2(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_1(JSNAME, CLASSNAME, FUNCNAME, TYPE1, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self, TYPE1 p1) { \
+    return self.FUNCNAME(p1); \
+}))
+
+// 2 Macros for MAXARGS = 1
+#define BIND_CLASS_FUNC_1_1(...) \
+BIND_CLASS_FUNC_1(__VA_ARGS__)
+
+#define BIND_CLASS_FUNC_0_1(...) \
+BIND_CLASS_FUNC_1_1(__VA_ARGS__) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+
+#define BIND_CLASS_FUNC_0(JSNAME, CLASSNAME, FUNCNAME, ...) \
+.function(JSNAME, ems::optional_override([](CLASSNAME &self) { \
+    return self.FUNCNAME(); \
+}))
+
+// 1 Macros for MAXARGS = 0
+#define BIND_CLASS_FUNC_0_0(...) \
+BIND_CLASS_FUNC_0(__VA_ARGS__)
+
+#endif // JSMATERIALX_HELPERS_H

--- a/source/JsMaterialX/initMaterialX.js
+++ b/source/JsMaterialX/initMaterialX.js
@@ -101,7 +101,11 @@ function wrapperFactory(klass, funcArgOverride = {}) {
         var funcName = funcNames[parseInt(i)];
         var apiFunc = proto[String(funcName)];
         var defaultArgs = funcArgOverride[String(funcName)];
-        proto[String(funcName)] = wrapperFunction(apiFunc, defaultArgs);
+        var wrapperFunc = wrapperFunction(apiFunc, defaultArgs);
+        for (const [key, value] of Object.entries(apiFunc)) {
+            wrapperFunc[key] = value;
+        }
+        proto[String(funcName)] = wrapperFunc;
     }
     return klass;
 }


### PR DESCRIPTION
This PR introduces a way to conveniently create bindings for functions with optional parameters. The following compares the old with the new approach:

Old: Create a single binding that expects all parameters, including optional ones (due to a limitation of Emscripten). Allow to not provide optional parameters by adding additional logic on the JavaScript side, which essentially fills in all non-provided optional parameters.

New: Use macros to automatically register multiple bindings for a function, each taking a different number of parameters. No additional maintenance required on the JS side. This has several advantages:
- Compatibility of bindings with the actual source code is asserted at compile time (except for the cases where a previously required parameter becomes optional, or an additional optional parameter is added to the end of a function's declaration).
- Bindings don't need to be maintained in two different places (JS and C++) anymore.

All functions of the `Document` class that had default parameters defined in the JS boilerplate code have been redefined for illustration purposes.

Furthermore, this PR fixes an issue with the JS boilerplate code, which broke the function overloading capabilities of Emscripten.

@sdunkel @kohakukun