### PR TITLE
t-rusel/LOOKDEVX-484/add prefernces option

### DIFF
--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -181,8 +181,11 @@ string getBaseCompoundName(const string& nodeName, const string& typeNames, cons
     std::ostringstream tempStream;
 
     tempStream << nodeName;
+
+    tempStream << "_";
     tempStream << typeNames;
 
+    tempStream << "_";
     tempStream << version;
 
     const bool isNameSpaced = !namespaceString.empty();   

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -6,6 +6,8 @@
 #include <MaterialXCore/Types.h>
 
 #include <cctype>
+#include <sstream>
+#include <iomanip> 
 
 namespace MaterialX
 {
@@ -173,6 +175,23 @@ string parentNamePath(const string& namePath)
         return createNamePath(nameVec);
     }
     return EMPTY_STRING;
+}
+
+string getBaseCompoundName(const string& nodeName, const string& typeNames, const string& version, const string& namespaceString) {
+    std::ostringstream tempStream;
+
+    tempStream << nodeName;
+    tempStream << typeNames;
+
+    tempStream << version;
+
+    const bool isNameSpaced = !namespaceString.empty();   
+    if (isNameSpaced) {
+        tempStream << "_";
+        tempStream << namespaceString;
+    }
+
+    return tempStream.str();
 }
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -70,7 +70,7 @@ MX_CORE_API string createNamePath(const StringVec& nameVec);
 /// Given a name path, return the parent name path
 MX_CORE_API string parentNamePath(const string& namePath);
 
-/// Generates the Base Compiund Name given the input
+/// Generates the Base Compound Name given the input
 MX_CORE_API string getBaseCompoundName(const string& nodeName, const string& typeNames, const string& version, const string& namespaceString);
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -70,6 +70,9 @@ MX_CORE_API string createNamePath(const StringVec& nameVec);
 /// Given a name path, return the parent name path
 MX_CORE_API string parentNamePath(const string& namePath);
 
+/// Generates the Base Compiund Name given the input
+MX_CORE_API string getBaseCompoundName(const string& nodeName, const string& typeNames, const string& version, const string& namespaceString);
+
 } // namespace MaterialX
 
 #endif

--- a/source/MaterialXTest/MaterialXCore/Unit.cpp
+++ b/source/MaterialXTest/MaterialXCore/Unit.cpp
@@ -216,7 +216,7 @@ TEST_CASE("UnitDocument", "[unit]")
 
 TEST_CASE("ComboundBaseName", "[compound]")
 {
-    const std::string baseName = mx::getBaseCompoundName("BaseName", "_color3", "_v1.0", "adsk");
+    const std::string baseName = mx::getBaseCompoundName("BaseName", "color3", "v1.0", "adsk");
 
     REQUIRE(baseName == "BaseName_color3_v1.0_adsk");
 }

--- a/source/MaterialXTest/MaterialXCore/Unit.cpp
+++ b/source/MaterialXTest/MaterialXCore/Unit.cpp
@@ -213,3 +213,10 @@ TEST_CASE("UnitDocument", "[unit]")
         }
     }
 }
+
+TEST_CASE("ComboundBaseName", "[compound]")
+{
+    const std::string baseName = mx::getBaseCompoundName("BaseName", "_color3", "_v1.0", "adsk");
+
+    REQUIRE(baseName == "BaseName_color3_v1.0_adsk");
+}


### PR DESCRIPTION
Move the function building the base compound name into MaterialX utils and add a basic test case.