### PR TITLE
fix: JSMaterialXView draco path

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -65,12 +65,6 @@ jobs:
         npm run test
       working-directory: build
 
-    - name: Upload Installed Package
-      uses: actions/upload-artifact@v2
-      with:
-        name: MaterialX_${{ matrix.name }}
-        path: build/installed/
-
     - name: Build Sample App
       if: github.ref == matrix.deploy_branch
       run: |

--- a/source/JsMaterialX/JsMaterialXView/src/index.js
+++ b/source/JsMaterialX/JsMaterialXView/src/index.js
@@ -125,7 +125,7 @@ function init() {
     // Load model and shaders
     const fileloader = new THREE.FileLoader();
     const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath( '/draco/' );
+    dracoLoader.setDecoderPath( 'draco/' );
     const gltfLoader = new GLTFLoader();
     gltfLoader.setDRACOLoader( dracoLoader );
     const hdrloader = new RGBELoader();


### PR DESCRIPTION
Use relative path instead of absolute to fix issue when loading draco loader
![image](https://user-images.githubusercontent.com/4264247/125434723-d60259b2-95ae-441b-b44f-d30c72731a1d.png)
