### PR TITLE
Adjust Windows DLL search path for Python 3.8+

### DIFF
--- a/python/MaterialX/__init__.py
+++ b/python/MaterialX/__init__.py
@@ -1,3 +1,20 @@
+# Python 3.8+ on Windows: DLL search paths for dependent
+# shared libraries
+# Refs.:
+# - https://github.com/python/cpython/issues/80266
+# - https://docs.python.org/3.8/library/os.html#os.add_dll_directory
+import os
+import sys
+if sys.platform == "win32" and sys.version_info >= (3, 8):
+    # On a standard installation, this file is in %INSTALLDIR%\python\MaterialX
+    # We need to add %INSTALLDIR%\bin to the DLL path.
+    mxdir = os.path.dirname(__file__)
+    pydir = os.path.split(mxdir)[0]
+    installdir = os.path.split(pydir)[0]
+    bindir = os.path.join(installdir, "bin")
+    if os.path.exists(bindir):
+        os.add_dll_directory(bindir)
+
 from .main import *
 from .colorspace import *
 


### PR DESCRIPTION
Fixes https://github.com/AcademySoftwareFoundation/MaterialX/issues/1439

Required by https://github.com/python/cpython/issues/80266