### PR TITLE
Add correct category for adsk:ND_adsk_height_map node

### DIFF
--- a/libraries/adsk/adsklib/adsklib_defs.mtlx
+++ b/libraries/adsk/adsklib/adsklib_defs.mtlx
@@ -110,7 +110,7 @@
   </nodedef>
 
   <!-- <adsk_height_map> -->
-  <nodedef name="ND_adsk_height_map" node="height_map" version="1.0.1" isdefaultversion="true" namespace="adsk">
+  <nodedef name="ND_adsk_height_map" node="height_map" nodegroup="texture2d" version="1.0.1" isdefaultversion="true" namespace="adsk">
     <input name="file" type="filename" />
     <input name="realworld_offset" type="vector2" unittype="distance" />
     <input name="realworld_scale" type="vector2" unittype="distance" />


### PR DESCRIPTION
adsk:ND_adsk_height_map was not categorized as Texture node, this was causing Hydra/Storm to ignore the associates samplers with this node.