### PR TITLE
Fix STL crash in Debug and remove ESSLContext config

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -553,7 +553,9 @@ void Viewer::applyDirectLights(mx::DocumentPtr doc)
         std::vector<mx::NodePtr> lights;
         _lightHandler->findLights(doc, lights);
         _lightHandler->registerLights(doc, lights, _genContext);
+#if MATERIALX_BUILD_GEN_ESSL
         _lightHandler->registerLights(doc, lights, _genContextEssl);
+#endif
         _lightHandler->setLightSources(lights);
     }
     catch (std::exception& e)
@@ -935,6 +937,10 @@ void Viewer::createAdvancedSettings(Widget* parent)
     referenceQualityBox->setCallback([this](bool enable)
     {
         _genContext.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_IS : mx::DIRECTIONAL_ALBEDO_TABLE;
+#if MATERIALX_BUILD_GEN_ESSL
+        // No Albedo Table support for Essl yet.
+        _genContextEssl.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_IS : mx::DIRECTIONAL_ALBEDO_CURVE_FIT;
+#endif
         reloadShaders();
     });
 
@@ -943,6 +949,9 @@ void Viewer::createAdvancedSettings(Widget* parent)
     importanceSampleBox->setCallback([this](bool enable)
     {
         _genContext.getOptions().hwSpecularEnvironmentMethod = enable ? mx::SPECULAR_ENVIRONMENT_FIS : mx::SPECULAR_ENVIRONMENT_PREFILTER;
+#if MATERIALX_BUILD_GEN_ESSL
+        _genContextEssl.getOptions().hwSpecularEnvironmentMethod = _genContext.getOptions().hwSpecularEnvironmentMethod;
+#endif
         reloadShaders();
     });
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -318,7 +318,7 @@ void Viewer::initialize()
     mx::FileSearchPath imageSearchPath = _searchPath;
     for (auto ipath : _searchPath)
     {
-        _searchPath.append(ipath / "libraries");
+        imageSearchPath.append(ipath / "libraries");
     }
     _imageHandler->setSearchPath(imageSearchPath);
 
@@ -935,8 +935,6 @@ void Viewer::createAdvancedSettings(Widget* parent)
     referenceQualityBox->setCallback([this](bool enable)
     {
         _genContext.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_IS : mx::DIRECTIONAL_ALBEDO_TABLE;
-        // No Albedo Table support for Essl yet.
-        _genContextEssl.getOptions().hwDirectionalAlbedoMethod = enable ? mx::DIRECTIONAL_ALBEDO_IS : mx::DIRECTIONAL_ALBEDO_CURVE_FIT;
         reloadShaders();
     });
 
@@ -945,7 +943,6 @@ void Viewer::createAdvancedSettings(Widget* parent)
     importanceSampleBox->setCallback([this](bool enable)
     {
         _genContext.getOptions().hwSpecularEnvironmentMethod = enable ? mx::SPECULAR_ENVIRONMENT_FIS : mx::SPECULAR_ENVIRONMENT_PREFILTER;
-        _genContextEssl.getOptions().hwSpecularEnvironmentMethod = _genContext.getOptions().hwSpecularEnvironmentMethod;
         reloadShaders();
     });
 


### PR DESCRIPTION
Fix a typo in MaterialXView. 
Remove use of _genContextEssl since it is not used for Rendering but only for CodeGen.