### PR TITLE
Fix non-deterministic Runtime test

### DIFF
--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -2543,6 +2543,7 @@ TEST_CASE("Runtime: graph output connection", "[runtime]")
 
     // Load in all libraries required for materials
     mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    searchPath.append(mx::FilePath::getCurrentPath() / RuntimeGlobals::LIBRARY_PATH());
     api->setSearchPath(searchPath);
     api->loadLibrary(CORE_LIBRARY_NAME, RuntimeGlobals::LIBRARY_PATH());
 


### PR DESCRIPTION
Add in missing search path. Ordering of tests may differ resulting in this test failing due to lack of path.