### PR TITLE
Fix image pathing regression in viewer

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -313,7 +313,12 @@ void Viewer::initialize()
 #if MATERIALX_BUILD_OIIO
     _imageHandler->addLoader(mx::OiioImageLoader::create());
 #endif
-    _imageHandler->setSearchPath(_searchPath);
+    mx::FileSearchPath imageSearchPath = _searchPath;
+    for (auto ipath : _searchPath)
+    {
+        _searchPath.append(ipath / "libraries");
+    }
+    _imageHandler->setSearchPath(imageSearchPath);
 
     // Initialize user interfaces.
     createLoadMeshInterface(_window, "Load Mesh");


### PR DESCRIPTION
Fix regression dues to not considering "libraries" folder as root for texture paths for definitions.
