### PR TITLE
Support multiple UV

### DIFF
--- a/libraries/adsk/adsklib/adsklib_defs.mtlx
+++ b/libraries/adsk/adsklib/adsklib_defs.mtlx
@@ -105,6 +105,7 @@
     <input name="normal_scale" type="float" value="1.0" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -119,6 +120,7 @@
     <input name="depth" type="float" unittype="distance" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="vector3" />
   </nodedef>
   

--- a/libraries/adsk/adsklib/adsklib_defs.mtlx
+++ b/libraries/adsk/adsklib/adsklib_defs.mtlx
@@ -23,6 +23,7 @@
     <input name="invert" type="boolean" value="false" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="color3"/>
   </nodedef>
 
@@ -42,6 +43,7 @@
     <input name="invert" type="boolean" value="false" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="color4"/>
   </nodedef>
   
@@ -61,6 +63,7 @@
     <input name="invert" type="boolean" value="false" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -83,6 +86,7 @@
     <input name="outhigh" type="float" value="1.0" />
     <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
     <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uv_index" type="integer" value="0" />
     <output name="out" type="float" />
   </nodedef>
 

--- a/libraries/adsk/adsklib/adsklib_ng.mtlx
+++ b/libraries/adsk/adsklib/adsklib_ng.mtlx
@@ -27,7 +27,9 @@
     </multiply>
 
     <!-- use placement node to transform uv -->
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />
@@ -83,7 +85,9 @@
     </multiply>
 
     <!-- use placement node to transform uv -->
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />
@@ -139,7 +143,9 @@
     </multiply>
 
     <!-- use placement node to transform uv -->
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />
@@ -201,7 +207,9 @@
     </multiply>
 
     <!-- use placement node to transform uv -->
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />
@@ -274,7 +282,9 @@
     </multiply>
 
     <!-- use placement node to transform uv -->
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />
@@ -328,7 +338,9 @@
       <input name="in2" type="float" value="-1.0"/>
     </multiply>
 
-    <texcoord name="texcoord1" type="vector2" />
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" interfacename="uv_index"/>
+    </texcoord>
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1"/>
       <input name="offset" type="vector2" nodename="total_offset" />


### PR DESCRIPTION
Add a simple uv_index input for adsk:bitmap, adsk:normal_map, adsk:height_map. This parameter enable client to set uv index number and another consumer side could parse and use this value. This solution is used to support multiple UV for 3ds Max glTF exprot workflow.