### PR TITLE
Enable arm64 for macOS Xcode 12 build

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -30,7 +30,6 @@ jobs:
           compiler: xcode
           compiler_version: "11.7"
           python: 3.7
-          cmake_config: -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
         - name: MacOS_Xcode_12_Python37
           os: macos-10.15

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -30,12 +30,14 @@ jobs:
           compiler: xcode
           compiler_version: "11.7"
           python: 3.7
+          cmake_config: -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
         - name: MacOS_Xcode_12_Python37
           os: macos-10.15
           compiler: xcode
           compiler_version: "12.2"
           python: 3.7
+          cmake_config: -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
`lipo MaterialXView -detailed_info `
```

Fat header in: MaterialXView
fat_magic 0xcafebabe
nfat_arch 2
architecture x86_64
  cputype CPU_TYPE_X86_64
  cpusubtype CPU_SUBTYPE_X86_64_ALL
  capabilities 0x0
  offset 16384
  size 47879072
  align 2^14 (16384)
architecture arm64
  cputype CPU_TYPE_ARM64
  cpusubtype CPU_SUBTYPE_ARM64_ALL
  capabilities 0x0
  offset 47906816
  size 48289248
  align 2^15 (32768)
```