### PR TITLE
MATX-303 : Material Node discovery 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         - name: MacOS_Xcode_12_Python37
           os: macos-11
           compiler: xcode
-          compiler_version: "12.5"
+          compiler_version: "12.5.1"
           python: 3.7
           run_on_push : OFF
 

--- a/resources/Materials/TestSuite/stdlib/materials/material_node_discovery.mtlx
+++ b/resources/Materials/TestSuite/stdlib/materials/material_node_discovery.mtlx
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodedef name="ND_material_def_material_1_0" node="material_def" version="1.0" isdefaultversion="true">
+    <output name="out" type="material" value="" />
+  </nodedef>
+  <standard_surface name="top_level_shader" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader" version="1.0.1" xpos="620" ypos="950" />
+  <surfacematerial name="top_level_material_no_asssign" type="material" nodedef="ND_surfacematerial" xpos="925" ypos="926">
+    <input name="surfaceshader" type="surfaceshader" nodename="top_level_shader" />
+    <input name="displacementshader" type="displacementshader" value="" />
+  </surfacematerial>
+  <nodegraph name="top_level_material_in_graph_no_assign" xpos="925" ypos="1357" >
+    <standard_surface name="standard_surface2" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader" version="1.0.1" xpos="-414.603" ypos="326.959" />
+    <surfacematerial name="surfacematerial1" type="material" nodedef="ND_surfacematerial" xpos="-67.8807" ypos="21.3596">
+      <input name="surfaceshader" type="surfaceshader" nodename="standard_surface2" />
+      <input name="displacementshader" type="displacementshader" value="" />
+    </surfacematerial>
+    <output name="out" type="material" nodename="surfacematerial1" />
+  </nodegraph>
+  <standard_surface name="top_level_shader1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader" version="1.0.1" xpos="10" ypos="34" />
+  <surfacematerial name="top_level_material_assigned" type="material" nodedef="ND_surfacematerial" xpos="315" ypos="10">
+    <input name="surfaceshader" type="surfaceshader" nodename="top_level_shader1" />
+    <input name="displacementshader" type="displacementshader" value="" />
+  </surfacematerial>
+  <nodegraph name="NG_material_def_material_1_0" xpos="925" ypos="1596" nodedef="ND_material_def_material_1_0">
+    <standard_surface name="standard_surface2" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader" version="1.0.1" xpos="-414.603" ypos="326.959" />
+    <surfacematerial name="surfacematerial1" type="material" nodedef="ND_surfacematerial" xpos="-67.8807" ypos="21.3596">
+      <input name="surfaceshader" type="surfaceshader" nodename="standard_surface2" />
+      <input name="displacementshader" type="displacementshader" value="" />
+    </surfacematerial>
+    <output name="out" type="material" nodename="surfacematerial1" />
+  </nodegraph>
+  <material_def name="top_level_material_def" type="material" nodedef="ND_material_def_material_1_0" version="1.0" xpos="925" ypos="1787" />
+  <nodegraph name="top_level_material_in_graph_assigned" xpos="315" ypos="468" ldx_io_nodes="&amp;lt;?xml version=&quot;1.0&quot;?&amp;gt;&#10;&amp;lt;materialx version=&quot;1.38&quot;&amp;gt;&#10;  &amp;lt;layout name=&quot;io&quot; type=&quot;&quot; /&amp;gt;&#10;&amp;lt;/materialx&amp;gt;&#10;">
+    <standard_surface name="standard_surface2" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader" version="1.0.1" xpos="-414.603" ypos="326.959" />
+    <surfacematerial name="surfacematerial1" type="material" nodedef="ND_surfacematerial" xpos="-67.8807" ypos="21.3596">
+      <input name="surfaceshader" type="surfaceshader" nodename="standard_surface2" />
+      <input name="displacementshader" type="displacementshader" value="" />
+    </surfacematerial>
+    <output name="out" type="material" nodename="surfacematerial1" />
+  </nodegraph>
+  <material_def name="top_level_material_def_assigned" type="material" nodedef="ND_material_def_material_1_0" version="1.0" xpos="925" ypos="1978" />
+  <collection name="collection1" includecollection="" xpos="315" ypos="229" />
+  <collection name="collection2" includecollection="" xpos="315" ypos="687" />
+  <collection name="collection3" includecollection="" xpos="962.402" ypos="2147.13" />
+  <look name="look1" xpos="925" ypos="35">
+    <materialassign name="materialnode_to_materialassign" geom="" collection="collection1" material="top_level_material_assigned" xpos="620" ypos="83" />
+  </look>
+  <look name="look2" xpos="925" ypos="493">
+    <materialassign name="materialgraph_to_materialassign" geom="" collection="collection2" material="top_level_material_in_graph_assigned" xpos="620" ypos="542" />
+  </look>
+  <look name="look3" xpos="1599.09" ypos="1869.59">
+    <materialassign name="materialdef_to_materialassign" geom="" collection="collection3" material="top_level_material_def_assigned" xpos="1270.81" ypos="1960.71" />
+  </look>
+</materialx>

--- a/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
@@ -44,5 +44,5 @@ EMSCRIPTEN_BINDINGS(material)
     }));
 
     ems::function("getConnectedOutputs", &mx::getConnectedOutputs);
-    ems::function("getMaterialNodes", &mx::getMaterialNodes);
+    ems::function("getMaterials", &mx::getMaterials);
 }

--- a/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
@@ -44,4 +44,5 @@ EMSCRIPTEN_BINDINGS(material)
     }));
 
     ems::function("getConnectedOutputs", &mx::getConnectedOutputs);
+    ems::function("getMaterialNodes", &mx::getMaterialNodes);
 }

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -144,7 +144,7 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
     vector<InterfaceElementPtr> materialNodes;
     std::unordered_set<ElementPtr> processedSources;
 
-    // Handle the case that the root is a graph element ( document or nodegraph )
+    // Handle the case where the root is a graph element ( document or a nodegraph )
     GraphElementPtr graphElement = root->asA<GraphElement>();
     if (graphElement)
     {
@@ -161,26 +161,22 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
                 if (graphOutput->getType() == MATERIAL_TYPE_STRING)
                 {
                     NodePtr node = graphOutput->getConnectedNode();
-                    if (node && node->getType() == MATERIAL_TYPE_STRING)
+                    if (node && (node->getType() == MATERIAL_TYPE_STRING) && 
+                        !processedSources.count(node))
                     {
-                        if (!processedSources.count(node))
-                        {
-                            materialNodes.push_back(node);
-                            processedSources.insert(node);
-                        }
+                        materialNodes.push_back(node);
+                        processedSources.insert(node);
                     }
                 }
             }
         }
 
-        // Find all material nodes in the document at the top level or inside a nodegraph.
-        // Finds all nodes in a top level graph or connected to a top level output first.
-        // Optionally looks for stray nodes.
+        // Find all nodes which have a "material" output at the document level
         else if (document)
         {
             const std::string documentUri = document->getSourceUri();
 
-            // Look for any nodegraphs which output materials
+            // Look for any nodegraphs with "material" outputs.
             vector<OutputPtr> testOutputs;
             for (NodeGraphPtr docNodeGraph : document->getNodeGraphs())
             {
@@ -200,7 +196,7 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
                     {
                         NodePtr node = graphOutput->getConnectedNode();
                         if (node && node->getType() == MATERIAL_TYPE_STRING &&
-                            !processedSources.count(node))
+                            !processedSources.count(docNodeGraph))
                         {
                             materialNodes.push_back(docNodeGraph);
                             processedSources.insert(node);
@@ -222,7 +218,7 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
         }
     }
 
-    // Handle the case where it's a material assignment
+    // Look for materials associated with a material assignment
     MaterialAssignPtr materialAssign = root->asA<MaterialAssign>();
     if (materialAssign)
     {
@@ -242,13 +238,11 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
                     if (graphOutput->getType() == MATERIAL_TYPE_STRING)
                     {
                         NodePtr node = graphOutput->getConnectedNode();
-                        if (node && node->getType() == MATERIAL_TYPE_STRING)
+                        if (node && (node->getType() == MATERIAL_TYPE_STRING) && 
+                            !processedSources.count(node))
                         {
-                            if (!processedSources.count(node))
-                            {
-                                materialNodes.push_back(node);
-                                processedSources.insert(node);
-                            }
+                            materialNodes.push_back(node);
+                            processedSources.insert(node);
                         }
                     }
                 }
@@ -258,6 +252,5 @@ MX_CORE_API vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool s
 
     return materialNodes;
 }
-
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -3,7 +3,11 @@
 // All rights reserved.  See LICENSE.txt for license.
 //
 
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Node.h>
 #include <MaterialXCore/Material.h>
+
+#include <unordered_set>
 
 namespace MaterialX
 {
@@ -134,5 +138,168 @@ vector<OutputPtr> getConnectedOutputs(NodePtr node)
     }
     return outputVec;
 }
+
+MX_CORE_API vector<NodePtr> getMaterialNodes(ElementPtr root, bool addUnconnectedNodes, bool skipIncludes)
+{
+    vector<NodePtr> materialNodes;
+    std::unordered_set<ElementPtr> processedSources;
+
+    // Handle the case that the root is a graph element. In this either
+    // a document or nodegraph
+    GraphElementPtr graphElement = root->asA<GraphElement>();
+    if (graphElement)
+    {
+        DocumentPtr document = graphElement->asA<Document>();
+        NodeGraphPtr nodeGraph = graphElement->asA<NodeGraph>();
+
+        // Look for any material nodes exposed as outputs
+        if (nodeGraph)
+        {
+            for (auto graphOutput : nodeGraph->getOutputs())
+            {
+                if (graphOutput->getType() == MATERIAL_TYPE_STRING)
+                {
+                    NodePtr node = graphOutput->getConnectedNode();
+                    if (node && node->getType() == MATERIAL_TYPE_STRING)
+                    {
+                        if (!processedSources.count(node))
+                        {
+                            materialNodes.push_back(node);
+                            processedSources.insert(node);
+                        }
+                    }
+                }
+            }
+
+            // Q: Should there be an option to check for stray material nodes ?
+            if (addUnconnectedNodes)
+            {
+                vector<NodePtr> allMaterialNodes = nodeGraph->getMaterialNodes();
+                for (auto node : allMaterialNodes)
+                {
+                    if (!processedSources.count(node))
+                    {
+                        materialNodes.push_back(node);
+                        processedSources.insert(node);
+                    }
+                }
+            }
+        }
+
+        // Find all material nodes in the document at the top level or inside a nodegraph.
+        // Finds all nodes in a top level graph or connected to a top level output first.
+        // Optionally looks for stray nodes.
+        else if (document)
+        {
+            const std::string documentUri = document->getSourceUri();
+
+            // Look for a nodegraph which outputs materials
+            vector<OutputPtr> testOutputs;
+            for (NodeGraphPtr docNodeGraph : document->getNodeGraphs())
+            {
+                // Skip anything from an include file including libraries.
+                // Skip any nodegraph which is a definition
+                if (!docNodeGraph->hasAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE))
+                {
+                    if (skipIncludes && (documentUri != docNodeGraph->getSourceUri()))
+                    {
+                        continue;
+                    }
+                    for (auto graphOutput : docNodeGraph->getOutputs())
+                    {
+                        if (graphOutput->getType() == MATERIAL_TYPE_STRING)
+                        {
+                            testOutputs.push_back(graphOutput);
+                        }
+                    }
+                }
+            }
+
+            // Add in all top-level outputs not already processed.
+            auto docOutputs = document->getOutputs();
+            for (auto docOutput : docOutputs)
+            {
+                if (skipIncludes && (documentUri != docOutput->getSourceUri()))
+                {
+                    continue;
+                }
+                if (docOutput->getType() == MATERIAL_TYPE_STRING)
+                {
+                    testOutputs.push_back(docOutput);
+                }
+            }
+
+            for (OutputPtr output : testOutputs)
+            {
+                if (processedSources.count(output))
+                {
+                    continue;
+                }
+                processedSources.insert(output);
+
+                NodePtr node = output->getConnectedNode();
+                if (node->getType() == MATERIAL_TYPE_STRING)
+                {
+                    if (!processedSources.count(node))
+                    {
+                        materialNodes.push_back(node);
+                        processedSources.insert(node);
+                    }
+                }
+            }
+
+            // Add in stray material nodes
+            if (addUnconnectedNodes)
+            {
+                vector<NodePtr> allMaterialNodes = document->getMaterialNodes();
+                for (auto node : allMaterialNodes)
+                {
+                    if (!processedSources.count(node))
+                    {
+                        materialNodes.push_back(node);
+                        processedSources.insert(node);
+                    }
+                }
+            }
+        }
+    }
+
+    // Handle the case where it's a material assignment
+    MaterialAssignPtr materialAssign = root->asA<MaterialAssign>();
+    if (materialAssign)
+    {
+        NodePtr materialNode = materialAssign->getReferencedMaterial();
+        if (materialNode && (materialNode->getType() == MATERIAL_TYPE_STRING) &&
+            !processedSources.count(materialNode) )
+        {
+            materialNodes.push_back(materialNode);
+        }
+        else
+        {
+            NodeGraphPtr materialGraph = materialAssign->resolveRootNameReference<NodeGraph>(materialAssign->getMaterial());
+            if (materialGraph)
+            {
+                for (auto graphOutput : materialGraph->getOutputs())
+                {
+                    if (graphOutput->getType() == MATERIAL_TYPE_STRING)
+                    {
+                        NodePtr node = graphOutput->getConnectedNode();
+                        if (node && node->getType() == MATERIAL_TYPE_STRING)
+                        {
+                            if (!processedSources.count(node))
+                            {
+                                materialNodes.push_back(node);
+                                processedSources.insert(node);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return materialNodes;
+}
+
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -30,12 +30,12 @@ MX_CORE_API vector<NodePtr> getShaderNodes(NodePtr materialNode,
 /// Return a vector of all outputs connected to the given node's inputs.
 MX_CORE_API vector<OutputPtr> getConnectedOutputs(NodePtr node);
 
-/// Return a list of upstream elements which are connected to a given root element by a connection
-/// of type `material`.
-/// The root element types which are considered are: materialassign, document, and nodegraph.
+// Return all materials associated with a given root element. 
+// The root element types considered are: materialassign, document, and nodegraph.
+// The returned material elements are either nodes or nodegraphs of output type 'material'.
 /// @param root element to start from.
 /// @param skipIncludes Skip nodes that are from an included document. 
-MX_CORE_API std::vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool skipIncludes);
+MX_CORE_API std::vector<InterfaceElementPtr> getMaterials(ElementPtr root, bool skipIncludes);
 
 } // namespace MaterialX
 

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -30,9 +30,9 @@ MX_CORE_API vector<NodePtr> getShaderNodes(NodePtr materialNode,
 /// Return a vector of all outputs connected to the given node's inputs.
 MX_CORE_API vector<OutputPtr> getConnectedOutputs(NodePtr node);
 
-/// Return a list upstream elements which are connected to a given root element by a connection
+/// Return a list of upstream elements which are connected to a given root element by a connection
 /// of type `material`.
-/// The root elements which are considered are: materialassigns, documents, and nodegraphs.
+/// The root element types which are considered are: materialassign, document, and nodegraph.
 /// @param root element to start from.
 /// @param skipIncludes Skip nodes that are from an included document. 
 MX_CORE_API std::vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool skipIncludes);

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -12,6 +12,7 @@
 #include <MaterialXCore/Export.h>
 
 #include <MaterialXCore/Node.h>
+#include <set>
 
 namespace MaterialX
 {
@@ -28,6 +29,15 @@ MX_CORE_API vector<NodePtr> getShaderNodes(NodePtr materialNode,
 
 /// Return a vector of all outputs connected to the given node's inputs.
 MX_CORE_API vector<OutputPtr> getConnectedOutputs(NodePtr node);
+
+/// Return a list upstream material nodes which are connected to a given root element.
+/// The root elements which are considered are materialassigns, documents, and nodegraphs
+/// @param root element to start from
+/// @param addUnconnectedNodes Whether to return material nodes which are not connected to an output when the
+/// root provided is either a nodegraph or a document. This option has no effect if a materialassign is
+/// passed as a root.
+/// @param skipIncludes Skip nodes that are from an included document. 
+MX_CORE_API std::vector<NodePtr> getMaterialNodes(ElementPtr root, bool addUnconnectedNodes, bool skipIncludes);
 
 } // namespace MaterialX
 

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -12,7 +12,6 @@
 #include <MaterialXCore/Export.h>
 
 #include <MaterialXCore/Node.h>
-#include <set>
 
 namespace MaterialX
 {

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -30,14 +30,12 @@ MX_CORE_API vector<NodePtr> getShaderNodes(NodePtr materialNode,
 /// Return a vector of all outputs connected to the given node's inputs.
 MX_CORE_API vector<OutputPtr> getConnectedOutputs(NodePtr node);
 
-/// Return a list upstream material nodes which are connected to a given root element.
-/// The root elements which are considered are materialassigns, documents, and nodegraphs
-/// @param root element to start from
-/// @param addUnconnectedNodes Whether to return material nodes which are not connected to an output when the
-/// root provided is either a nodegraph or a document. This option has no effect if a materialassign is
-/// passed as a root.
+/// Return a list upstream elements which are connected to a given root element by a connection
+/// of type `material`.
+/// The root elements which are considered are: materialassigns, documents, and nodegraphs.
+/// @param root element to start from.
 /// @param skipIncludes Skip nodes that are from an included document. 
-MX_CORE_API std::vector<NodePtr> getMaterialNodes(ElementPtr root, bool addUnconnectedNodes, bool skipIncludes);
+MX_CORE_API std::vector<InterfaceElementPtr> getMaterialNodes(ElementPtr root, bool skipIncludes);
 
 } // namespace MaterialX
 

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -7,6 +7,8 @@
 
 #include <MaterialXCore/Document.h>
 #include <MaterialXCore/Value.h>
+#include <MaterialXFormat/XmlIo.h>
+#include <MaterialXFormat/Util.h>
 
 namespace mx = MaterialX;
 
@@ -53,4 +55,83 @@ TEST_CASE("Material", "[material]")
     REQUIRE(instanceSpecColor->getValue()->asA<mx::Color3>() == mx::Color3(1.0f));
     REQUIRE(instanceSpecColor->getDefaultValue()->asA<mx::Color3>() == mx::Color3(0.0f));
     REQUIRE(doc->validate());
+}
+
+#include <iostream>
+
+TEST_CASE("Material Discovery", "[material]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+
+    mx::FileSearchPath searchPath;
+    const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    searchPath.append(currentPath / mx::FilePath("libraries"));
+    searchPath.append(currentPath / mx::FilePath("resources/Materials/TestSuite"));
+
+    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    loadLibraries({ "targets", "stdlib", "pbrlib" }, searchPath, doc);
+
+    mx::FilePath filename = "stdlib/materials/material_node_discovery.mtlx";
+    mx::readFromXmlFile(doc, filename, searchPath);
+
+
+    // Material assignment test
+    for (auto look : doc->getLooks())
+    {
+        for (auto materialAssign : look->getMaterialAssigns())
+        {
+            std::vector<mx::NodePtr> assignNodes = mx::getMaterialNodes(materialAssign, false, false);
+            if (!assignNodes.empty())
+            {
+                std::cout << "*** Material node for assignment: " << materialAssign->getNamePath() << std::endl;
+                for (auto n : assignNodes)
+                {
+                    std::cout << "Found material node: " << n->getNamePath() << std::endl;
+                }
+            }
+        }
+    }
+
+    // Nodegraph level test
+    for (auto nodeGraph : doc->getNodeGraphs())
+    {
+        std::vector<mx::NodePtr> connectedGraphNodes = mx::getMaterialNodes(nodeGraph, false, false);
+        if (!connectedGraphNodes.empty())
+        {
+            std::cout << "*** Connected nodes for graph: " << nodeGraph->getNamePath() << std::endl;
+            for (auto n : connectedGraphNodes)
+            {
+                std::cout << "Found output material node: " << n->getNamePath() << std::endl;
+            }
+        }
+        std::vector<mx::NodePtr> unconnectedGraphNodes = mx::getMaterialNodes(nodeGraph, true, false);
+        if (!unconnectedGraphNodes.empty())
+        {
+            std::cout << "*** UN-Connected nodes for graph: " << nodeGraph->getNamePath() << std::endl;
+            for (auto n : unconnectedGraphNodes)
+            {
+                std::cout << "Found output material node: " << n->getNamePath() << std::endl;
+            }
+        }
+    }
+
+    // Document level test
+    std::vector<mx::NodePtr> connectedDocNodes = mx::getMaterialNodes(doc, false, false);
+    if (!connectedDocNodes.empty())
+    {
+        std::cout << "*** Connected nodes for document: " << std::endl;
+        for (auto n : connectedDocNodes)
+        {
+            std::cout << "Found output material node: " << n->getNamePath() << std::endl;
+        }
+    }
+    std::vector<mx::NodePtr> unconnectedDocNodes = mx::getMaterialNodes(doc, true, false);
+    if (!unconnectedDocNodes.empty())
+    {
+        std::cout << "*** UN-Connected nodes for document: " << std::endl;
+        for (auto n : unconnectedDocNodes)
+        {
+            std::cout << "Found output material node: " << n->getNamePath() << std::endl;
+        }
+    }
 }

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -85,12 +85,25 @@ TEST_CASE("Material Discovery", "[material]")
     {
         for (auto materialAssign : look->getMaterialAssigns())
         {
-            std::vector<mx::InterfaceElementPtr> assignNodes = mx::getMaterialNodes(materialAssign, false);
+            std::vector<mx::InterfaceElementPtr> assignNodes = mx::getMaterials(materialAssign, false);
             for (auto assignNode : assignNodes)
             {
-                const std::string& graphNodeName = assignNode->getNamePath();
-                CHECK(assignmentMaterialPaths.count(graphNodeName));
-                foundNames.insert(graphNodeName);
+                if (assignNode->isA<mx::NodeGraph>())
+                {
+                    std::vector<mx::InterfaceElementPtr> assignGraphNodes = mx::getMaterials(assignNode, false);
+                    for (auto assignGraphNode : assignGraphNodes)
+                    {
+                        const std::string& graphNodeName = assignGraphNode->getNamePath();
+                        CHECK(assignmentMaterialPaths.count(graphNodeName));
+                        foundNames.insert(graphNodeName);
+                    }
+                }
+                else
+                {
+                    const std::string& graphNodeName = assignNode->getNamePath();
+                    CHECK(assignmentMaterialPaths.count(graphNodeName));
+                    foundNames.insert(graphNodeName);
+                }
             }
         }
     }
@@ -110,7 +123,7 @@ TEST_CASE("Material Discovery", "[material]")
     mx::StringSet graphNodeNames;
     for (auto nodeGraph : doc->getNodeGraphs())
     {
-        std::vector<mx::InterfaceElementPtr> graphNodes = mx::getMaterialNodes(nodeGraph, false);
+        std::vector<mx::InterfaceElementPtr> graphNodes = mx::getMaterials(nodeGraph, false);
         if (!graphNodes.empty())
         {
             for (auto graphNode : graphNodes)
@@ -132,14 +145,14 @@ TEST_CASE("Material Discovery", "[material]")
         "top_level_material_def_assigned"
     };
     documentMaterialNodePaths.insert(compareGraphNodeNames.begin(), compareGraphNodeNames.end());
-    std::vector<mx::InterfaceElementPtr> docNodes = mx::getMaterialNodes(doc, false);
+    std::vector<mx::InterfaceElementPtr> docNodes = mx::getMaterials(doc, false);
     if (!docNodes.empty())
     {
         for (auto docNode : docNodes)
         {
-            if (docNode->asA<mx::NodeGraph>())
+            if (docNode->isA<mx::NodeGraph>())
             {
-                std::vector<mx::InterfaceElementPtr> docGraphNodes  = mx::getMaterialNodes(docNode, false);
+                std::vector<mx::InterfaceElementPtr> docGraphNodes  = mx::getMaterials(docNode, false);
                 for (auto docGraphNode : docGraphNodes)
                 {
                     // Check that we find the same node names as by directly scanning nodegraphs
@@ -156,8 +169,8 @@ TEST_CASE("Material Discovery", "[material]")
                 foundNames.insert(nodeName);
             }
         }
-        // Note: We are only comparing counts excluding the nodegraph
-        // implementation which contains material node.
+        // Note: We are only comparing counts excluding any nodegraph
+        // implementations which contain material nodes.
         CHECK(documentMaterialNodePaths.size() == foundNames.size());
     }
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
@@ -15,5 +15,6 @@ void bindPyMaterial(py::module& mod)
 {
     mod.def("getShaderNodes", &mx::getShaderNodes,
         py::arg("materialNode"), py::arg("nodeType") = mx::SURFACE_SHADER_TYPE_STRING, py::arg("target") = mx::EMPTY_STRING);
-    mod.def("getConnectedOutputs", &mx::getConnectedOutputs);
+    mod.def("getConnectedOutputs", &mx::getConnectedOutputs),
+    mod.def("getMaterialNodes", &mx::getMaterialNodes);
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
@@ -16,5 +16,5 @@ void bindPyMaterial(py::module& mod)
     mod.def("getShaderNodes", &mx::getShaderNodes,
         py::arg("materialNode"), py::arg("nodeType") = mx::SURFACE_SHADER_TYPE_STRING, py::arg("target") = mx::EMPTY_STRING);
     mod.def("getConnectedOutputs", &mx::getConnectedOutputs),
-    mod.def("getMaterialNodes", &mx::getMaterialNodes);
+    mod.def("getMaterials", &mx::getMaterials);
 }


### PR DESCRIPTION
### Discover Logic.
- discovery returns any node or nodegraph which has a one or more `material` outputs
- Works on a nodegraph, materialassign, or document as the element to test from.
- Document level . It ignores implementation nodegraphs.
- Nodegraph discovery does not check if the graph is an implementation or not.

### Configurations Supported.
Refer to images in:
https://github.com/materialx/MaterialX/issues/737
for graphical view of configurations tested.

### Test Results.
*Material nodes discovered which are referenced by `materialassigns`*
- Found material node: top_level_material_assigned
- Found material node: top_level_material_in_graph_assigned/surfacematerial1
- Found material node: top_level_material_def_assigned

*Material nodes discover which are within a nodegraph*
- Found output material node: top_level_material_in_graph_no_assign/surfacematerial1
- Found output material node on definition: NG_material_def_material_1_0/surfacematerial1
- Found output material node: top_level_material_in_graph_assigned/surfacematerial1

*Material nodes or nodegraphs discovered within a Document*
This scans at the document level first, and then for each nodegraph scans inside. The difference
when scanning at document level is that nodegraph implementations are skipped so `NG_material_def_material_1_0/surfacematerial1` is not return.
- NodeGraph Node: top_level_material_in_graph_no_assign/surfacematerial1
- NodeGraph Node: top_level_material_in_graph_assigned/surfacematerial1
- Node: top_level_material_no_asssign
- Node: top_level_material_assigned
- Node: top_level_material_def
- Node: top_level_material_def_assigned