### PR TITLE
Ignore luminance connection in std surface for transparency heuristic.

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -144,9 +144,16 @@ namespace
                         return false;
                     }
                 }
-                if (checkInput->getConnectedNode())
+
+                // If mapped but not an adjustment then assume transparency
+                NodePtr inputNode = checkInput->getConnectedNode();
+                if (inputNode)
                 {
-                    return true;
+                    NodeDefPtr nodeDef = inputNode->getNodeDef();
+                    if (nodeDef && nodeDef->getAttribute(NodeDef::NODE_GROUP_ATTRIBUTE) != NodeDef::ADJUSTMENT_NODE_GROUP)
+                    {
+                        return true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Update #1280

Ignore "adjustment nodes" and assume they do not affect the transparency heuristic.
This handles the luminance connection in std surface.