### PR TITLE
Fix regression of creating invalid name when create new definitions

### DIFF
--- a/source/MaterialXRuntime/Private/PvtPrim.cpp
+++ b/source/MaterialXRuntime/Private/PvtPrim.cpp
@@ -154,7 +154,7 @@ RtPrimIterator PvtPrim::getChildren(RtObjectPredicate predicate) const
 
 RtString PvtPrim::makeUniqueChildName(const RtString& name) const
 {
-    RtString newName = name;
+    RtString newName = RtString(createValidName(name.str()));
 
     // Check if there is another child with this name.
     // We must check both prims, inputs and outputs since in

--- a/source/MaterialXRuntime/RtStage.cpp
+++ b/source/MaterialXRuntime/RtStage.cpp
@@ -162,9 +162,10 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
 
     // Always used qualified namespace
     const bool isNameSpaced = !namespaceString.empty();
-    const RtString qualifiedNodeDefName = isNameSpaced ? RtString(namespaceString.str() + MaterialX::NAME_PREFIX_SEPARATOR + nodeDefName.str()) : nodeDefName;
+    string qualifiedNodeDefName = isNameSpaced ? namespaceString.str() + MaterialX::NAME_PREFIX_SEPARATOR + nodeDefName.str() : nodeDefName.str();
+    qualifiedNodeDefName = createValidName(qualifiedNodeDefName);
 
-    PvtPrim* nodedefPrim = stage->createPrim(stage->getPath(), qualifiedNodeDefName, RtNodeDef::typeName());
+    PvtPrim* nodedefPrim = stage->createPrim(stage->getPath(), RtString(qualifiedNodeDefName), RtNodeDef::typeName());
     RtNodeDef nodedef(nodedefPrim->hnd());
 
     // Set node, version and optional node group
@@ -221,7 +222,7 @@ RtPrim RtStage::createNodeDef(RtPrim nodegraphPrim,
 
     // Set the definition on the nodegraph
     // turning this into a functional graph
-    nodegraph.setDefinition(qualifiedNodeDefName);
+    nodegraph.setDefinition(RtString(qualifiedNodeDefName));
 
     // Create the relationship between nodedef and it's implementation.
     nodedef.getNodeImpls().connect(nodegraph.getPrim());


### PR DESCRIPTION
Numbers such as "1.0" were being directly embedded into new definition and nodegraph names
when create a new nodedef via the runtime.

Add in valid name checking on nodedef creation and for general unique name utility which is used when renaming
a node (nodegraph in this case).
