### PR TITLE
Throw if EsslShaderGenerator has access to a resource binding context

### DIFF
--- a/source/MaterialXGenEssl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenEssl/EsslShaderGenerator.cpp
@@ -47,7 +47,7 @@ BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
 END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
-void EsslShaderGenerator::emitUniforms(GenContext& context, ShaderStage& stage, HwResourceBindingContextPtr& resourceBindingCtx) const
+void EsslShaderGenerator::emitUniforms(GenContext& context, ShaderStage& stage, HwResourceBindingContextPtr&) const
 {
     for (const auto& it : stage.getUniformBlocks())
     {

--- a/source/MaterialXGenEssl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenEssl/EsslShaderGenerator.cpp
@@ -57,15 +57,8 @@ void EsslShaderGenerator::emitUniforms(GenContext& context, ShaderStage& stage, 
         if (!uniforms.empty() && uniforms.getName() != HW::LIGHT_DATA)
         {
             emitComment("Uniform block: " + uniforms.getName(), stage);
-            if (resourceBindingCtx)
-            {
-                resourceBindingCtx->emitResourceBindings(context, uniforms, stage);
-            }
-            else
-            {
-                emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage, false);
-                emitLineBreak(stage);
-            }
+            emitVariableDeclarations(uniforms, _syntax->getUniformQualifier(), Syntax::SEMICOLON, context, stage, false);
+            emitLineBreak(stage);
         }
     }
 }
@@ -114,6 +107,15 @@ END_SHADER_STAGE(stage, Stage::PIXEL)
 const string EsslShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
 {
     return "";
+}
+
+const HwResourceBindingContextPtr EsslShaderGenerator::getResourceBindingContext(GenContext& context) const
+{
+    HwResourceBindingContextPtr resoureBindingCtx = GlslShaderGenerator::getResourceBindingContext(context);
+    if (resoureBindingCtx) {
+      throw ExceptionShaderGenError("The EsslShaderGenerator does not support resource binding.");
+    }
+    return resoureBindingCtx;
 }
 
 }

--- a/source/MaterialXGenEssl/EsslShaderGenerator.h
+++ b/source/MaterialXGenEssl/EsslShaderGenerator.h
@@ -41,6 +41,7 @@ class EsslShaderGenerator : public GlslShaderGenerator
     void emitUniforms(GenContext& context, ShaderStage& stage, HwResourceBindingContextPtr &resourceBindingCtx) const override;
     void emitInputs(GenContext& context, ShaderStage& stage) const override;
     void emitOutpus(GenContext& context, ShaderStage& stage) const override;
+    const HwResourceBindingContextPtr getResourceBindingContext(GenContext& context) const override;
 };
 
 }

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -275,7 +275,7 @@ ShaderPtr GlslShaderGenerator::generate(const string& name, ElementPtr element, 
     ScopedFloatFormatting fmt(Value::FloatFormatFixed);
 
     // Make sure we initialize/reset the binding context before generation.
-    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    HwResourceBindingContextPtr resourceBindingCtx = getResourceBindingContext(context);
     if (resourceBindingCtx)
     {
         resourceBindingCtx->initialize();
@@ -296,7 +296,7 @@ ShaderPtr GlslShaderGenerator::generate(const string& name, ElementPtr element, 
 
 void GlslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const
 {
-    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    HwResourceBindingContextPtr resourceBindingCtx = getResourceBindingContext(context);
 
     emitDirectives(context, stage);
     if (resourceBindingCtx)
@@ -474,6 +474,11 @@ const string GlslShaderGenerator::getPixelStageOutputVariable(const ShaderGraphO
     return outputSocket.getVariable();
 }
 
+const HwResourceBindingContextPtr GlslShaderGenerator::getResourceBindingContext(GenContext& context) const
+{
+    return context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+}
+
 const string GlslShaderGenerator::getVertexDataPrefix(const VariableBlock& vertexData) const
 {
     return vertexData.getInstance() + ".";
@@ -481,7 +486,7 @@ const string GlslShaderGenerator::getVertexDataPrefix(const VariableBlock& verte
 
 void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const
 {
-    HwResourceBindingContextPtr resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
+    HwResourceBindingContextPtr resourceBindingCtx = getResourceBindingContext(context);
 
     // Add directives
     emitDirectives(context, stage);

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -68,6 +68,8 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     virtual void emitOutpus(GenContext& context, ShaderStage& stage) const;
 
     virtual const string getPixelStageOutputVariable(const ShaderGraphOutputSocket& outputSocket) const;
+    
+    virtual const HwResourceBindingContextPtr getResourceBindingContext(GenContext& context) const;
 
     virtual bool requiresLighting(const ShaderGraph& graph) const;
 


### PR DESCRIPTION
Resource bindings via a location qualifier are not supported on Webgl.