### PR TITLE
GlslResourceBindingContext option to separate binding locations 

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_math.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_math.glsl
@@ -63,11 +63,11 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D tex_sampler)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(sampler, uv, lod).rgb;
+    return textureLod(tex_sampler, uv, lod).rgb;
 }
 
 vec3 mx_forward_facing_normal(vec3 N, vec3 V)

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -32,6 +32,19 @@ void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage
 {
     ShaderGenerator& generator = context.getShaderGenerator();
 
+    // write shader stage directives for Vulkan compliance
+    if( _separateBindingLocation )
+    {
+        std::string shaderStage;
+        if( stage.getName() == Stage::VERTEX )
+            shaderStage = "vertex";
+        else if( stage.getName() == Stage::PIXEL )
+            shaderStage = "fragment";
+
+        if( shaderStage.length() > 0 )
+            generator.emitLine("#pragma shader_stage(" + shaderStage + ")", stage, false);
+    }
+
     for (auto& extension : _requiredExtensions)
     {
         generator.emitLine("#extension " + extension + " : enable", stage, false);
@@ -77,7 +90,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     {
         if (uniform->getType() == Type::FILENAME)
         {
-            generator.emitString("layout (binding=" + std::to_string(_hwSamplerBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
+            generator.emitString("layout (binding=" + std::to_string( _separateBindingLocation ? _hwUniformBindLocation++ : _hwSamplerBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
             generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);
             generator.emitLineEnd(stage, true);
         }

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -48,6 +48,9 @@ public:
         ShaderStage& stage, const std::string& structInstanceName,
         const std::string& arraySuffix) override;
 
+    // Emit separate binding locations for sampler and uniform table
+    void enableSeparateBindingLocations(bool separateBindingLocation) { _separateBindingLocation = separateBindingLocation; };
+
 protected:
     // List of required extensions
     StringSet _requiredExtensions;
@@ -63,6 +66,10 @@ protected:
 
     // Initial value of sampler binding location
     size_t _hwInitSamplerBindLocation = 0;
+
+    // Separate binding locations
+    // Shared binding counter for samplers and uniforms v/s separate 
+    bool _separateBindingLocation = false;
 
 };
 

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -155,7 +155,8 @@ GlslSyntax::GlslSyntax()
         "image1DShadow", "image2DShadow",
         "image1DArrayShadow", "image2DArrayShadow",
         "imageBuffer", "iimageBuffer", "uimageBuffer",
-        "sizeof", "cast", "namespace", "using", "row_major"
+        "sizeof", "cast", "namespace", "using", "row_major",
+        "sampler"
     });
 
     // Register restricted tokens in GLSL

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -145,7 +145,9 @@ static void generateGlslCode(bool generateLayout = false)
     if (generateLayout)
     {
         // Set binding context to handle resource binding layouts
-        tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, mx::GlslResourceBindingContext::create());
+        mx::GlslResourceBindingContextPtr glslresourceBinding(mx::GlslResourceBindingContext::create());
+        glslresourceBinding->enableSeparateBindingLocations(true);
+        tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, glslresourceBinding);
     }
 
     GenShaderUtil::TestSuiteOptions options;


### PR DESCRIPTION

Addresses an issue that we need to generate Vulkan semantics to generate Vulkan-compliant code. Also treat 'sampler' as a reserved word.
Thanks to Jerran for the changes.

```
100% tests passed, 0 tests failed out of 105
Total Test time (real) = 363.45 sec
```