### PR TITLE
Expose names of transforms for UDIM texture atlases 

### DIFF
--- a/source/MaterialXGenShader/Nodes/HwImageNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.cpp
@@ -13,8 +13,8 @@
 namespace MaterialX
 {
 // Additional implementaton arguments for image nodes
-const string UV_SCALE = "uv_scale";
-const string UV_OFFSET = "uv_offset";
+string HwImageNode::UV_SCALE = "uv_scale";
+string HwImageNode::UV_OFFSET = "uv_offset";
 
 ShaderNodeImplPtr HwImageNode::create()
 {

--- a/source/MaterialXGenShader/Nodes/HwImageNode.h
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.h
@@ -19,6 +19,12 @@ public:
 
     void addInputs(ShaderNode& node, GenContext& context) const override;
     void setValues(const Node& node, ShaderNode& shaderNode, GenContext& context) const override;
+
+    // Aguments which may be added as part of the signature for image nodes
+    // to allow for additional texture coordinate transformations.
+    // Currently these are added to support UDIM texture atlas lookup.
+    static string UV_SCALE;
+    static string UV_OFFSET;
 };
 
 } // namespace MaterialX


### PR DESCRIPTION
Update #1144
Expose hardcoded UDIM transform names.
Currently used for texture atlas lookup but can be used for texture array lookup when that is supported.
