### PR TITLE
Added method Element::addChild (by shared pointer)

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -262,6 +262,15 @@ ElementPtr Element::addChildOfCategory(const string& category, string name)
     return child;
 }
 
+void Element::addChild(ElementPtr child)
+{
+    if (_childMap.count(child->getName()))
+    {
+        throw Exception("Child name is not unique: " + child->getName());
+    }
+    registerChildElement(child);
+}
+
 ElementPtr Element::changeChildCategory(ElementPtr child, const string& category)
 {
     int childIndex = getChildIndex(child->getName());

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -400,6 +400,12 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @return A shared pointer to the new child element.
     template <class T> shared_ptr<T> addChild(const string& name = EMPTY_STRING);
 
+    /// Add a child element.
+    /// @param child A shared pointer to the child element.
+    /// @throws Exception if a child of this element already possesses the
+    ///     given name.
+    void addChild(ElementPtr child);
+
     /// Add a child element of the given category and name.
     /// @param category The category string of the new child element.
     ///     If the category string is recognized, then the correponding Element


### PR DESCRIPTION
This is needed for edit operations on an Element hierarchy. `removeChild(by string name)` already exists but there was no way to add an existing element as child of another element.