### PR TITLE
Stop rendering of baked documents.

### DIFF
--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -334,7 +334,8 @@ bool ShaderRenderTester::validate(const mx::FilePathVec& testRootPaths, const mx
                     if (doctoBake.bakeFile == outputBakeFile.asString())
                     {
                         outputBakeFile.removeExtension();
-                        outputBakeFile = outputPath / (outputBakeFile.asString() + "_baked.mtlx");
+                        // Bake to "xml" to avoid trying to render baked in render tests
+                        outputBakeFile = outputPath / (outputBakeFile.asString() + "_baked.xml");
                         runBake(doc, imageSearchPath, searchPath, outputBakeFile, doctoBake, log);
                         break;
 


### PR DESCRIPTION
Update #1245.
Patch to not write out baked document files with extension "mtlx" as these will be picked up later for rendering.
Use "xml" instead.
