### PR TITLE
Fix node graph and node definition reference when publishing compounds.

### DIFF
--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -200,7 +200,21 @@ namespace
     void writeNodeDef(const PvtPrim* src, DocumentPtr dest, const RtWriteOptions* options)
     {
         RtNodeDef nodedef(src->hnd());
-        NodeDefPtr destNodeDef = dest->addNodeDef(nodedef.getName().str(), EMPTY_STRING, nodedef.getNode().str());
+        string nodedefName = nodedef.getName().str();
+
+        // Strip out any extraneous namespace prefix in the name
+        string namespaceString = nodedef.getNamespace().str();
+        if (!namespaceString.empty())
+        {
+            namespaceString += NAME_PREFIX_SEPARATOR;
+            auto location = nodedefName.find(namespaceString);
+            if (location != string::npos)
+            {
+                nodedefName.erase(location, namespaceString.length());
+            }
+        }
+
+        NodeDefPtr destNodeDef = dest->addNodeDef(nodedefName, EMPTY_STRING, nodedef.getNode().str());
 
         const RtString& version = nodedef.getVersion();
         if (!version.empty())

--- a/source/MaterialXRuntime/RtFileIo.cpp
+++ b/source/MaterialXRuntime/RtFileIo.cpp
@@ -701,7 +701,11 @@ namespace
         RtNodeDef nodedef(prim->hnd());
         RtString nodeDefName = prim->getName();
         RtString defNamespace = nodedef.getNamespace();
-        RtString qualifiedName = !defNamespace.empty() ? RtString(defNamespace.str() + NAME_PREFIX_SEPARATOR  + nodeDefName.str()) : nodeDefName;
+        RtString qualifiedName = nodeDefName;
+        //The Node Definition name can already have a namespace prefix attached at the front, so don't bother doing it again.
+        if(!defNamespace.empty() && qualifiedName.str().rfind(defNamespace.str() + NAME_PREFIX_SEPARATOR , 0) != 0) {
+            qualifiedName = RtString(defNamespace.str() + NAME_PREFIX_SEPARATOR  + nodeDefName.str());
+        }
         RtSchemaPredicate<RtNodeGraph> filter;
         for (RtPrim child : stage->getRootPrim()->getChildren(filter))
         {

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -160,7 +160,11 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
         throw ExceptionRuntimeError("The nodedef name '" + nodeDefName.str() + "' is not unique");
     }
 
-    PvtPrim* nodedefPrim = stage->createPrim(stage->getPath(), nodeDefName, RtNodeDef::typeName());
+    // Always used qualified namespace
+    const bool isNameSpaced = !namespaceString.empty();
+    const RtString qualifiedNodeDefName = isNameSpaced ? RtString(namespaceString.str() + MaterialX::NAME_PREFIX_SEPARATOR + nodeDefName.str()) : nodeDefName;
+
+    PvtPrim* nodedefPrim = stage->createPrim(stage->getPath(), qualifiedNodeDefName, RtNodeDef::typeName());
     RtNodeDef nodedef(nodedefPrim->hnd());
 
     // Set node, version and optional node group
@@ -208,10 +212,6 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
         RtValue::copy(output.getType(), output.getValue(), nodedefOutput.getValue());
     }
 
-    // Always used qualified namespace
-    const bool isNameSpaced = !namespaceString.empty();
-    const RtString qualifiedNodeDefName = isNameSpaced ? RtString(namespaceString.str() + MaterialX::NAME_PREFIX_SEPARATOR + nodeDefName.str()) : nodeDefName;
-
     // Set namespace for the nodegraph and nodedef
     if (isNameSpaced)
     {
@@ -221,8 +221,9 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
 
     // Set the definition on the nodegraph
     // turning this into a functional graph
-    // Note that the nodeDefName is a Qualified node def name.
-    nodegraph.setDefinition(qualifiedNodeDefName);
+    // Note that the Qualified node def should not be used here, but we need to
+    // use the nodeDefinitionName without a namespace prefix.
+    nodegraph.setDefinition(nodeDefName);
 
     // Create the relationship between nodedef and it's implementation.
     nodedef.getNodeImpls().connect(nodegraph.getPrim());

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -221,9 +221,7 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
 
     // Set the definition on the nodegraph
     // turning this into a functional graph
-    // Note that the Qualified node def should not be used here, but we need to
-    // use the nodeDefinitionName without a namespace prefix.
-    nodegraph.setDefinition(nodeDefName);
+    nodegraph.setDefinition(qualifiedNodeDefName);
 
     // Create the relationship between nodedef and it's implementation.
     nodedef.getNodeImpls().connect(nodegraph.getPrim());

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -1000,7 +1000,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, "ND_addgraph.mtlx");
     doc->validate();
-    mx::NodeDefPtr nodeDef = doc->getNodeDef(NAMESPACED_QUALIFIED_DEFINITION.str());
+    mx::NodeDefPtr nodeDef = doc->getNodeDef(QUALIFIED_DEFINITION.str());
     {
         // 1. Check nodedef
         REQUIRE(nodeDef);

--- a/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
+++ b/source/MaterialXTest/MaterialXRuntime/Runtime.cpp
@@ -943,7 +943,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     mx::RtPrim addgraphPrim = stage->createNodeDef(graph1.getPrim(), ND_ADDGRAPH, ADDGRAPH, ADDGRAPH_VERSION, isDefaultVersion, MATH_GROUP, NAMESPACE, DOC);
     api->registerDefinition<mx::RtNodeDef>(addgraphPrim);
     api->registerImplementation<mx::RtNodeGraph>(graph1.getPrim());
-    REQUIRE(api->hasDefinition<mx::RtNodeDef>(QUALIFIED_DEFINITION));
+    REQUIRE(api->hasDefinition<mx::RtNodeDef>(NAMESPACED_QUALIFIED_DEFINITION));
     REQUIRE(api->hasImplementation<mx::RtNodeGraph>(NG_ADDGRAPH));
 
     mx::RtNodeDef addgraphDef(addgraphPrim);
@@ -957,7 +957,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(addgraphDef.getInput(B).isUIVisible());
     REQUIRE(addgraphDef.numOutputs() == 1);
     REQUIRE(addgraphDef.getOutput().getName() == OUT);
-    REQUIRE(addgraphDef.getName() == QUALIFIED_DEFINITION);
+    REQUIRE(addgraphDef.getName() == NAMESPACED_QUALIFIED_DEFINITION);
     REQUIRE(addgraphDef.getNode() == ADDGRAPH);
     REQUIRE(addgraphDef.getNodeGroup() == MATH_GROUP);
     REQUIRE(addgraphDef.getVersion() == ADDGRAPH_VERSION);
@@ -971,7 +971,7 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     REQUIRE(addGraphImpl.getPath() == graph1.getPath());
 
     // Check instance creation:
-    mx::RtPrim agPrim = stage->createPrim("addgraph1", QUALIFIED_DEFINITION);
+    mx::RtPrim agPrim = stage->createPrim("addgraph1", NAMESPACED_QUALIFIED_DEFINITION);
     REQUIRE(agPrim.isValid());
     mx::RtNode agNode(agPrim);
     {
@@ -994,13 +994,13 @@ TEST_CASE("Runtime: NodeGraphs", "[runtime]")
     // Check export to MTLX document:
     mx::RtFileIo stageIo(stage);
     mx::RtStringVec names;
-    names.push_back(QUALIFIED_DEFINITION);
+    names.push_back(NAMESPACED_QUALIFIED_DEFINITION);
     stageIo.writeDefinitions("ND_addgraph.mtlx", names);
 
     mx::DocumentPtr doc = mx::createDocument();
     mx::readFromXmlFile(doc, "ND_addgraph.mtlx");
     doc->validate();
-    mx::NodeDefPtr nodeDef = doc->getNodeDef(QUALIFIED_DEFINITION.str());
+    mx::NodeDefPtr nodeDef = doc->getNodeDef(NAMESPACED_QUALIFIED_DEFINITION.str());
     {
         // 1. Check nodedef
         REQUIRE(nodeDef);


### PR DESCRIPTION
This is the current logic. Rt may or may not have namespaced nodedefs. Ones created by publishing via Rt and ones imported via core will have qualified names. On write to MTLX always strip out any qualifier on a nodedef if it's already namespaced.
![image](https://user-images.githubusercontent.com/14275104/132585240-5837ea6c-d335-48cf-b17e-a9468b1b45f4.png)
