### PR TITLE
fix texture shearing problem for adsk bitmap nodes

### DIFF
--- a/libraries/adsk/adsklib/adsklib_ng.mtlx
+++ b/libraries/adsk/adsklib/adsklib_ng.mtlx
@@ -36,6 +36,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
@@ -94,6 +95,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="color4">
       <input name="file" type="filename" interfacename="file" />
@@ -152,6 +154,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
@@ -216,6 +219,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="color3">
       <input name="file" type="filename" interfacename="file" />
@@ -291,6 +295,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="vector3" >
       <input name="file" type="filename" interfacename="file" />
@@ -347,6 +352,7 @@
       <input name="scale" type="vector2" nodename="total_scale" />
       <input name="pivot" type="vector2" value="0.0, 0.0" />
       <input name="rotate" type="float" value="0" nodename="rotation_angle_param" />
+      <input name="operationorder" type="integer" value="1" />
     </place2d>
     <image name="b_image" type="float" >
       <input name="file" type="filename" interfacename="file" />


### PR DESCRIPTION
To solve the texture shearing issue https://github.com/AcademySoftwareFoundation/MaterialX/issues/1021, we have added a new input "operationorder" for `place2d `node in this pr https://github.com/AcademySoftwareFoundation/MaterialX/pull/1027.
Here for all adsk bitmap nodes, we change the "operationorder" value to 1 so that they won't be sheared any more.