### PR TITLE
Initial commit 3d wood material

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_3dwood_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_3dwood_defs.mtlx
@@ -1,0 +1,261 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!--
+  DESCRIPTION: Node Definitions for Autodesk 3D wood material
+  -->
+
+  <!-- 
+      ==============================================
+      Nodedefs for Autodesk 3D wood custom nodes
+      * These nodes are used more than once
+      ==============================================
+  -->
+  <!--
+    Node: <wood3d_util_hashnoise2d>
+    2D hash noise in 3 channels.
+  -->
+  <nodedef name="ND_wood3d_util_hashnoise2d_vector3" node="wood3d_util_hashnoise2d">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
+  </nodedef>
+ <!--
+    Node: <wood3d_util_noise1d>
+    1D Perlin noise in 1 channel.
+  -->
+  <nodedef name="ND_wood3d_util_noise1d_float" node="wood3d_util_noise1d">
+    <input name="amplitude" type="float" value="1.0" />
+    <input name="pivot" type="float" value="0.0" />
+    <input name="p" type="float" default="0.0" />
+    <output name="out" type="float" default="0.0" />
+  </nodedef>
+  <!--
+    Node: <wood3d_util_pore_impulse>
+    Output a pore weight for 3D wood material by accumulating wyvill impulse from all potentially
+    contributing cells.
+  -->
+  <nodedef name="ND_wood3d_util_pore_impulse" node="wood3d_util_pore_impulse" >
+    <input name="position" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="wood_weight" type="float" value="0.0" />    
+    <input name="seed" type="float" value="0.0" />    
+    <input name="pore_cell_dim" type="float" value="0.0" />    
+    <input name="pore_radius" type="float" value="0.0" />    
+    <output name="weight" type="float" default="0.0" />
+  </nodedef>
+
+  <!-- 
+      ==============================================
+      Nodedefs for Autodesk 3D wood subgraphs 
+      * These nodes are used only once, they are designed 
+        to improve readability / help reduce complexity
+      ==============================================
+  -->
+  <!--
+    Node: <wood3d_util_ratio>
+    Compute early wood ratio.
+  -->
+  <nodedef name="ND_wood3d_util_ratio" node="wood3d_util_ratio" >
+    <input name="ring_thickness" type="float" value="0.0" xpos="-49.768116" ypos="-50.068966" />
+    <input name="late_wood_sharpness" type="float" value="0.0" xpos="-50.115944" ypos="-46.068966" />
+    <input name="early_wood_sharpness" type="float" value="0.0" xpos="-50.217392" ypos="-47.051723" />
+    <input name="late_wood_ratio" type="float" value="0.0" xpos="-49.768116" ypos="-48.137932" />
+    <input name="radius" type="float" value="0.0" xpos="-49.420288" ypos="-51.189655" />
+    <output name="earlywood_ratio" type="float"  />
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_fiber_cosine_distortion>
+    Apply cosine distortion to wood position.
+  -->
+  <nodedef name="ND_wood3d_util_fiber_cosine_distortion" node="wood3d_util_fiber_cosine_distortion" >
+    <input name="fiber_cosine_frequencies" type="vector4" value="0, 0, 0, 0" xpos="-82.456520" ypos="-23.560345" />
+    <input name="fiber_cosine_weights"  type="vector4" value="0, 0, 0, 0" xpos="-72.913040" ypos="-17.974138" />
+    <input name="wood_position" type="vector3"  value="0, 0, 0" xpos="-79.000000" ypos="-28.034483"/>
+    <output name="distorted_position" type="vector3"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_fiber_perlin_distortion>
+    Apply perlin distortion to wood position.
+  -->
+  <nodedef name="ND_wood3d_util_fiber_perlin_distortion" node="wood3d_util_fiber_perlin_distortion" >
+    <input name="fiber_perlin_scale_z" type="float" value="0.0" xpos="-84.188408" ypos="-45.637932"  />
+    <input name="fiber_perlin_frequencies" type="vector4" value="0, 0, 0, 0" xpos="-87.514496" ypos="-41.698277" />
+    <input name="fiber_perlin_weights" type="vector4" value="0, 0, 0, 0" xpos="-73.920288" ypos="-34.646553"/>
+    <input name="wood_position" type="vector3" value="0.0, 0.0, 0.0"  xpos="-86.739128" ypos="-48.431034"/>
+    <output name="distorted_position" type="vector3"  xpos="-52.775364" ypos="-40.844826"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_growth_perlin>
+    Apply growth perlin distortion to wood radius.
+  -->
+  <nodedef name="ND_wood3d_util_growth_perlin" node="wood3d_util_growth_perlin">
+    <input name="growth_perlin_weights" type="vector4" value="0, 0, 0, 0" xpos="-55.847828" ypos="-25.439655" />
+    <input name="growth_perlin_frequencies" type="vector4" value="0, 0, 0, 0" xpos="-72.942032" ypos="-34.051723"  />
+    <input name="radius" type="float" value="0" xpos="-67.739128" ypos="-30.206896"/>
+    <output name="distorted_radius" type="float" />
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_earlywood_color>
+    Compute earlywood color.
+  -->
+  <nodedef name="ND_wood3d_util_earlywood_color" node="wood3d_util_earlywood_color"  >
+    <input name="earlycolor_perlin_frequencies" type="vector4" value="0.0, 0.0, 0.0, 0.0" xpos="-60.550724" ypos="-46.206898" />
+    <input name="earlycolor_perlin_weights" type="vector4" value="0.0, 0.0, 0.0, 0.0" xpos="-46.521740" ypos="-48.982758" />
+    <input name="early_color" type="color3" value="0.0, 0.0, 0.0" xpos="-29.478260" ypos="-43.879311" />
+    <input name="radius" type="float" value="0.0" xpos="-51.347828" ypos="-47.879311" />
+    <output name="earlywood_color" type="color3"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_latewood_color>
+    Compute latewood color.
+  -->
+  <nodedef name="ND_wood3d_util_latewood_color" node="wood3d_util_latewood_color" >
+    <input name="latecolor_perlin_frequencies" type="vector4" value="0.0, 0.0, 0.0, 0.0" xpos="-56.775364" ypos="-30.543104" />
+    <input name="latecolor_perlin_weights" type="vector4" value="0.0, 0.0, 0.0, 0.0" xpos="-43.739132" ypos="-24.568966" />
+    <input name="radius" type="float" value="0.0" xpos="-47.289856" ypos="-32.413792" />
+    <input name="late_color" type="color3" value="0.0, 0.0, 0.0" xpos="-27.311594" ypos="-28.155172" />
+    <output name="latewood_color" type="color3" />
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_perlin_color>
+    Compute perlin color.
+  -->
+  <nodedef name="ND_wood3d_util_perlin_color" node="wood3d_util_perlin_color" >
+    <input name="diffuse_perlin_weights" xpos="-11.876812" ypos="-10.224138" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="diffuse_perlin_scale_z" xpos="-23.920290" ypos="-6.870690" type="float" value="0.0" />
+    <input name="diffuse_perlin_frequencies" xpos="-26.913044" ypos="-4.293103" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="wood_position" xpos="-26.000000" ypos="-9.120689" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="color" type="color3" xpos="5.413043" ypos="-4.982759" value="0.0, 0.0, 0.0" />
+    <output name="perlin_color" type="color3"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_ray>
+    Compute ray color, and ray weight for roughness.
+  -->
+  <nodedef name="ND_wood3d_util_ray" node="wood3d_util_ray" >
+    <input name="ray_seg_length_z" type="float" value="0.0" xpos="-82.260872" ypos="-52.827587" />
+    <input name="ray_ellipse_depth" type="float" value="0.0" xpos="-86.289856" ypos="-55.051723" />
+    <input name="ray_color_power" type="float" value="0.0" xpos="-31.173914" ypos="-58.241379" />
+    <input name="ray_ellipse_scale_x" type="float" value="0.0" xpos="-86.521736" ypos="-49.120689" />
+    <input name="ray_num_slices" type="float" value="0.0" xpos="-64.840576" ypos="-56.413792" />
+    <input name="ray_ellipse_z2x" type="float" value="0.0" xpos="-86.289856" ypos="-51.034481" />
+    <input name="seed" type="float" value="0.0" xpos="-61.086956" ypos="-56.413792" />
+    <input name="wood_position" type="vector3" value="0.0, 0.0, 0.0" xpos="-86.094200" ypos="-58.086208" />
+    <input name="color" type="color3" value="0.0, 0.0, 0.0" xpos="-24.456522" ypos="-59.017242"/>
+    <output name="ray_color" type="color3"  />
+    <output name="ray_weight" type="float" />
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_pore_color>
+    Compute pore color.
+  -->
+  <nodedef name="ND_wood3d_util_pore_color" node="wood3d_util_pore_color">
+    <input name="pore_color_power" type="float" value="0.0" />
+    <input name="pore_weight" type="float" value="0.0"/>
+    <input name="color" type="color3" value="0, 0, 0"/>
+    <output name="pore_color" type="color3"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_roughness>
+    Compute wood roughness
+  -->
+  <nodedef name="ND_wood3d_util_roughness" node="wood3d_util_roughness" >
+    <input name="use_groove_roughness" type="boolean" value="true" xpos="-72.840576" ypos="-55.172413" />
+    <input name="groove_roughness" type="float" value="0.0" xpos="-79.594200" ypos="-51.879311" />
+    <input name="earlywood_ratio" type="float" value="0.0" xpos="-79.521736" ypos="-50.913792" />
+    <input name="ray_weight" type="float" value="0.0" xpos="-70.753624" ypos="-50.913792" />
+    <input name="roughness" type="float" value="0.0" xpos="-75.702896" ypos="-53.810345" />
+    <input name="ray_roughness" type="float" value="0.0" xpos="-70.869568" ypos="-49.913792" />
+    <output name="wood_roughness" type="float"/>
+  </nodedef>
+
+  <!--
+    Node: <wood3d_util_bump>
+    Compute wood bump. Not working due to the issue of procedural normal map in MaterialX
+  -->
+  <nodedef name="ND_wood3d_util_bump" node="wood3d_util_bump">
+    <input name="use_pores_bump" xpos="-78.398552" ypos="-34.534481" type="boolean" value="false"/>
+    <input name="use_late_wood_bump" xpos="-74.442032" ypos="-30.836206" type="boolean" value="false"/>
+    <input name="late_wood_bump_depth" xpos="-75.405800" ypos="-26.758621" type="float"  value="0.0" />
+    <input name="pore_depth" xpos="-87.246376" ypos="-37.732758"  type="float" value="0.0"/>
+    <input name="earlywood_ratio" type="float" value="0.0" xpos="-80.492752" ypos="-29.241379" />
+    <input name="pore_bump_weight" type="float" value="0.0"  xpos="-88.405800" ypos="-33.931034"/>
+    <output name="normal" type="vector3" />
+  </nodedef>
+
+  <!-- 
+      ==============================================
+      Nodedefs for Autodesk 3D wood graph 
+      ==============================================
+  -->
+  <!--
+    Node: <wood3d>
+    3d wood material node graph
+  -->
+  <nodedef name="ND_wood3d" node="wood3d" nodegroup="texture3d">
+    <input name="seed" uiname="Wood generation seed" uifolder="Wood Space Settings" type="float" value="2" uimin="0" uisoftmax="4096" xpos="-107.971016" ypos="-45.672413" />
+    <input name="scale" unittype="distance" uivisible="false" uiname="Scale (should not be changed by user)" uifolder="Wood Space Settings" type="float" value="0.1" uimin="0" uisoftmax="10" xpos="-110.057968" ypos="-47.879311" />
+    <input name="axis" uiname="Wood axis" uifolder="Wood Space Settings" enum="xyz, yzx, zxy" enumvalues="0,1,2" uimin="0" uimax="2" type="float" value="1" xpos="-112.681160" ypos="-48.689655" />
+    <input name="ring_thickness" uiname="Ring thickness" uifolder="Wood Growth Params" uimin="0" uisoftmax="10" type="float" value="0.9" xpos="-74.579712" ypos="-44.551723" />
+    <input name="early_wood_sharpness" uiname="Early wood sharpness" uifolder="Wood Growth Params" uimin="0" uisoftmax="1" type="float" value="0.793" xpos="-75.144928" ypos="-42.637932" />
+    <input name="late_wood_sharpness" uiname="Late wood sharpness" uifolder="Wood Growth Params" uimin="0" uisoftmax="1" type="float" value="0.527" xpos="-75.043480" ypos="-43.603447" />
+    <input name="late_wood_ratio" uiname="Late wood ratio" uifolder="Wood Growth Params" uimin="0" uisoftmax="1" type="float" value="0.059" xpos="-74.652176" ypos="-41.672413" />
+    <input name="use_fiber_perlin" uiname="Use fiber perlin distortion" uifolder="Wood Growth Params" type="boolean" value="true" xpos="-89.681160" ypos="-51.741379" />
+    <input name="fiber_perlin_frequencies" uiname="Fiber perlin frequencies(cm)" uifolder="Wood Growth Params" uimin="0" uisoftmax="100" type="vector4" value="23.5, 8, 2, 0" xpos="-95.101448" ypos="-52.827587" />
+    <input name="fiber_perlin_weights" uiname="Fiber perlin weights" uifolder="Wood Growth Params" uimin="0" uisoftmax="10" type="vector4" value="1.25, 0.75, 0.15, 0" xpos="-94.753624" ypos="-51.862068" />
+    <input name="fiber_perlin_scale_z" uiname="Fiber perlin scale z" uifolder="Wood Growth Params" uimin="0" uisoftmax="1" type="float" value="0.3" xpos="-94.739128" ypos="-53.793102" />
+    <input name="use_fiber_cosine" uiname="Use fiber cosine distortion" uifolder="Wood Growth Params" type="boolean" value="true" xpos="-97.101448" ypos="-51.862068" />
+    <input name="fiber_cosine_frequencies" uiname="Fiber cosine frequencies(cm)" uifolder="Wood Growth Params" uimin="0" uisoftmax="100" type="vector4" value="15, 2, 0, 0" xpos="-102.057968" ypos="-52.965519" />
+    <input name="fiber_cosine_weights" uiname="Fiber cosine weights" uifolder="Wood Growth Params" uimin="0" uisoftmax="10" type="vector4" value="0.5, 0.5, 0, 0" xpos="-101.710144" ypos="-52.000000" />
+    <input name="use_growth_perlin" uiname="Use growth perlin distortion" uifolder="Wood Growth Params" type="boolean" value="false" xpos="-77.905800" ypos="-52.051723" />
+    <input name="growth_perlin_frequencies" uiname="Growth Perlin distortion frequencies(cm)" uifolder="Wood Growth Params" uimin="0" uisoftmax="100" type="vector4" value="1.0, 0, 0, 0" xpos="-81.710144" ypos="-51.775864" />
+    <input name="growth_perlin_weights" uiname="Growth Perlin distortion weights" uifolder="Wood Growth Params" uimin="0" uisoftmax="10" type="vector4" value="0.5, 0, 0, 0" xpos="-81.340576" ypos="-52.741379" />
+    <input name="early_color" uiname="Early wood color" uifolder="Color Params" type="color3" value="0.420508 0.267358 0.144972" xpos="-71.101448" ypos="-49.948277" />
+    <input name="use_early_wood_color_perlin" uiname="Use early wood color distortion" uifolder="Color Params" type="boolean" value="true" xpos="-60.724636" ypos="-51.982758" />
+    <input name="earlycolor_perlin_frequencies" uiname="Early wood color distortion frequencies(cm)" uifolder="Color Params" uimin="0" uisoftmax="100" type="vector4" value="8, 3, 0.35, 0.0" xpos="-66.463768" ypos="-52.568966" />
+    <input name="earlycolor_perlin_weights" uiname="Early wood color distortion weights" uifolder="Color Params" uimin="0" uisoftmax="10" type="vector4" value="0.2, 0.3, 0.15, 0.0" xpos="-66.137680" ypos="-51.568966" />
+    <input name="use_manual_late_wood_color" uiname="Use manual late wood color" uifolder="Color Params" type="boolean" value="false" xpos="-70.159424" ypos="-46.913792" />
+    <input name="manual_late_wood_color" uiname="Manual late wood color" uifolder="Color Params" type="color3" value="0, 0, 0" xpos="-69.826088" ypos="-48.000000" />
+    <input name="late_wood_color_power" uiname="Late wood color power" uimin="0" uisoftmax="5" uifolder="Color Params" type="float" value="1.38" xpos="-71.797104" ypos="-45.672413" />
+    <input name="use_late_wood_color_perlin" uiname="Use late wood color distortion" uifolder="Color Params" type="boolean" value="true" xpos="-60.666668" ypos="-47.568966" />
+    <input name="latecolor_perlin_frequencies" uiname="Late wood color distortion frequencies(cm)" uifolder="Color Params" uimin="0" uisoftmax="100" type="vector4" value="4.5, 1.5 , 0, 0" xpos="-66.000000" ypos="-48.517242" />
+    <input name="latecolor_perlin_weights" uiname="Late wood color distortion weights" uifolder="Color Params" uimin="0" uisoftmax="10" type="vector4" value="0.25, 0.15, 0.0, 0.0" xpos="-65.652176" ypos="-47.568966" />
+    <input name="use_diffuse_perlin" uiname="Use diffuse color perlin" uifolder="Color Params" type="boolean" value="true" xpos="-45.920288" ypos="-49.931034" />
+    <input name="diffuse_perlin_frequencies" uiname="Diffuse color perlin frequencies(cm)" uifolder="Color Params" uimin="0" uisoftmax="100" type="vector4" value="0.1, 0.4, 5, 0.01" xpos="-51.536232" ypos="-49.258621" />
+    <input name="diffuse_perlin_weights" uiname="Diffuse color perlin weights" uifolder="Color Params" uimin="0" uisoftmax="10" type="vector4" value="0.1, 0.15, 0.2, 0.4" xpos="-51.210144" ypos="-51.172413" />
+    <input name="diffuse_perlin_scale_z" uiname="Diffuse color perlin scale z" uifolder="Color Params" uimin="0" uisoftmax="1" type="float" value="0.1" xpos="-51.210144" ypos="-50.224136" />
+    <input name="diffuse_lobe_weight" uiname="Diffuse lobe weight" uifolder="Color Params" uimin="0" uisoftmax="1" type="float" value="0.8" xpos="-28.000000" ypos="-46.482758" />
+    <input name="use_pore_color" uiname="Use pore" uifolder="Pores Params" type="boolean" value="true" xpos="-39.818840" ypos="-49.948277" />
+    <input name="pore_type" uiname="Pore type" uifolder="Pores Params" enum="both, early, late" enumvalues="0,1,2" uimin="0" uimax="2" type="integer" value="0" xpos="-46.869564" ypos="-44.844826" />
+    <input name="pore_cell_dim" uiname="Pore cell dim" uifolder="Pores Params" uimin="0" uisoftmax="10" type="float" value="1.5" xpos="-47.217392" ypos="-43.862068" />
+    <input name="pore_radius" uiname="Pore radius" uifolder="Pores Params" uimin="0" uisoftmax="1" type="float" value="0.06" xpos="-47.101448" ypos="-42.905174" />
+    <input name="pore_color_power" uiname="Pore color power" uifolder="Pores Params" uimin="0" uisoftmax="5" type="float" value="1.45" xpos="-42.753624" ypos="-49.948277" />
+    <input name="use_ray_color" uiname="Use ray" uifolder="Rays Params" type="boolean" value="true" xpos="-31.166666" ypos="-50.637932" />
+    <input name="ray_seg_length_z" uiname="Ray seg length z" uifolder="Rays Params" uimin="0" uisoftmax="10" type="float" value="5" xpos="-36.376812" ypos="-53.948277" />
+    <input name="ray_ellipse_depth" uiname="Ray ellipse depth" uifolder="Rays Params" uimin="0" uisoftmax="10" type="float" value="2" xpos="-36.347828" ypos="-52.974136" />
+    <input name="ray_color_power" uiname="Ray color power" uifolder="Rays Params" uimin="0" uisoftmax="5" type="float" value="1.1" xpos="-36.347828" ypos="-52.034481" />
+    <input name="ray_ellipse_scale_x" uiname="Ray ellipse scale x" uifolder="Rays Params" uimin="0" uisoftmax="1" type="float" value="0.2" xpos="-36.347828" ypos="-51.051723" />
+    <input name="ray_num_slices" uiname="Ray num" uifolder="Rays Params" type="float" uimin="0" uisoftmax="500" value="160" xpos="-36.347828" ypos="-50.086208" />
+    <input name="ray_ellipse_z2x" uiname="Ray ellipse z2x" uifolder="Rays Params" uimin="0" uisoftmax="50" type="float" value="10" xpos="-36.304348" ypos="-49.112068" />
+    <input name="use_groove_roughness" uiname="Use groove roughness" uifolder="Wood Roughness Params" type="boolean" value="true" xpos="-29.594202" ypos="-45.155174" />
+    <input name="groove_roughness" uiname="Groove roughness" uifolder="Wood Roughness Params" uimin="0" uisoftmax="1" type="float" value="0.19" xpos="-29.246376" ypos="-44.189655" />
+    <input name="roughness" uiname="Roughness" uifolder="Wood Roughness Params" uimin="0" uisoftmax="1" type="float" value="0.16" xpos="-28.666666" ypos="-41.551723" />
+    <input name="ray_roughness" uiname="Ray roughness" uifolder="Wood Roughness Params" uimin="0" uisoftmax="1" type="float" value="0.1" xpos="-28.934782" ypos="-40.586208" />
+    <input name="use_pores_bump" uiname="Use pores for bump" uifolder="Wood Bump Params (not working)" type="boolean" value="false" xpos="-41.195652" ypos="-44.137932" />
+    <input name="use_late_wood_bump" uiname="Use late wood bump" uifolder="Wood Bump Params (not working)" type="boolean" value="true" xpos="-41.543480" ypos="-43.310345" />
+    <input name="late_wood_bump_depth" uiname="Late wood bump depth" uifolder="Wood Bump Params (not working)" type="float" xpos="-41.760868" ypos="-42.344826" value="0" />
+    <input name="pore_depth" uiname="Pore depth" uifolder="Wood Bump Params (not working)" type="float" value="0.025" xpos="-41.000000" ypos="-41.379311" />
+    <output name="diffuse_color" type="color3"/>
+    <output name="wood_roughness" type="float"/>
+    <output name="normal" type="vector3"/>
+  </nodedef>
+
+
+</materialx>

--- a/contrib/adsk/libraries/adsklib/adsklib_3dwood_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_3dwood_ng.mtlx
@@ -1,0 +1,1659 @@
+<?xml version="1.0" ?>
+<materialx version="1.38">
+  <!--
+  DESCRIPTION: Nodegraphs for Autodesk 3D wood material
+  -->
+
+  <!-- 
+      ================================================
+      Nodegraphs for Autodesk 3D wood material
+      ================================================
+  -->
+  <nodegraph name="NG_wood3d_util_ratio" nodedef="ND_wood3d_util_ratio">
+    <divide name="ratio_divide_float7" type="float" xpos="-38.934784" ypos="-51.327587">
+      <input name="in1" type="float" nodename="ratio_subtract_float" />
+      <input name="in2" type="float" nodename="ratio_fall_width" />
+    </divide>
+    <multiply name="ratio_early_wood_to_fall" type="float" xpos="-45.130436" ypos="-48.258621">
+      <input name="in1" type="float" nodename="fall_to_late_wood" />
+      <input name="in2" type="float" interfacename="early_wood_sharpness" />
+    </multiply>
+    <ifgreatereq name="_earlywood_ratio" type="float" xpos="-32.028984" ypos="-49.327587">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" nodename="ratio_ifgreatereq_float2" />
+      <input name="value2" type="float" nodename="ratio_fraction" />
+      <input name="value1" type="float" nodename="ratio_early_wood_to_fall" />
+    </ifgreatereq>
+    <floor name="ratio_floor_float" type="float" xpos="-45.826088" ypos="-50.206898">
+      <input name="in" type="float" nodename="ratio_divide_float9" />
+    </floor>
+    <subtract name="ratio_fraction" type="float" xpos="-43.963768" ypos="-51.189655">
+      <input name="in2" type="float" nodename="ratio_floor_float" />
+      <input name="in1" type="float" nodename="ratio_divide_float9" />
+    </subtract>
+    <subtract name="ratio_rise_width" type="float" xpos="-41.797100" ypos="-45.396553">
+      <input name="in2" type="float" nodename="ratio_late_wood_to_rise" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <subtract name="ratio_fall_width" type="float" xpos="-41.021740" ypos="-50.741379">
+      <input name="in1" type="float" nodename="fall_to_late_wood" />
+      <input name="in2" type="float" nodename="ratio_early_wood_to_fall" />
+    </subtract>
+    <add name="ratio_late_wood_to_rise" type="float" xpos="-45.347828" ypos="-46.189655">
+      <input name="in2" type="float" nodename="ratio_multiply_float20" />
+      <input name="in1" type="float" nodename="fall_to_late_wood" />
+    </add>
+    <divide name="ratio_divide_float8" type="float" xpos="-39.710144" ypos="-46.224136">
+      <input name="in1" type="float" nodename="ratio_subtract_float3" />
+      <input name="in2" type="float" nodename="ratio_rise_width" />
+    </divide>
+    <subtract name="ratio_subtract_float3" type="float" xpos="-42.181160" ypos="-46.741379">
+      <input name="in1" type="float" nodename="ratio_fraction" />
+      <input name="in2" type="float" nodename="ratio_late_wood_to_rise" />
+    </subtract>
+    <ifgreatereq name="ratio_ifgreatereq_float3" type="float" xpos="-37.536232" ypos="-46.775864">
+      <input name="in1" type="float" value="0" />
+      <input name="in2" type="float" nodename="ratio_divide_float8" />
+      <input name="value2" type="float" nodename="ratio_fraction" />
+      <input name="value1" type="float" nodename="ratio_late_wood_to_rise" />
+    </ifgreatereq>
+    <subtract name="ratio_subtract_float" type="float" xpos="-41.355072" ypos="-51.982758">
+      <input name="in1" type="float" nodename="ratio_fraction" />
+      <input name="in2" type="float" nodename="ratio_early_wood_to_fall" />
+    </subtract>
+    <subtract name="ratio_subtract_float2" type="float" xpos="-36.731884" ypos="-51.327587">
+      <input name="in2" type="float" nodename="ratio_divide_float7" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <multiply name="ratio_multiply_float20" type="float" xpos="-47.702900" ypos="-46.189655">
+      <input name="in1" type="float" interfacename="late_wood_ratio" />
+      <input name="in2" type="float" interfacename="late_wood_sharpness" />
+    </multiply>
+    <ifgreatereq name="ratio_ifgreatereq_float2" type="float" xpos="-34.637680" ypos="-49.241379">
+      <input name="in1" type="float" nodename="ratio_subtract_float2" />
+      <input name="in2" type="float" nodename="ratio_ifgreatereq_float3" />
+      <input name="value2" type="float" nodename="ratio_fraction" />
+      <input name="value1" type="float" nodename="fall_to_late_wood" />
+    </ifgreatereq>
+    <subtract name="fall_to_late_wood" type="float" xpos="-47.789856" ypos="-48.155174">
+      <input name="in2" type="float" interfacename="late_wood_ratio" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <divide name="ratio_divide_float9" type="float" xpos="-48.007248" ypos="-50.905174">
+      <input name="in1" type="float" interfacename="radius" />
+      <input name="in2" type="float" interfacename="ring_thickness" />
+    </divide>
+    <output name="earlywood_ratio" type="float" nodename="_earlywood_ratio" xpos="-30.057972" ypos="-48.827587" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_fiber_cosine_distortion" nodedef="ND_wood3d_util_fiber_cosine_distortion">
+    <combine2 name="radius_combine2_vector2" type="vector2" xpos="-66.811592" ypos="-30.603449">
+      <input name="in1" type="float" output="outx" nodename="seperated_wood_position" />
+      <input name="in2" type="float" output="outy" nodename="seperated_wood_position" />
+    </combine2>
+    <separate4 name="fiber_separated_weight" type="multioutput" xpos="-69.811592" ypos="-17.603449">
+      <input name="in" type="vector4" interfacename="fiber_cosine_weights" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <multiply name="fiber_multiply_float5" type="float" xpos="-67.043480" ypos="-24.431034">
+      <input name="in2" type="float" output="outx" nodename="fiber_separated_weight" />
+      <input name="in1" type="float" nodename="cos_float" />
+    </multiply>
+    <add name="fiber_add_float" type="float" xpos="-64.608696" ypos="-23.568966">
+      <input name="in1" type="float" nodename="fiber_multiply_float5" />
+      <input name="in2" type="float" nodename="fiber_multiply_float6" />
+    </add>
+    <add name="fiber_add_float2" type="float" xpos="-63.014492" ypos="-21.103449">
+      <input name="in2" type="float" nodename="fiber_multiply_float7" />
+      <input name="in1" type="float" nodename="fiber_add_float" />
+    </add>
+    <cos name="cos_float3" type="float" xpos="-68.702896" ypos="-21.103449">
+      <input name="in" type="float" nodename="fiber_multiply_float3" />
+    </cos>
+    <multiply name="fiber_multiply_float14" type="float" xpos="-43.673912" ypos="-23.612068">
+      <input name="in2" type="float" nodename="fiber_shift_weight" />
+      <input name="in1" type="float" nodename="radius_sin_theta" />
+    </multiply>
+    <multiply name="fiber_multiply_float4" type="float" xpos="-71.101448" ypos="-19.844828">
+      <input name="in2" type="float" nodename="inverse_freq_w" />
+      <input name="in1" type="float" nodename="radius_angdist" />
+    </multiply>
+    <multiply name="fiber_multiply_float7" type="float" xpos="-66.992752" ypos="-21.224138">
+      <input name="in1" type="float" nodename="cos_float3" />
+      <input name="in2" type="float" output="outz" nodename="fiber_separated_weight" />
+    </multiply>
+    <multiply name="fiber_multiply_float8" type="float" xpos="-66.927536" ypos="-19.844828">
+      <input name="in1" type="float" nodename="cos_float4" />
+      <input name="in2" type="float" output="outw" nodename="fiber_separated_weight" />
+    </multiply>
+    <divide name="fiber_divide_float" type="float" xpos="-60.500000" ypos="-24.672413">
+      <input name="in1" type="float" nodename="radius_magnitude_vector2" />
+      <input name="in2" type="float" value="1.5" />
+    </divide>
+    <multiply name="fiber_multiply_float13" type="float" xpos="-43.413044" ypos="-25.810345">
+      <input name="in2" type="float" nodename="fiber_shift_weight" />
+      <input name="in1" type="float" nodename="radius_cos_theta" />
+    </multiply>
+    <multiply name="fiber_multiply_float11" type="float" xpos="-52.898552" ypos="-21.086206">
+      <input name="in2" type="float" nodename="fiber_subtract_float2" />
+      <input name="in1" type="float" nodename="saturate_float" />
+    </multiply>
+    <ifgreatereq name="radius_ifgreatereq_vector3" type="vector3" xpos="-36.471016" ypos="-27.887932">
+      <input name="value1" type="float" nodename="radius_magnitude_vector2" />
+      <input name="value2" type="float" value="0.0001" />
+      <input name="in2" type="vector3" value="0, 0, 0" />
+      <input name="in1" type="vector3" nodename="fiber_p2" />
+    </ifgreatereq>
+    <separate4 name="fiber_separated_frequencies" type="multioutput" xpos="-79.333336" ypos="-23.086206">
+      <input name="in" type="vector4" interfacename="fiber_cosine_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <cos name="cos_float2" type="float" xpos="-68.702896" ypos="-22.637932">
+      <input name="in" type="float" nodename="fiber_multiply_float2" />
+    </cos>
+    <cos name="cos_float" type="float" xpos="-68.746376" ypos="-24.431034">
+      <input name="in" type="float" nodename="fiber_multiply_float" />
+    </cos>
+    <multiply name="fiber_multiply_float9" type="float" xpos="-57.717392" ypos="-21.637932">
+      <input name="in2" type="float" value="2" />
+      <input name="in1" type="float" nodename="saturate_float" />
+    </multiply>
+    <divide name="radius_angdist" type="float" xpos="-75.043480" ypos="-27.172413">
+      <input name="in1" type="float" output="outz" nodename="seperated_wood_position" />
+      <input name="in2" type="float" value="6.28319" />
+    </divide>
+    <multiply name="fiber_multiply_float6" type="float" xpos="-66.992752" ypos="-22.775862">
+      <input name="in1" type="float" nodename="cos_float2" />
+      <input name="in2" type="float" output="outy" nodename="fiber_separated_weight" />
+    </multiply>
+    <subtract name="fiber_subtract_float2" type="float" xpos="-55.565216" ypos="-21.086206">
+      <input name="in2" type="float" nodename="fiber_multiply_float9" />
+      <input name="in1" type="float" value="3" />
+    </subtract>
+    <ifgreater name="fiber_ifgreater_float" type="float" xpos="-47.797100" ypos="-22.982759">
+      <input name="value1" type="float" nodename="saturate_float" />
+      <input name="value2" type="float" value="0.5" />
+      <input name="in2" type="float" nodename="saturate_float" />
+      <input name="in1" type="float" nodename="fiber_multiply_float12" />
+    </ifgreater>
+    <multiply name="fiber_multiply_float" type="float" xpos="-71.202896" ypos="-24.732759">
+      <input name="in1" type="float" nodename="radius_angdist" />
+      <input name="in2" type="float" nodename="inverse_freq_x" />
+    </multiply>
+    <add name="fiber_add_float6" type="float" xpos="-39.760868" ypos="-23.750000">
+      <input name="in2" type="float" nodename="fiber_multiply_float14" />
+      <input name="in1" type="float" output="outy" nodename="seperated_wood_position" />
+    </add>
+    <add name="fiber_add_float3" type="float" xpos="-61.275364" ypos="-19.465517">
+      <input name="in1" type="float" nodename="fiber_add_float2" />
+      <input name="in2" type="float" nodename="fiber_multiply_float8" />
+    </add>
+    <multiply name="fiber_multiply_float3" type="float" xpos="-71.166664" ypos="-21.241379">
+      <input name="in2" type="float" nodename="inverse_freq_z" />
+      <input name="in1" type="float" nodename="radius_angdist" />
+    </multiply>
+    <divide name="radius_cos_theta" type="float" xpos="-61.826088" ypos="-29.120689">
+      <input name="in1" type="float" output="outx" nodename="seperated_wood_position" />
+      <input name="in2" type="float" nodename="radius_magnitude_vector2" />
+    </divide>
+    <cos name="cos_float4" type="float" xpos="-68.586960" ypos="-19.724138">
+      <input name="in" type="float" nodename="fiber_multiply_float4" />
+    </cos>
+    <divide name="radius_sin_theta" type="float" xpos="-61.826088" ypos="-27.741379">
+      <input name="in1" type="float" output="outy" nodename="seperated_wood_position" />
+      <input name="in2" type="float" nodename="radius_magnitude_vector2" />
+    </divide>
+    <multiply name="fiber_multiply_float2" type="float" xpos="-71.217392" ypos="-22.879311">
+      <input name="in2" type="float" nodename="inverse_freq_y" />
+      <input name="in1" type="float" nodename="radius_angdist" />
+    </multiply>
+    <multiply name="fiber_multiply_float12" type="float" xpos="-50.485508" ypos="-20.965517">
+      <input name="in1" type="float" nodename="saturate_float" />
+      <input name="in2" type="float" nodename="fiber_multiply_float11" />
+    </multiply>
+    <combine3 name="fiber_p2" type="vector3" xpos="-36.833332" ypos="-25.215517">
+      <input name="in3" type="float" output="outz" nodename="seperated_wood_position" />
+      <input name="in1" type="float" nodename="fiber_add_float5" />
+      <input name="in2" type="float" nodename="fiber_add_float6" />
+    </combine3>
+    <add name="fiber_add_float5" type="float" xpos="-39.811596" ypos="-26.474138">
+      <input name="in2" type="float" nodename="fiber_multiply_float13" />
+      <input name="in1" type="float" output="outx" nodename="seperated_wood_position" />
+    </add>
+    <multiply name="fiber_shift_weight" type="float" xpos="-45.710144" ypos="-19.310345">
+      <input name="in1" type="float" nodename="fiber_ifgreater_float" />
+      <input name="in2" type="float" nodename="fiber_add_float3" />
+    </multiply>
+    <magnitude name="radius_magnitude_vector2" type="float" xpos="-64.434784" ypos="-30.482759">
+      <input name="in" type="vector2" nodename="radius_combine2_vector2" />
+    </magnitude>
+    <clamp name="saturate_float" type="float" xpos="-58.347828" ypos="-24.336206">
+      <input name="in" type="float" nodename="fiber_divide_float" />
+    </clamp>
+    <separate3 name="seperated_wood_position" type="multioutput" xpos="-77.478264" ypos="-28.844828">
+      <input name="in" type="vector3" interfacename="wood_position" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+    </separate3>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-74.231888" ypos="-24.120689">
+      <input name="value1" type="float" output="outx" nodename="fiber_separated_frequencies" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-75.586960" ypos="-24.120689">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="fiber_separated_frequencies" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-75.586960" ypos="-22.862068">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="fiber_separated_frequencies" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-74.231888" ypos="-22.844828">
+      <input name="value1" type="float" output="outy" nodename="fiber_separated_frequencies" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-75.586960" ypos="-21.603449">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="fiber_separated_frequencies" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-74.231888" ypos="-21.603449">
+      <input name="value1" type="float" output="outz" nodename="fiber_separated_frequencies" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-75.507248" ypos="-20.362068">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="fiber_separated_frequencies" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-74.231888" ypos="-20.258621">
+      <input name="value1" type="float" output="outw" nodename="fiber_separated_frequencies" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+  
+    <output name="distorted_position" type="vector3" nodename="radius_ifgreatereq_vector3" xpos="-33.057972" ypos="-27.310345" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_fiber_perlin_distortion" nodedef="ND_wood3d_util_fiber_perlin_distortion">
+    <combine3 name="radius_p_aniso" type="vector3" xpos="-78.869568" ypos="-46.293102">
+      <input name="in3" type="float" nodename="radius_multiply_float3" />
+      <input name="in2" type="float" output="outy" nodename="radius_separated" />
+      <input name="in1" type="float" output="outx" nodename="radius_separated" />
+    </combine3>
+    <separate3 name="radius_separated" type="multioutput" xpos="-83.659424" ypos="-48.456898">
+      <input name="in" type="vector3" interfacename="wood_position" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+    </separate3>
+    <multiply name="radius_multiply_float3" type="float" xpos="-81.710144" ypos="-45.905174">
+      <input name="in1" type="float" output="outz" nodename="radius_separated" />
+      <input name="in2" type="float" interfacename="fiber_perlin_scale_z" />
+    </multiply>
+    <multiply name="radius_multiply_vector3FA" type="vector3" xpos="-77.210144" ypos="-42.318966">
+      <input name="in1" type="vector3" nodename="radius_p_aniso" />
+      <input name="in2" type="float" nodename="inverse_freq_x" />
+    </multiply>
+    <multiply name="radius_multiply_float5" type="float" xpos="-67.543480" ypos="-37.836208">
+      <input name="in1" type="float" nodename="radius_multiply_float11" />
+      <input name="in2" type="float" output="outz" nodename="perlin_weights_separated" />
+    </multiply>
+    <multiply name="radius_multiply_vector3FA3" type="vector3" xpos="-77.231888" ypos="-39.051723">
+      <input name="in1" type="vector3" nodename="radius_p_aniso" />
+      <input name="in2" type="float" nodename="inverse_freq_z" />
+    </multiply>
+    <add name="radius_add_float" type="float" xpos="-66.717392" ypos="-40.603447">
+      <input name="in1" type="float" nodename="radius_multiply_float4" />
+      <input name="in2" type="float" nodename="radius_multiply_float6" />
+    </add>
+    <noise3d name="radius_noise3d_float2" type="float" xpos="-74.471016" ypos="-40.551723">
+      <input name="position" type="vector3" nodename="radius_multiply_vector3FA2" />
+    </noise3d>
+    <separate4 name="perlin_frequencies_separated" type="multioutput" xpos="-84.963768" ypos="-42.172413">
+      <input name="in" type="vector4" interfacename="fiber_perlin_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <multiply name="radius_multiply_vector3FA2" type="vector3" xpos="-77.260872" ypos="-40.801723">
+      <input name="in1" type="vector3" nodename="radius_p_aniso" />
+      <input name="in2" type="float" nodename="inverse_freq_y" />
+    </multiply>
+    <separate4 name="perlin_weights_separated" type="multioutput" xpos="-71.311592" ypos="-35.301723">
+      <input name="in" type="vector4" interfacename="fiber_perlin_weights" />
+      <output name="outx" type="float" />
+      <output name="outz" type="float" />
+      <output name="outy" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <multiply name="radius_multiply_float10" type="float" xpos="-66.260872" ypos="-35.732758">
+      <input name="in2" type="float" output="outw" nodename="perlin_weights_separated" />
+      <input name="in1" type="float" nodename="radius_multiply_float13" />
+    </multiply>
+    <multiply name="radius_multiply_float8" type="float" xpos="-72.173912" ypos="-42.353447">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="radius_noise3d_float" />
+    </multiply>
+    <multiply name="radius_multiply_vector3FA5" type="vector3" xpos="-77.152176" ypos="-37.422413">
+      <input name="in2" type="float" nodename="inverse_freq_w" />
+      <input name="in1" type="vector3" nodename="radius_p_aniso" />
+    </multiply>
+    <add name="radius_add_float4" type="float" xpos="-64.173912" ypos="-39.870689">
+      <input name="in1" type="float" nodename="radius_add_float" />
+      <input name="in2" type="float" nodename="radius_multiply_float5" />
+    </add>
+    <multiply name="radius_multiply_float13" type="float" xpos="-71.934784" ypos="-36.870689">
+      <input name="in2" type="float" nodename="radius_noise3d_float8" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="radius_multiply_float11" type="float" xpos="-71.833336" ypos="-38.508621">
+      <input name="in2" type="float" nodename="radius_noise3d_float3" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <noise3d name="radius_noise3d_float8" type="float" xpos="-74.188408" ypos="-37.232758">
+      <input name="position" type="vector3" nodename="radius_multiply_vector3FA5" />
+    </noise3d>
+    <multiply name="radius_multiply_float14" type="float" xpos="-72.166664" ypos="-40.456898">
+      <input name="in2" type="float" nodename="radius_noise3d_float2" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <noise3d name="radius_noise3d_float" type="float" xpos="-74.478264" ypos="-42.215519">
+      <input name="position" type="vector3" nodename="radius_multiply_vector3FA" />
+    </noise3d>
+    <noise3d name="radius_noise3d_float3" type="float" xpos="-74.413040" ypos="-38.758621">
+      <input name="position" type="vector3" nodename="radius_multiply_vector3FA3" />
+    </noise3d>
+    <multiply name="radius_multiply_float4" type="float" xpos="-69.862320" ypos="-42.232758">
+      <input name="in1" type="float" nodename="radius_multiply_float8" />
+      <input name="in2" type="float" output="outx" nodename="perlin_weights_separated" />
+    </multiply>
+    <add name="radius_add_float2" type="float" xpos="-58.811596" ypos="-42.224136">
+      <input name="in2" type="float" nodename="radius_radial_shift" />
+      <input name="in1" type="float" output="outy" nodename="radius_separated" />
+    </add>
+    <add name="radius_add_float3" type="float" xpos="-59.934784" ypos="-44.672413">
+      <input name="in1" type="float" output="outx" nodename="radius_separated" />
+      <input name="in2" type="float" nodename="radius_radial_shift" />
+    </add>
+    <combine3 name="radius_distorted_position" type="vector3" xpos="-55.978260" ypos="-41.129311">
+      <input name="in3" type="float" output="outz" nodename="radius_separated" />
+      <input name="in2" type="float" nodename="radius_add_float2" />
+      <input name="in1" type="float" nodename="radius_add_float3" />
+    </combine3>
+    <add name="radius_radial_shift" type="float" xpos="-61.398552" ypos="-40.577587">
+      <input name="in1" type="float" nodename="radius_add_float4" />
+      <input name="in2" type="float" nodename="radius_multiply_float10" />
+    </add>
+    <multiply name="radius_multiply_float6" type="float" xpos="-69.420288" ypos="-40.068966">
+      <input name="in1" type="float" nodename="radius_multiply_float14" />
+      <input name="in2" type="float" output="outy" nodename="perlin_weights_separated" />
+    </multiply>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-79.681160" ypos="-42.189655">
+      <input name="value1" type="float" output="outx" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-81.036232" ypos="-42.189655">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="perlin_frequencies_separated" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-81.036232" ypos="-40.931034">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-79.681160" ypos="-40.913792">
+      <input name="value1" type="float" output="outy" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-81.036232" ypos="-39.672413">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-79.681160" ypos="-39.672413">
+      <input name="value1" type="float" output="outz" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-80.956520" ypos="-38.431034">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-79.681160" ypos="-38.327587">
+      <input name="value1" type="float" output="outw" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+    <output name="distorted_position" type="vector3" xpos="-52.775364" ypos="-40.844826" nodename="radius_distorted_position" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_growth_perlin"  nodedef="ND_wood3d_util_growth_perlin">
+    <multiply name="radius_multiply_float26" type="float" xpos="-60.695652" ypos="-31.732759">
+      <input name="in1" type="float" nodename="inverse_freq_y" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <multiply name="radius_multiply_float24" type="float" xpos="-60.695652" ypos="-33.525864">
+      <input name="in1" type="float" nodename="inverse_freq_x" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <add name="radius_growth" type="float" xpos="-42.275364" ypos="-29.836206">
+      <input name="in1" type="float" nodename="radius_add_float8" />
+      <input name="in2" type="float" nodename="radius_multiply_float12" />
+    </add>
+    <add name="radius_add_float7" type="float" xpos="-46.521740" ypos="-32.767242">
+      <input name="in1" type="float" nodename="radius_multiply_float21" />
+      <input name="in2" type="float" nodename="radius_multiply_float25" />
+    </add>
+    <multiply name="radius_multiply_float21" type="float" xpos="-49.210144" ypos="-32.939655">
+      <input name="in1" type="float" nodename="radius_multiply_float15" />
+      <input name="in2" type="float" output="outx" nodename="growth_perlin_weights_separated" />
+    </multiply>
+    <multiply name="radius_multiply_float22" type="float" xpos="-60.826088" ypos="-29.836206">
+      <input name="in1" type="float" nodename="inverse_freq_z" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <multiply name="radius_multiply_float23" type="float" xpos="-49.065216" ypos="-29.508621">
+      <input name="in1" type="float" nodename="radius_multiply_float17" />
+      <input name="in2" type="float" output="outz" nodename="growth_perlin_weights_separated" />
+    </multiply>
+    <multiply name="radius_multiply_float25" type="float" xpos="-49.173912" ypos="-31.387932">
+      <input name="in1" type="float" nodename="radius_multiply_float16" />
+      <input name="in2" type="float" output="outy" nodename="growth_perlin_weights_separated" />
+    </multiply>
+    <add name="radius_add_float8" type="float" xpos="-44.586956" ypos="-31.060345">
+      <input name="in1" type="float" nodename="radius_add_float7" />
+      <input name="in2" type="float" nodename="radius_multiply_float23" />
+    </add>
+    <combine3 name="radius_combine3_2" type="vector3" xpos="-57.681160" ypos="-31.767241">
+      <input name="in1" type="float" nodename="radius_multiply_float26" />
+    </combine3>
+    <noise3d name="radius_noise3d_float4" type="float" xpos="-54.282608" ypos="-31.594828">
+      <input name="position" type="vector3" nodename="radius_combine3_2" />
+    </noise3d>
+    <noise3d name="radius_noise3d_float6" type="float" xpos="-54.166668" ypos="-27.870689">
+      <input name="position" type="vector3" nodename="radius_combine3_4" />
+    </noise3d>
+    <noise3d name="radius_noise3d_float7" type="float" xpos="-54.217392" ypos="-29.801723">
+      <input name="position" type="vector3" nodename="radius_combine3_3" />
+    </noise3d>
+    <combine3 name="radius_combine3_1" type="vector3" xpos="-57.579712" ypos="-33.801723">
+      <input name="in1" type="float" nodename="radius_multiply_float24" />
+    </combine3>
+    <combine3 name="radius_combine3_4" type="vector3" xpos="-57.804348" ypos="-28.025862">
+      <input name="in1" type="float" nodename="radius_multiply_float9" />
+    </combine3>
+    <combine3 name="radius_combine3_3" type="vector3" xpos="-57.681160" ypos="-29.956896">
+      <input name="in1" type="float" nodename="radius_multiply_float22" />
+    </combine3>
+    <multiply name="radius_multiply_float9" type="float" xpos="-60.826088" ypos="-27.767241">
+      <input name="in1" type="float" nodename="inverse_freq_w" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <noise3d name="radius_noise3d_float5" type="float" xpos="-54.333332" ypos="-33.801723">
+      <input name="position" type="vector3" nodename="radius_combine3_1" />
+    </noise3d>
+    <multiply name="radius_multiply_float12" type="float" xpos="-49.101448" ypos="-27.474138">
+      <input name="in2" type="float" output="outw" nodename="growth_perlin_weights_separated" />
+      <input name="in1" type="float" nodename="radius_multiply_float18" />
+    </multiply>
+    <multiply name="radius_multiply_float17" type="float" xpos="-51.898552" ypos="-29.698277">
+      <input name="in2" type="float" nodename="radius_noise3d_float7" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <add name="radius_add_float5" type="float" xpos="-40.724636" ypos="-27.741379">
+      <input name="in2" type="float" interfacename="radius" />
+      <input name="in1" type="float" nodename="radius_growth" />
+    </add>
+    <multiply name="radius_multiply_float15" type="float" xpos="-51.782608" ypos="-33.405174">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="radius_noise3d_float5" />
+    </multiply>
+    <multiply name="radius_multiply_float18" type="float" xpos="-51.768116" ypos="-27.767241">
+      <input name="in2" type="float" nodename="radius_noise3d_float6" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="radius_multiply_float16" type="float" xpos="-51.782608" ypos="-31.353449">
+      <input name="in2" type="float" nodename="radius_noise3d_float4" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <separate4 name="growth_frequencies_separated" type="multioutput" xpos="-69.594200" ypos="-34.327587">
+      <input name="in" type="vector4" interfacename="growth_perlin_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <separate4 name="growth_perlin_weights_separated" type="multioutput" xpos="-51.855072" ypos="-25.603449">
+      <input name="in" type="vector4" interfacename="growth_perlin_weights" />
+      <output name="outx" type="float" />
+      <output name="outz" type="float" />
+      <output name="outy" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-64.949272" ypos="-35.603447">
+      <input name="value1" type="float" output="outx" nodename="growth_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-66.304344" ypos="-35.603447">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="growth_frequencies_separated" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-66.304344" ypos="-34.344826">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="growth_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-64.949272" ypos="-34.327587">
+      <input name="value1" type="float" output="outy" nodename="growth_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-66.304344" ypos="-33.086208">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="growth_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-64.949272" ypos="-33.086208">
+      <input name="value1" type="float" output="outz" nodename="growth_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-66.224640" ypos="-31.844828">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="growth_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-64.949272" ypos="-31.741379">
+      <input name="value1" type="float" output="outw" nodename="growth_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+    <output name="distorted_radius" type="float"  nodename="radius_add_float5" xpos="-38.246376" ypos="-27.465517"   />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_latewood_color" nodedef="ND_wood3d_util_latewood_color">
+    <multiply name="late_color_multiply_float2" type="float" xpos="-40.362320" ypos="-29.637932">
+      <input name="in2" type="float" nodename="latecolor_noise1d_float2" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="late_color_multiply_float4" type="float" xpos="-40.362320" ypos="-26.741379">
+      <input name="in2" type="float" nodename="latecolor_noise1d_float4" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <wood3d_util_noise1d name="latecolor_noise1d_float3" type="float" xpos="-43.043480" ypos="-28.137932">
+      <input name="p" type="float" nodename="latecolor_multiply_float3" />
+    </wood3d_util_noise1d>
+    <wood3d_util_noise1d name="latecolor_noise1d_float" type="float" xpos="-43.144928" ypos="-30.775862">
+      <input name="p" type="float" nodename="latecolor_multiply_float" />
+    </wood3d_util_noise1d>
+    <multiply name="late_color_multiply_float3" type="float" xpos="-40.362320" ypos="-28.258621">
+      <input name="in2" type="float" nodename="latecolor_noise1d_float3" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <wood3d_util_noise1d name="latecolor_noise1d_float4" type="float" xpos="-43.043480" ypos="-26.620689">
+      <input name="p" type="float" nodename="latecolor_multiply_float4" />
+    </wood3d_util_noise1d>
+    <wood3d_util_noise1d name="latecolor_noise1d_float2" type="float" xpos="-43.101448" ypos="-29.534483">
+      <input name="p" type="float" nodename="latecolor_multiply_float2" />
+    </wood3d_util_noise1d>
+    <multiply name="late_color_multiply_float" type="float" xpos="-40.376812" ypos="-31.051723">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="latecolor_noise1d_float" />
+    </multiply>
+    <add name="exponent2" type="float" xpos="-27.275362" ypos="-26.637932">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" nodename="latecolor_add_float9" />
+    </add>
+    <multiply name="latecolor_multiply_float17" type="float" xpos="-37.463768" ypos="-28.120689">
+      <input name="in1" type="float" nodename="late_color_multiply_float3" />
+      <input name="in2" type="float" output="outz" nodename="latecolor_perlin_weights_separated" />
+    </multiply>
+    <add name="latecolor_add_float9" type="float" xpos="-29.579710" ypos="-26.620689">
+      <input name="in1" type="float" nodename="latecolor_add_float" />
+      <input name="in2" type="float" nodename="latecolor_multiply_float6" />
+    </add>
+    <add name="latecolor_add_float6" type="float" xpos="-34.449276" ypos="-30.086206">
+      <input name="in1" type="float" nodename="latecolor_multiply_float19" />
+      <input name="in2" type="float" nodename="latecolor_multiply_float16" />
+    </add>
+    <power name="latecolor_power" type="color3" xpos="-25.608696" ypos="-26.637932">
+      <input name="in1" type="color3" interfacename="late_color" />
+      <input name="in2" type="float" nodename="exponent2" />
+    </power>
+    <multiply name="latecolor_multiply_float19" type="float" xpos="-37.463768" ypos="-30.913794">
+      <input name="in1" type="float" nodename="late_color_multiply_float" />
+      <input name="in2" type="float" output="outx" nodename="latecolor_perlin_weights_separated" />
+    </multiply>
+    <multiply name="latecolor_multiply_float16" type="float" xpos="-37.463768" ypos="-29.500000">
+      <input name="in1" type="float" nodename="late_color_multiply_float2" />
+      <input name="in2" type="float" output="outy" nodename="latecolor_perlin_weights_separated" />
+    </multiply>
+    <multiply name="latecolor_multiply_float6" type="float" xpos="-37.362320" ypos="-26.741379">
+      <input name="in1" type="float" nodename="late_color_multiply_float4" />
+      <input name="in2" type="float" output="outw" nodename="latecolor_perlin_weights_separated" />
+    </multiply>
+    <multiply name="latecolor_multiply_float2" type="float" xpos="-45.826088" ypos="-29.655172">
+      <input name="in2" type="float" nodename="inverse_freq_y" />
+      <input name="in1" type="float" interfacename="radius" />
+    </multiply>
+    <add name="latecolor_add_float" type="float" xpos="-32.028984" ypos="-28.137932">
+      <input name="in1" type="float" nodename="latecolor_add_float6" />
+      <input name="in2" type="float" nodename="latecolor_multiply_float17" />
+    </add>
+    <multiply name="latecolor_multiply_float4" type="float" xpos="-45.826088" ypos="-26.879311">
+      <input name="in2" type="float" nodename="inverse_freq_w" />
+      <input name="in1" type="float" interfacename="radius" />
+    </multiply>
+    <separate4 name="latecolor_perlin_weights_separated" type="multioutput" xpos="-40.956520" ypos="-24.637932">
+      <input name="in" type="vector4" interfacename="latecolor_perlin_weights" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <multiply name="latecolor_multiply_float" type="float" xpos="-45.768116" ypos="-30.913794">
+      <input name="in1" type="float" interfacename="radius" />
+      <input name="in2" type="float" nodename="inverse_freq_x" />
+    </multiply>
+    <multiply name="latecolor_multiply_float3" type="float" xpos="-45.826088" ypos="-28.293104">
+      <input name="in2" type="float" nodename="inverse_freq_z" />
+      <input name="in1" type="float" interfacename="radius" />
+    </multiply>
+    <separate4 name="latecolor_perlin_frequencies_separated" type="multioutput" xpos="-53.644928" ypos="-30.741379">
+      <input name="in" type="vector4" interfacename="latecolor_perlin_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-47.681160" ypos="-30.913794">
+      <input name="value1" type="float" output="outx" nodename="latecolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-49.028984" ypos="-30.913794">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="latecolor_perlin_frequencies_separated" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-49.028984" ypos="-29.646551">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="latecolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-47.681160" ypos="-29.637932">
+      <input name="value1" type="float" output="outy" nodename="latecolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-49.028984" ypos="-28.396551">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="latecolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-47.681160" ypos="-28.396551">
+      <input name="value1" type="float" output="outz" nodename="latecolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-48.956520" ypos="-27.155172">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="latecolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-47.681160" ypos="-27.051723">
+      <input name="value1" type="float" output="outw" nodename="latecolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+    <output name="latewood_color" type="color3" nodename="latecolor_power" xpos="-23.797102" ypos="-26.500000" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_earlywood_color" nodedef="ND_wood3d_util_earlywood_color">
+    <multiply name="earlycolor_multiply_float" type="float" xpos="-49.884056" ypos="-42.327587">
+      <input name="in1" type="float" nodename="inverse_freq_w" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <multiply name="earlycolor_multiply_float2" type="float" xpos="-39.681160" ypos="-42.051723">
+      <input name="in1" type="float" output="outw" nodename="earlycolor_separate4_vector7" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float7" />
+    </multiply>
+    <add name="earlycolor_add_float" type="float" xpos="-34.000000" ypos="-43.706898">
+      <input name="in1" type="float" nodename="earlycolor_add_float5" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float13" />
+    </add>
+    <multiply name="earlycolor_multiply_float8" type="float" xpos="-49.869564" ypos="-46.189655">
+      <input name="in1" type="float" nodename="inverse_freq_x" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <add name="earlycolor_add_float8" type="float" xpos="-31.797102" ypos="-42.362068">
+      <input name="in1" type="float" nodename="earlycolor_add_float" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float2" />
+    </add>
+    <multiply name="earlycolor_multiply_float10" type="float" xpos="-49.884056" ypos="-43.706898">
+      <input name="in1" type="float" nodename="inverse_freq_z" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <add name="exponent" type="float" xpos="-29.478260" ypos="-42.362068">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" nodename="earlycolor_add_float8" />
+    </add>
+    <multiply name="earlycolor_multiply_float9" type="float" xpos="-49.869564" ypos="-44.948277">
+      <input name="in1" type="float" nodename="inverse_freq_y" />
+      <input name="in2" type="float" interfacename="radius" />
+    </multiply>
+    <power name="early_color_power" type="color3" xpos="-28.079710" ypos="-42.362068">
+      <input name="in1" type="color3" interfacename="early_color" />
+      <input name="in2" type="float" nodename="exponent" />
+    </power>
+    <separate4 name="earlycolor_separate4_vector7" type="multioutput" xpos="-43.833332" ypos="-49.000000">
+      <input name="in" type="vector4" interfacename="earlycolor_perlin_weights" />
+      <output name="outx" type="float" />
+      <output name="outz" type="float" />
+      <output name="outy" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <add name="earlycolor_add_float5" type="float" xpos="-36.666668" ypos="-45.534481">
+      <input name="in1" type="float" nodename="earlycolor_multiply_float11" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float12" />
+    </add>
+    <multiply name="earlycolor_multiply_float11" type="float" xpos="-39.797100" ypos="-46.086208">
+      <input name="in1" type="float" output="outx" nodename="earlycolor_separate4_vector7" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float4" />
+    </multiply>
+    <separate4 name="earlycolor_perlin_frequencies_separated" type="multioutput" xpos="-57.652172" ypos="-46.155174">
+      <input name="in" type="vector4" interfacename="earlycolor_perlin_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <multiply name="earlycolor_multiply_float12" type="float" xpos="-39.797100" ypos="-44.844826">
+      <input name="in1" type="float" output="outy" nodename="earlycolor_separate4_vector7" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float5" />
+    </multiply>
+    <multiply name="earlycolor_multiply_float13" type="float" xpos="-39.797100" ypos="-43.431034">
+      <input name="in1" type="float" output="outz" nodename="earlycolor_separate4_vector7" />
+      <input name="in2" type="float" nodename="earlycolor_multiply_float6" />
+    </multiply>
+    <wood3d_util_noise1d name="earlycolor_noise1d_float4" type="float" xpos="-47.101448" ypos="-42.086208">
+      <input name="p" type="float" nodename="earlycolor_multiply_float" />
+    </wood3d_util_noise1d>
+    <wood3d_util_noise1d name="earlycolor_noise1d_float3" type="float" xpos="-47.101448" ypos="-43.448277">
+      <input name="p" type="float" nodename="earlycolor_multiply_float10" />
+    </wood3d_util_noise1d>
+    <multiply name="earlycolor_multiply_float7" type="float" xpos="-43.840580" ypos="-42.086208">
+      <input name="in2" type="float" nodename="earlycolor_noise1d_float4" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="earlycolor_multiply_float4" type="float" xpos="-43.840580" ypos="-46.224136">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="earlycolor_noise1d_float" />
+    </multiply>
+    <multiply name="earlycolor_multiply_float5" type="float" xpos="-43.840580" ypos="-44.810345">
+      <input name="in2" type="float" nodename="earlycolor_noise1d_float2" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <wood3d_util_noise1d name="earlycolor_noise1d_float2" type="float" xpos="-47.101448" ypos="-44.706898">
+      <input name="p" type="float" nodename="earlycolor_multiply_float9" />
+    </wood3d_util_noise1d>
+    <wood3d_util_noise1d name="earlycolor_noise1d_float" type="float" xpos="-47.101448" ypos="-45.810345">
+      <input name="p" type="float" nodename="earlycolor_multiply_float8" />
+    </wood3d_util_noise1d>
+    <multiply name="earlycolor_multiply_float6" type="float" xpos="-43.840580" ypos="-43.431034">
+      <input name="in2" type="float" nodename="earlycolor_noise1d_float3" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-51.963768" ypos="-46.224136">
+      <input name="value1" type="float" output="outx" nodename="earlycolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-53.311596" ypos="-46.224136">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="earlycolor_perlin_frequencies_separated" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-53.311596" ypos="-44.956898">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="earlycolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-51.963768" ypos="-44.948277">
+      <input name="value1" type="float" output="outy" nodename="earlycolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-53.311596" ypos="-43.706898">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="earlycolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-51.963768" ypos="-43.706898">
+      <input name="value1" type="float" output="outz" nodename="earlycolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-53.239132" ypos="-42.465519">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="earlycolor_perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-51.963768" ypos="-42.362068">
+      <input name="value1" type="float" output="outw" nodename="earlycolor_perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+    <output name="earlywood_color" type="color3" xpos="-26.188406" ypos="-42.224136" nodename="early_color_power" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_perlin_color" nodedef="ND_wood3d_util_perlin_color">
+    <add name="perlincolor_add_float3" type="float" xpos="4.355072" ypos="-3.741379">
+      <input name="in2" type="float" value="1" />
+      <input name="in1" type="float" nodename="perlincolor_add_float5" />
+    </add>
+    <separate3 name="wood_position_separated" type="multioutput" xpos="-24.260870" ypos="-9.206897">
+      <input name="in" type="vector3" interfacename="wood_position" />
+      <output name="outz" type="float" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+    </separate3>
+    <multiply name="perlincolor_multiply_float" type="float" xpos="-21.253624" ypos="-7.146552">
+      <input name="in2" type="float" interfacename="diffuse_perlin_scale_z" />
+      <input name="in1" type="float" output="outz" nodename="wood_position_separated" />
+    </multiply>
+    <separate4 name="perlin_frequencies_separated" type="multioutput" xpos="-24.260870" ypos="-4.362069">
+      <input name="in" type="vector4" interfacename="diffuse_perlin_frequencies" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <separate4 name="perlin_weights_separated" type="multioutput" xpos="-9.536232" ypos="-10.224138">
+      <input name="in" type="vector4" interfacename="diffuse_perlin_weights" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outw" type="float" />
+    </separate4>
+    <add name="perlincolor_add_float2" type="float" xpos="-2.927536" ypos="-7.327586">
+      <input name="in1" type="float" nodename="perlincolor_multiply_float5" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float7" />
+    </add>
+    <power name="perlin_color_power" type="color3" xpos="6.862319" ypos="-3.741379">
+      <input name="in2" type="float" nodename="perlincolor_add_float3" />
+      <input name="in1" type="color3" interfacename="color" />
+    </power>
+    <multiply name="perlincolor_multiply_float6" type="float" xpos="-6.057971" ypos="-4.948276">
+      <input name="in1" type="float" output="outz" nodename="perlin_weights_separated" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float8" />
+    </multiply>
+    <multiply name="perlincolor_multiply_float5" type="float" xpos="-6.115942" ypos="-8.017241">
+      <input name="in1" type="float" output="outx" nodename="perlin_weights_separated" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float4" />
+    </multiply>
+    <multiply name="perlincolor_multiply_float7" type="float" xpos="-6.115942" ypos="-6.637931">
+      <input name="in1" type="float" output="outy" nodename="perlin_weights_separated" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float10" />
+    </multiply>
+    <add name="perlincolor_add_float" type="float" xpos="-0.376812" ypos="-5.672414">
+      <input name="in1" type="float" nodename="perlincolor_add_float2" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float6" />
+    </add>
+    <multiply name="perlincolor_multiply_vector3FA" type="vector3" xpos="-15.579710" ypos="-8.017241">
+      <input name="in1" type="vector3" nodename="perlincolor_combine3_vector3" />
+      <input name="in2" type="float" nodename="inverse_freq_x" />
+    </multiply>
+    <combine3 name="perlincolor_combine3_vector3" type="vector3" xpos="-18.594202" ypos="-8.948276">
+      <input name="in1" type="float" output="outx" nodename="wood_position_separated" />
+      <input name="in2" type="float" output="outy" nodename="wood_position_separated" />
+      <input name="in3" type="float" nodename="perlincolor_multiply_float" />
+    </combine3>
+    <multiply name="perlincolor_multiply_vector3FA2" type="vector3" xpos="-15.637681" ypos="-6.620690">
+      <input name="in1" type="vector3" nodename="perlincolor_combine3_vector3" />
+      <input name="in2" type="float" nodename="inverse_freq_y" />
+    </multiply>
+    <multiply name="perlincolor_multiply_vector3FA3" type="vector3" xpos="-15.579710" ypos="-5.112069">
+      <input name="in1" type="vector3" nodename="perlincolor_combine3_vector3" />
+      <input name="in2" type="float" nodename="inverse_freq_z" />
+    </multiply>
+    <multiply name="perlincolor_multiply_vector3FA4" type="vector3" xpos="-15.637681" ypos="-3.724138">
+      <input name="in1" type="vector3" nodename="perlincolor_combine3_vector3" />
+      <input name="in2" type="float" nodename="inverse_freq_w" />
+    </multiply>
+    <noise3d name="perlincolor_noise3d_float" type="float" xpos="-12.456522" ypos="-7.879310">
+      <input name="position" type="vector3" nodename="perlincolor_multiply_vector3FA" />
+    </noise3d>
+    <noise3d name="perlincolor_noise3d_float2" type="float" xpos="-12.434783" ypos="-6.500000">
+      <input name="position" type="vector3" nodename="perlincolor_multiply_vector3FA2" />
+    </noise3d>
+    <noise3d name="perlincolor_noise3d_float3" type="float" xpos="-12.434783" ypos="-4.982759">
+      <input name="position" type="vector3" nodename="perlincolor_multiply_vector3FA3" />
+    </noise3d>
+    <noise3d name="perlincolor_noise3d_float4" type="float" xpos="-12.434783" ypos="-3.586207">
+      <input name="position" type="vector3" nodename="perlincolor_multiply_vector3FA4" />
+    </noise3d>
+    <multiply name="perlincolor_multiply_float8" type="float" xpos="-9.594203" ypos="-5.103448">
+      <input name="in2" type="float" nodename="perlincolor_noise3d_float3" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="perlincolor_multiply_float9" type="float" xpos="-9.594203" ypos="-3.706897">
+      <input name="in2" type="float" nodename="perlincolor_noise3d_float4" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <multiply name="perlincolor_multiply_float4" type="float" xpos="-9.652174" ypos="-8.120689">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="perlincolor_noise3d_float" />
+    </multiply>
+    <multiply name="perlincolor_multiply_float3" type="float" xpos="-6.000000" ypos="-3.706897">
+      <input name="in1" type="float" output="outw" nodename="perlin_weights_separated" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float9" />
+    </multiply>
+    <add name="perlincolor_add_float5" type="float" xpos="1.826087" ypos="-3.741379">
+      <input name="in1" type="float" nodename="perlincolor_add_float" />
+      <input name="in2" type="float" nodename="perlincolor_multiply_float3" />
+    </add>
+    <multiply name="perlincolor_multiply_float10" type="float" xpos="-9.673913" ypos="-6.637931">
+      <input name="in2" type="float" nodename="perlincolor_noise3d_float2" />
+      <input name="in1" type="float" value="0.5" />
+    </multiply>
+    <ifgreater name="inverse_freq_x" type="float" xpos="-19.152174" ypos="-5.362069">
+      <input name="value1" type="float" output="outx" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_x" />
+    </ifgreater>
+    <divide name="inverse_x" type="float" xpos="-20.500000" ypos="-5.362069">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outx" nodename="perlin_frequencies_separated" />
+    </divide>
+    <divide name="inverse_y" type="float" xpos="-20.500000" ypos="-4.094828">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outy" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_y" type="float" xpos="-19.152174" ypos="-4.086207">
+      <input name="value1" type="float" output="outy" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_y" />
+    </ifgreater>
+    <divide name="inverse_z" type="float" xpos="-20.500000" ypos="-2.844828">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outz" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_z" type="float" xpos="-19.152174" ypos="-2.844828">
+      <input name="value1" type="float" output="outz" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_z" />
+    </ifgreater>
+    <divide name="inverse_w" type="float" xpos="-20.427536" ypos="-1.594828">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" output="outw" nodename="perlin_frequencies_separated" />
+    </divide>
+    <ifgreater name="inverse_freq_w" type="float" xpos="-19.152174" ypos="-1.500000">
+      <input name="value1" type="float" output="outw" nodename="perlin_frequencies_separated" />
+      <input name="in1" type="float" nodename="inverse_w" />
+    </ifgreater>
+    <output name="perlin_color" type="color3" nodename="perlin_color_power" xpos="8.891304" ypos="-3.586207" />
+  </nodegraph>
+  
+  <nodegraph name="NG_wood3d_util_ray" nodedef="ND_wood3d_util_ray">
+    <subtract name="ray_subtract_float2" type="float" xpos="-29.391304" ypos="-58.327587">
+      <input name="in2" type="float" value="1" />
+      <input name="in1" type="float" interfacename="ray_color_power" />
+    </subtract>
+    <multiply name="ray_multiply_float" type="float" xpos="-27.572464" ypos="-55.879311">
+      <input name="in1" type="float" nodename="ray_subtract_float2" />
+      <input name="in2" type="float" nodename="ray_weight_sum" />
+    </multiply>
+    <max name="ray_max_float" type="float" xpos="-84.123192" ypos="-54.913792">
+      <input name="in1" type="float" interfacename="ray_ellipse_depth" />
+      <input name="in2" type="float" value="1e-05" />
+    </max>
+    <add name="ray_add_float" type="float" xpos="-25.536232" ypos="-55.896553">
+      <input name="in1" type="float" nodename="ray_multiply_float" />
+      <input name="in2" type="float" value="1" />
+    </add>
+    <divide name="ray_divide_float" type="float" xpos="-81.797104" ypos="-54.879311">
+      <input name="in1" type="float" output="outz" nodename="wood_position_separated" />
+      <input name="in2" type="float" nodename="ray_max_float" />
+    </divide>
+    <floor name="segment_id_0" type="float" xpos="-74.797104" ypos="-61.491379">
+      <input name="in" type="float" nodename="ray_floor_float" />
+    </floor>
+    <divide name="ray_divide_float4" type="float" xpos="-69.942032" ypos="-54.482758">
+      <input name="in1" type="float" nodename="ray_add_float4" />
+      <input name="in2" type="float" value="6.28319" />
+    </divide>
+    <subtract name="ray_factor" type="float" xpos="-76.362320" ypos="-50.224136">
+      <input name="in1" type="float" nodename="ray_divide_float3" />
+      <input name="in2" type="float" nodename="segment_id_0" />
+    </subtract>
+    <add name="ray_add_float4" type="float" xpos="-71.797104" ypos="-54.517242">
+      <input name="in1" type="float" nodename="ray_theta" />
+      <input name="in2" type="float" value="3.14159" />
+    </add>
+    <multiply name="ray_pos_z_0" type="float" xpos="-63.217392" ypos="-60.155174">
+      <input name="in1" type="float" nodename="ray_add_float7" />
+      <input name="in2" type="float" interfacename="ray_seg_length_z" />
+    </multiply>
+    <subtract name="ray_theta_0" type="float" xpos="-59.043480" ypos="-61.810345">
+      <input name="in1" type="float" nodename="ray_multiply_float6" />
+      <input name="in2" type="float" value="3.14159" />
+    </subtract>
+    <subtract name="ray_subtract_float5" type="float" xpos="-63.797100" ypos="-54.344826">
+      <input name="in2" type="float" value="1" />
+      <input name="in1" type="float" nodename="slice_id" />
+    </subtract>
+    <multiply name="ray_multiply_float4" type="float" xpos="-65.768112" ypos="-63.189655">
+      <input name="in2" type="float" value="5" />
+      <input name="in1" type="float" output="outx" nodename="ray_separate3_vector6" />
+    </multiply>
+    <ifequal name="final_slice_id" type="float" xpos="-61.471016" ypos="-54.741379">
+      <input name="value1" type="float" nodename="slice_id" />
+      <input name="value2" type="float" interfacename="ray_num_slices" />
+      <input name="in2" type="float" nodename="slice_id" />
+      <input name="in1" type="float" nodename="ray_subtract_float5" />
+    </ifequal>
+    <crossproduct name="ray_crossproduct_vector3" type="vector3" xpos="-52.898552" ypos="-60.120689">
+      <input name="in1" type="vector3" nodename="ray_direction_0" />
+      <input name="in2" type="vector3" nodename="p_normalized_0" />
+    </crossproduct>
+    <max name="ray_max_float3" type="float" xpos="-84.079712" ypos="-49.224136">
+      <input name="in1" type="float" interfacename="ray_ellipse_scale_x" />
+      <input name="in2" type="float" value="1e-05" />
+    </max>
+    <divide name="ray_divide_float3" type="float" xpos="-79.913040" ypos="-53.637932">
+      <input name="in1" type="float" nodename="ray_divide_float" />
+      <input name="in2" type="float" interfacename="ray_seg_length_z" />
+    </divide>
+    <cos name="ray_cos_float" type="float" xpos="-56.992752" ypos="-62.637932">
+      <input name="in" type="float" nodename="ray_theta_0" />
+    </cos>
+    <combine3 name="p_normalized_0" type="vector3" xpos="-56.949276" ypos="-60.293102">
+      <input name="in1" type="float" output="outx" nodename="wood_position_separated" />
+      <input name="in2" type="float" output="outy" nodename="wood_position_separated" />
+      <input name="in3" type="float" nodename="ray_divide_float2" />
+    </combine3>
+    <divide name="ray_divide_float2" type="float" xpos="-59.043480" ypos="-60.258621">
+      <input name="in2" type="float" nodename="ray_max_float2" />
+      <input name="in1" type="float" nodename="ray_subtract_float6" />
+    </divide>
+    <subtract name="wyvill_subtract_float2" type="float" xpos="-41.420288" ypos="-59.982758">
+      <input name="in2" type="float" nodename="wyvill_multiply_float" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <multiply name="ray_multiply_float6" type="float" xpos="-61.391304" ypos="-61.810345">
+      <input name="in1" type="float" nodename="ray_divide_float5" />
+      <input name="in2" type="float" value="6.28319" />
+    </multiply>
+    <multiply name="wyvill_multiply_float" type="float" xpos="-43.739132" ypos="-60.017242">
+      <input name="in1" type="float" nodename="ray_divide_float10" />
+      <input name="in2" type="float" nodename="ray_divide_float10" />
+    </multiply>
+    <ifgreatereq name="wyvill_ifgreatereq_float" type="float" xpos="-37.130436" ypos="-61.396553">
+      <input name="value1" type="float" nodename="ray_divide_float10" />
+      <input name="value2" type="float" value="1" />
+      <input name="in2" type="float" nodename="power_float" />
+    </ifgreatereq>
+    <multiply name="ray_multiply_float2" type="float" xpos="-67.275360" ypos="-54.344826">
+      <input name="in1" type="float" nodename="ray_divide_float4" />
+      <input name="in2" type="float" interfacename="ray_num_slices" />
+    </multiply>
+    <atan2 name="ray_theta" type="float" xpos="-73.036232" ypos="-54.500000">
+      <input name="in2" type="float" output="outx" nodename="wood_position_separated" />
+      <input name="in1" type="float" output="outy" nodename="wood_position_separated" />
+    </atan2>
+    <add name="ray_slice_id_add_seed" type="float" xpos="-57.536232" ypos="-54.086208">
+      <input name="in1" type="float" nodename="ray_multiply_float3" />
+      <input name="in2" type="float" nodename="final_slice_id" />
+    </add>
+    <ifgreatereq name="ray_ifgreatereq_float" type="float" xpos="-34.463768" ypos="-63.310345">
+      <input name="value2" type="float" nodename="ray_multiply_float4" />
+      <input name="value1" type="float" nodename="ray_magnitude_vector2" />
+      <input name="in1" type="float" nodename="wyvill_ifgreatereq_float" />
+    </ifgreatereq>
+    <add name="ray_add_float2" type="float" xpos="-76.702896" ypos="-51.500000">
+      <input name="in1" type="float" nodename="segment_id_0" />
+      <input name="in2" type="float" value="1" />
+    </add>
+    <divide name="ray_divide_float5" type="float" xpos="-63.326088" ypos="-61.810345">
+      <input name="in1" type="float" nodename="ray_add_float3" />
+      <input name="in2" type="float" interfacename="ray_num_slices" />
+    </divide>
+    <magnitude name="ray_magnitude_vector3" type="float" xpos="-50.297100" ypos="-60.000000">
+      <input name="in" type="vector3" nodename="ray_crossproduct_vector3" />
+    </magnitude>
+    <divide name="ray_divide_float7" type="float" xpos="-48.028984" ypos="-61.913792">
+      <input name="in1" type="float" nodename="ray_magnitude_vector3" />
+      <input name="in2" type="float" nodename="ray_magnitude_vector5" />
+    </divide>
+    <sin name="ray_sin_float" type="float" xpos="-56.978260" ypos="-61.482758">
+      <input name="in" type="float" nodename="ray_theta_0" />
+    </sin>
+    <subtract name="ray_subtract_float3" type="float" xpos="-77.057968" ypos="-49.017242">
+      <input name="in1" type="float" nodename="segment_id_0" />
+      <input name="in2" type="float" value="1" />
+    </subtract>
+    <combine2 name="ray_combine2_vector3" type="vector2" xpos="-81.420288" ypos="-59.862068">
+      <input name="in1" type="float" output="outx" nodename="wood_position_separated" />
+      <input name="in2" type="float" output="outy" nodename="wood_position_separated" />
+    </combine2>
+    <add name="ray_add_float3" type="float" xpos="-65.760872" ypos="-61.672413">
+      <input name="in1" type="float" output="outx" nodename="ray_separate3_vector6" />
+      <input name="in2" type="float" nodename="final_slice_id" />
+    </add>
+    <combine3 name="ray_direction_0" type="vector3" xpos="-55.057972" ypos="-62.189655">
+      <input name="in1" type="float" nodename="ray_cos_float" />
+      <input name="in2" type="float" nodename="ray_sin_float" />
+    </combine3>
+    <floor name="slice_id" type="float" xpos="-65.188408" ypos="-54.344826">
+      <input name="in" type="float" nodename="ray_multiply_float2" />
+    </floor>
+    <separate3 name="wood_position_separated" type="multioutput" xpos="-84.318840" ypos="-58.034481">
+      <output name="outz" type="float" />
+      <output name="outy" type="float" />
+      <output name="outx" type="float" />
+      <input name="in" type="vector3" interfacename="wood_position" />
+    </separate3>
+    <multiply name="ray_multiply_float3" type="float" xpos="-59.652172" ypos="-56.534481">
+      <input name="in2" type="float" value="39" />
+      <input name="in1" type="float" interfacename="seed" />
+    </multiply>
+    <ifgreater name="segment_id_1" type="float" xpos="-74.695656" ypos="-49.913792">
+      <input name="value1" type="float" nodename="ray_factor" />
+      <input name="value2" type="float" value="0.5" />
+      <input name="in1" type="float" nodename="ray_add_float2" />
+      <input name="in2" type="float" nodename="ray_subtract_float3" />
+    </ifgreater>
+    <subtract name="ray_subtract_float6" type="float" xpos="-61.362320" ypos="-60.258621">
+      <input name="in1" type="float" nodename="ray_divide_float" />
+      <input name="in2" type="float" nodename="ray_pos_z_0" />
+    </subtract>
+    <max name="ray_max_float2" type="float" xpos="-84.079712" ypos="-51.293102">
+      <input name="in1" type="float" interfacename="ray_ellipse_z2x" />
+      <input name="in2" type="float" value="1e-05" />
+    </max>
+    <magnitude name="ray_magnitude_vector5" type="float" xpos="-52.898552" ypos="-61.948277">
+      <input name="in" type="vector3" nodename="ray_direction_0" />
+    </magnitude>
+    <add name="ray_add_float7" type="float" xpos="-65.760872" ypos="-60.155174">
+      <input name="in1" type="float" nodename="segment_id_0" />
+      <input name="in2" type="float" output="outy" nodename="ray_separate3_vector6" />
+    </add>
+    <magnitude name="ray_magnitude_vector2" type="float" xpos="-79.050728" ypos="-59.603447">
+      <input name="in" type="vector2" nodename="ray_combine2_vector3" />
+    </magnitude>
+    <ifgreatereq name="wyvill_ifgreatereq_float2" type="float" xpos="-36.108696" ypos="-48.241379">
+      <input name="value1" type="float" nodename="ray_divide_float12" />
+      <input name="value2" type="float" value="1" />
+      <input name="in2" type="float" nodename="power_float2" />
+    </ifgreatereq>
+    <power name="power_float" type="float" xpos="-38.753624" ypos="-59.982758">
+      <input name="in2" type="float" value="3" />
+      <input name="in1" type="float" nodename="wyvill_subtract_float2" />
+    </power>
+    <subtract name="ray_subtract_float8" type="float" xpos="-61.014492" ypos="-47.706898">
+      <input name="in1" type="float" value="0" />
+      <input name="in2" type="float" nodename="ray_pos_z_1" />
+    </subtract>
+    <separate3 name="ray_separate3_vector6" type="multioutput" xpos="-68.500000" ypos="-61.775864">
+      <input name="in" type="vector3" nodename="ray_hashnoise2d_1" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+    </separate3>
+    <divide name="ray_divide_float9" type="float" xpos="-48.376812" ypos="-49.655174">
+      <input name="in1" type="float" nodename="ray_magnitude_vector4" />
+      <input name="in2" type="float" nodename="ray_magnitude_vector6" />
+    </divide>
+    <combine2 name="ray_combine2_vector2" type="vector2" xpos="-72.760872" ypos="-49.672413">
+      <input name="in2" type="float" nodename="segment_id_1" />
+      <input name="in1" type="float" nodename="ray_slice_id_add_seed" />
+    </combine2>
+    <floor name="ray_floor_float" type="float" xpos="-77.826088" ypos="-53.379311">
+      <input name="in" type="float" nodename="ray_divide_float3" />
+    </floor>
+    <add name="ray_weight_sum" type="float" xpos="-31.326086" ypos="-56.120689">
+      <input name="in1" type="float" nodename="ray_ifgreatereq_float" />
+      <input name="in2" type="float" nodename="ray_ifgreatereq_float2" />
+    </add>
+    <divide name="ray_divide_float8" type="float" xpos="-58.572464" ypos="-47.568966">
+      <input name="in2" type="float" nodename="ray_max_float2" />
+      <input name="in1" type="float" nodename="ray_subtract_float8" />
+    </divide>
+    <subtract name="wyvill_subtract_float3" type="float" xpos="-40.260868" ypos="-47.982758">
+      <input name="in2" type="float" nodename="wyvill_multiply_float2" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <wood3d_util_hashnoise2d name="ray_hashnoise2d_1" type="vector3" xpos="-70.514496" ypos="-61.396553">
+      <input name="texcoord" type="vector2" nodename="ray_combine2_vector4" />
+    </wood3d_util_hashnoise2d>
+    <add name="ray_add_float6" type="float" xpos="-65.442032" ypos="-49.568966">
+      <input name="in1" type="float" output="outx" nodename="ray_separate3_vector5" />
+      <input name="in2" type="float" nodename="final_slice_id" />
+    </add>
+    <wood3d_util_hashnoise2d name="ray_hashnoise2d_2" type="vector3" xpos="-70.449272" ypos="-49.551723">
+      <input name="texcoord" type="vector2" nodename="ray_combine2_vector2" />
+    </wood3d_util_hashnoise2d>
+    <multiply name="ray_multiply_float7" type="float" xpos="-61.043480" ypos="-49.534481">
+      <input name="in1" type="float" nodename="ray_divide_float6" />
+      <input name="in2" type="float" value="6.28319" />
+    </multiply>
+    <combine3 name="p_normalized_1" type="vector3" xpos="-56.492752" ypos="-47.689655">
+      <input name="in1" type="float" output="outx" nodename="wood_position_separated" />
+      <input name="in2" type="float" output="outy" nodename="wood_position_separated" />
+      <input name="in3" type="float" nodename="ray_divide_float8" />
+    </combine3>
+    <combine2 name="ray_combine2_vector4" type="vector2" xpos="-72.826088" ypos="-61.534481">
+      <input name="in2" type="float" nodename="segment_id_0" />
+      <input name="in1" type="float" nodename="ray_slice_id_add_seed" />
+    </combine2>
+    <ifgreatereq name="ray_ifgreatereq_float2" type="float" xpos="-34.115944" ypos="-50.500000">
+      <input name="value2" type="float" nodename="ray_multiply_float5" />
+      <input name="value1" type="float" nodename="ray_magnitude_vector2" />
+      <input name="in1" type="float" nodename="wyvill_ifgreatereq_float2" />
+    </ifgreatereq>
+    <magnitude name="ray_magnitude_vector4" type="float" xpos="-50.297100" ypos="-47.448277">
+      <input name="in" type="vector3" nodename="ray_crossproduct_vector4" />
+    </magnitude>
+    <divide name="ray_divide_float6" type="float" xpos="-63.239132" ypos="-49.534481">
+      <input name="in1" type="float" nodename="ray_add_float6" />
+      <input name="in2" type="float" interfacename="ray_num_slices" />
+    </divide>
+    <crossproduct name="ray_crossproduct_vector4" type="vector3" xpos="-52.898552" ypos="-47.603447">
+      <input name="in1" type="vector3" nodename="ray_direction_1" />
+      <input name="in2" type="vector3" nodename="p_normalized_1" />
+    </crossproduct>
+    <add name="ray_add_float8" type="float" xpos="-65.449272" ypos="-47.879311">
+      <input name="in1" type="float" nodename="segment_id_1" />
+      <input name="in2" type="float" output="outy" nodename="ray_separate3_vector5" />
+    </add>
+    <combine3 name="ray_direction_1" type="vector3" xpos="-54.637680" ypos="-49.793102">
+      <input name="in1" type="float" nodename="ray_cos_float2" />
+      <input name="in2" type="float" nodename="ray_sin_float2" />
+    </combine3>
+    <multiply name="wyvill_multiply_float2" type="float" xpos="-44.137680" ypos="-47.879311">
+      <input name="in1" type="float" nodename="ray_divide_float12" />
+      <input name="in2" type="float" nodename="ray_divide_float12" />
+    </multiply>
+    <cos name="ray_cos_float2" type="float" xpos="-56.485508" ypos="-50.224136">
+      <input name="in" type="float" nodename="ray_theta_1" />
+    </cos>
+    <sin name="ray_sin_float2" type="float" xpos="-56.485508" ypos="-48.982758">
+      <input name="in" type="float" nodename="ray_theta_1" />
+    </sin>
+    <magnitude name="ray_magnitude_vector6" type="float" xpos="-52.847828" ypos="-49.672413">
+      <input name="in" type="vector3" nodename="ray_direction_1" />
+    </magnitude>
+    <divide name="ray_divide_float10" type="float" xpos="-46.007248" ypos="-60.120689">
+      <input name="in1" type="float" nodename="ray_divide_float7" />
+      <input name="in2" type="float" nodename="ray_max_float3" />
+    </divide>
+    <power name="power_float2" type="float" xpos="-37.898552" ypos="-47.982758">
+      <input name="in2" type="float" value="3" />
+      <input name="in1" type="float" nodename="wyvill_subtract_float3" />
+    </power>
+    <multiply name="ray_pos_z_1" type="float" xpos="-63.217392" ypos="-47.844826">
+      <input name="in1" type="float" nodename="ray_add_float8" />
+      <input name="in2" type="float" interfacename="ray_seg_length_z" />
+    </multiply>
+    <divide name="ray_divide_float12" type="float" xpos="-46.434784" ypos="-47.896553">
+      <input name="in1" type="float" nodename="ray_divide_float9" />
+      <input name="in2" type="float" nodename="ray_max_float3" />
+    </divide>
+    <subtract name="ray_theta_1" type="float" xpos="-58.601448" ypos="-49.379311">
+      <input name="in1" type="float" nodename="ray_multiply_float7" />
+      <input name="in2" type="float" value="3.14159" />
+    </subtract>
+    <separate3 name="ray_separate3_vector5" type="multioutput" xpos="-68.434784" ypos="-49.655174">
+      <input name="in" type="vector3" nodename="ray_hashnoise2d_2" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+    </separate3>
+    <multiply name="ray_multiply_float5" type="float" xpos="-65.478264" ypos="-51.068966">
+      <input name="in2" type="float" value="5" />
+      <input name="in1" type="float" output="outx" nodename="ray_separate3_vector5" />
+    </multiply>
+    <power name="raycolor_power" type="color3" xpos="-23.101450" ypos="-55.913792">
+      <input name="in1" type="color3" interfacename="color" />
+      <input name="in2" type="float" nodename="ray_add_float" />
+    </power>
+    <output name="ray_color" type="color3" nodename="raycolor_power" xpos="-21.485508" ypos="-55.775864" />
+    <output name="ray_weight" type="float" nodename="ray_weight_sum" xpos="-29.826086" ypos="-53.517242" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_pore_color" nodedef="ND_wood3d_util_pore_color">
+    <subtract name="pore_subtract_float2" type="float" xpos="-29.840580" ypos="-50.137932">
+      <input name="in1" type="float" interfacename="pore_color_power" />
+      <input name="in2" type="float" value="1" />
+    </subtract>
+    <multiply name="pore_multiply_float" type="float" xpos="-27.884058" ypos="-49.603447">
+      <input name="in1" type="float" nodename="pore_subtract_float2" />
+      <input name="in2" type="float" interfacename="pore_weight" />
+    </multiply>
+    <add name="pore_add_float" type="float" xpos="-25.557972" ypos="-49.568966">
+      <input name="in1" type="float" nodename="pore_multiply_float" />
+      <input name="in2" type="float" value="1" />
+    </add>
+    <power name="pore_power_color3FA" type="color3" xpos="-24.057972" ypos="-49.293102">
+      <input name="in2" type="float" nodename="pore_add_float" />
+      <input name="in1" type="color3" interfacename="color" />
+    </power>
+    <output name="pore_color" type="color3" nodename="pore_power_color3FA"/>
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d_util_roughness" nodedef="ND_wood3d_util_roughness">
+    <multiply name="rough_multiply_float3" type="float" xpos="-69.079712" ypos="-52.258621">
+      <input name="in1" type="float" interfacename="ray_weight" />
+      <input name="in2" type="float" interfacename="ray_roughness" />
+    </multiply>
+    <clamp name="rough_clamp_float" type="float" xpos="-65.065216" ypos="-53.655174">
+      <input name="in" type="float" nodename="rough_add_float2" />
+    </clamp>
+    <add name="rough_add_float2" type="float" xpos="-66.840576" ypos="-53.775864">
+      <input name="in2" type="float" nodename="rough_multiply_float3" />
+      <input name="in1" type="float" nodename="lobe_roughness" />
+    </add>
+    <multiply name="rough_multiply_float" type="float" xpos="-74.695656" ypos="-51.017242">
+      <input name="in1" type="float" interfacename="roughness" />
+      <input name="in2" type="float" nodename="rough_subtract_float" />
+    </multiply>
+    <subtract name="rough_subtract_float" type="float" xpos="-77.463768" ypos="-50.879311">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" interfacename="earlywood_ratio" />
+    </subtract>
+    <multiply name="rough_multiply_float2" type="float" xpos="-77.311592" ypos="-52.275864">
+      <input name="in1" type="float" interfacename="earlywood_ratio" />
+      <input name="in2" type="float" interfacename="groove_roughness" />
+    </multiply>
+    <add name="rough_add_float" type="float" xpos="-72.449272" ypos="-51.879311">
+      <input name="in1" type="float" nodename="rough_multiply_float2" />
+      <input name="in2" type="float" nodename="rough_multiply_float" />
+    </add>
+    <ifequal name="lobe_roughness" type="float" xpos="-70.746376" ypos="-53.948277">
+      <input name="in2" type="float" nodename="rough_add_float" />
+      <input name="in1" type="float" interfacename="roughness" />
+      <input name="value1" type="boolean" interfacename="use_groove_roughness" />
+      <input name="value2" type="boolean" value="true" />
+    </ifequal>
+    <output name="wood_roughness" type="float" xpos="-63.210144" ypos="-53.655174" nodename="rough_clamp_float" />
+  </nodegraph>
+  
+  <nodegraph name="NG_wood3d_util_bump" nodedef="ND_wood3d_util_bump">
+    <normalmap name="normalmap" type="vector3" xpos="-63.876812" ypos="-32.396553">
+      <input name="in" type="vector3" nodename="heighttonormal_vector3" />
+      <input name="scale" type="float" value="10" />
+    </normalmap>
+    <heighttonormal name="heighttonormal_vector3" type="vector3" xpos="-66.811592" ypos="-32.396553">
+      <input name="in" type="float" nodename="bump_add_float" />
+      <input name="scale" type="float" value="1" />
+    </heighttonormal>
+    <multiply name="bump_multiply_float" type="float" xpos="-85.644928" ypos="-34.250000">
+      <input name="in2" type="float" interfacename="pore_bump_weight" />
+      <input name="in1" type="float" interfacename="pore_depth" />
+    </multiply>
+    <add name="bump_add_float" type="float" xpos="-69.500000" ypos="-32.482758">
+      <input name="in1" type="float" nodename="bump_ifequal_floatB" />
+      <input name="in2" type="float" nodename="bump_ifequal_floatB2" />
+    </add>
+    <multiply name="bump_multiply_float2" type="float" xpos="-83.173912" ypos="-33.146553">
+      <input name="in1" type="float" nodename="bump_multiply_float" />
+      <input name="in2" type="float" value="-1" />
+    </multiply>
+    <subtract name="bump_subtract_float5" type="float" xpos="-75.260872" ypos="-29.215517">
+      <input name="in2" type="float" interfacename="earlywood_ratio" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <ifequal name="bump_ifequal_floatB" type="float" xpos="-77.159424" ypos="-33.129311">
+      <input name="value1" type="boolean" interfacename="use_pores_bump" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in1" type="float" nodename="bump_multiply_float2" />
+    </ifequal>
+    <multiply name="bump_multiply_float7" type="float" xpos="-72.637680" ypos="-28.258621">
+      <input name="in1" type="float" nodename="bump_subtract_float5" />
+      <input name="in2" type="float" interfacename="late_wood_bump_depth" />
+    </multiply>
+    <ifequal name="bump_ifequal_floatB2" type="float" xpos="-71.463768" ypos="-30.758621">
+      <input name="value1" type="boolean" interfacename="use_late_wood_bump" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in1" type="float" nodename="bump_multiply_float7" />
+      <input name="in2" type="float" value="0" />
+    </ifequal>
+    <output name="normal" type="vector3" nodename="normalmap" xpos="-62.166668" ypos="-32.137932" />
+  </nodegraph>
+
+  <nodegraph name="NG_wood3d" nodedef="ND_wood3d">
+    <wood3d_util_bump name="wood3d_bump" type="vector3" xpos="-38.855072" ypos="-41.862068">
+      <input name="use_pores_bump" type="boolean" interfacename="use_pores_bump" />
+      <input name="use_late_wood_bump" type="boolean" interfacename="use_late_wood_bump" />
+      <input name="late_wood_bump_depth" type="float" interfacename="late_wood_bump_depth" />
+      <input name="pore_depth" type="float" interfacename="pore_depth" />
+      <input name="earlywood_ratio" type="float" nodename="wood3d_ratio" />
+      <input name="pore_bump_weight" type="float" nodename="pore_bump_weight" />
+    </wood3d_util_bump>
+    <wood3d_util_pore_color name="wood3d_pore_color" type="color3" xpos="-41.442028" ypos="-48.568966">
+      <input name="pore_color_power" type="float" interfacename="pore_color_power" />
+      <input name="pore_weight" type="float" nodename="pore_weight" />
+      <input name="color" type="color3" nodename="wood_color_0" />
+    </wood3d_util_pore_color>
+    <wood3d_util_roughness name="wood3d_roughness" type="float" xpos="-25.652174" ypos="-43.465519">
+      <input name="use_groove_roughness" type="boolean" interfacename="use_groove_roughness" />
+      <input name="groove_roughness" type="float" interfacename="groove_roughness" />
+      <input name="earlywood_ratio" type="float" nodename="wood3d_ratio" />
+      <input name="ray_weight" type="float" nodename="ray_roughness_weight" />
+      <input name="roughness" type="float" interfacename="roughness" />
+      <input name="ray_roughness" type="float" interfacename="ray_roughness" />
+    </wood3d_util_roughness>
+    <wood3d_util_fiber_cosine_distortion name="wood3d_fiber_cosine_distortion" type="vector3" xpos="-99.449272" ypos="-50.620689">
+      <input name="fiber_cosine_frequencies" type="vector4" interfacename="fiber_cosine_frequencies" />
+      <input name="fiber_cosine_weights" type="vector4" interfacename="fiber_cosine_weights" />
+      <input name="wood_position" type="vector3" nodename="wood_position_0" />
+    </wood3d_util_fiber_cosine_distortion>
+    <wood3d_util_growth_perlin name="wood3d_growth_perlin" type="float" xpos="-78.862320" ypos="-50.534481">
+      <input name="growth_perlin_weights" type="vector4" interfacename="growth_perlin_weights" />
+      <input name="growth_perlin_frequencies" type="vector4" interfacename="growth_perlin_frequencies" />
+      <input name="radius" type="float" nodename="radius" />
+    </wood3d_util_growth_perlin>
+    <wood3d_util_ray name="wood3d_ray" type="multioutput" xpos="-33.449276" ypos="-50.879311">
+      <input name="ray_seg_length_z" type="float" interfacename="ray_seg_length_z" />
+      <input name="ray_ellipse_depth" type="float" interfacename="ray_ellipse_depth" />
+      <input name="ray_color_power" type="float" interfacename="ray_color_power" />
+      <input name="ray_ellipse_scale_x" type="float" interfacename="ray_ellipse_scale_x" />
+      <input name="ray_num_slices" type="float" interfacename="ray_num_slices" />
+      <input name="ray_ellipse_z2x" type="float" interfacename="ray_ellipse_z2x" />
+      <input name="seed" type="float" nodename="adjusted_seed" />
+      <input name="wood_position" type="vector3" nodename="wood_position" />
+      <input name="color" type="color3" nodename="wood_color_1" />
+    </wood3d_util_ray>
+    <wood3d_util_earlywood_color name="earlycolor_perlin" type="color3" xpos="-63.217392" ypos="-50.431034">
+      <input name="earlycolor_perlin_frequencies" type="vector4" interfacename="earlycolor_perlin_frequencies" />
+      <input name="earlycolor_perlin_weights" type="vector4" interfacename="earlycolor_perlin_weights" />
+      <input name="early_color" type="color3" interfacename="early_color" />
+      <input name="radius" type="float" nodename="final_radius" />
+    </wood3d_util_earlywood_color>
+    <wood3d_util_latewood_color name="latecolor_prelin" type="color3" xpos="-63.217392" ypos="-46.258621">
+      <input name="latecolor_perlin_frequencies" type="vector4" interfacename="latecolor_perlin_frequencies" />
+      <input name="latecolor_perlin_weights" type="vector4" interfacename="latecolor_perlin_weights" />
+      <input name="radius" type="float" nodename="final_radius" />
+      <input name="late_color" type="color3" nodename="latecolor" />
+    </wood3d_util_latewood_color>
+    <wood3d_util_ratio name="wood3d_ratio" type="float" xpos="-72.724640" ypos="-42.086208">
+      <input name="ring_thickness" type="float" interfacename="ring_thickness" />
+      <input name="late_wood_sharpness" type="float" interfacename="late_wood_sharpness" />
+      <input name="early_wood_sharpness" type="float" interfacename="early_wood_sharpness" />
+      <input name="late_wood_ratio" type="float" interfacename="late_wood_ratio" />
+      <input name="radius" type="float" nodename="final_radius" />
+    </wood3d_util_ratio>
+    <wood3d_util_perlin_color name="wood3d_perlin_color" type="color3" xpos="-48.753624" ypos="-49.086208">
+      <input name="diffuse_perlin_weights" type="vector4" interfacename="diffuse_perlin_weights" />
+      <input name="diffuse_perlin_scale_z" type="float" interfacename="diffuse_perlin_scale_z" />
+      <input name="diffuse_perlin_frequencies" type="vector4" interfacename="diffuse_perlin_frequencies" />
+      <input name="wood_position" type="vector3" nodename="wood_position" />
+      <input name="color" type="color3" nodename="overall_albedo" />
+    </wood3d_util_perlin_color>
+    <wood3d_util_fiber_perlin_distortion name="wood3d_fiber_perlin_distortion" type="vector3" xpos="-92.434784" ypos="-50.844826">
+      <input name="fiber_perlin_scale_z" type="float" interfacename="fiber_perlin_scale_z" />
+      <input name="fiber_perlin_frequencies" type="vector4" interfacename="fiber_perlin_frequencies" />
+      <input name="fiber_perlin_weights" type="vector4" interfacename="fiber_perlin_weights" />
+      <input name="wood_position" type="vector3" nodename="wood_position_1" />
+    </wood3d_util_fiber_perlin_distortion>
+    <separate3 name="separated_wood_pos" type="multioutput" xpos="-85.942032" ypos="-49.948277">
+      <input name="in" type="vector3" nodename="wood_position" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+    </separate3>
+    <combine3 name="wood_pos_xy" type="vector3" xpos="-83.739128" ypos="-49.672413">
+      <input name="in1" type="float" output="outx" nodename="separated_wood_pos" />
+      <input name="in2" type="float" output="outy" nodename="separated_wood_pos" />
+    </combine3>
+    <distance name="wood_xy_radius" type="float" xpos="-82.340576" ypos="-49.396553">
+      <input name="in1" type="vector3" nodename="wood_pos_xy" />
+    </distance>
+    <add name="radius" type="float" xpos="-80.456520" ypos="-49.517242">
+      <input name="in1" type="float" nodename="seed_1" />
+      <input name="in2" type="float" nodename="wood_xy_radius" />
+    </add>
+    <multiply name="seed_1" type="float" xpos="-81.760872" ypos="-47.844826">
+      <input name="in1" type="float" nodename="adjusted_seed" />
+      <input name="in2" type="float" value="20" />
+    </multiply>
+    <position name="input_xyz" type="vector3" xpos="-117.210144" ypos="-50.086208" />
+    <multiply name="seed_0" type="float" xpos="-104.956520" ypos="-48.258621">
+      <input name="in1" type="float" nodename="adjusted_seed" />
+      <input name="in2" type="float" value="50" />
+    </multiply>
+    <divide name="scaled_wood_position" type="vector3" xpos="-108.652176" ypos="-49.775864">
+      <input name="in1" type="vector3" nodename="original_wood_position" />
+      <input name="in2" type="float" interfacename="scale" />
+    </divide>
+    <separate3 name="separated_wood_position" type="multioutput" xpos="-106.333336" ypos="-50.034481">
+      <input name="in" type="vector3" nodename="scaled_wood_position" />
+      <output name="outx" type="float" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+    </separate3>
+    <add name="scaled_wood_z" type="float" xpos="-103.797104" ypos="-48.258621">
+      <input name="in1" type="float" output="outz" nodename="separated_wood_position" />
+      <input name="in2" type="float" nodename="seed_0" />
+    </add>
+    <combine3 name="wood_position_0" type="vector3" xpos="-102.130432" ypos="-49.896553">
+      <input name="in3" type="float" nodename="scaled_wood_z" />
+      <input name="in2" type="float" output="outy" nodename="separated_wood_position" />
+      <input name="in1" type="float" output="outx" nodename="separated_wood_position" />
+    </combine3>
+    <power name="darken_early_color" type="color3" xpos="-69.478264" ypos="-45.775864">
+      <input name="in2" type="float" interfacename="late_wood_color_power" />
+      <input name="in1" type="color3" interfacename="early_color" />
+    </power>
+    <add name="overall_albedo" type="color3" xpos="-53.123188" ypos="-47.982758">
+      <input name="in1" type="color3" nodename="weighted_earlycolor" />
+      <input name="in2" type="color3" nodename="weighted_latecolor" />
+    </add>
+    <multiply name="weighted_latecolor" type="color3" xpos="-55.630436" ypos="-46.034481">
+      <input name="in2" type="float" nodename="latecolor_ratio" />
+      <input name="in1" type="color3" nodename="final_latecolor" />
+    </multiply>
+    <multiply name="weighted_earlycolor" type="color3" xpos="-55.710144" ypos="-49.913792">
+      <input name="in1" type="color3" nodename="final_earlycolor" />
+      <input name="in2" type="float" nodename="wood3d_ratio" />
+    </multiply>
+    <ifequal name="latecolor" type="color3" xpos="-67.159424" ypos="-46.172413">
+      <input name="value1" type="boolean" interfacename="use_manual_late_wood_color" />
+      <input name="in1" type="color3" interfacename="manual_late_wood_color" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in2" type="color3" nodename="darken_early_color" />
+    </ifequal>
+    <subtract name="latecolor_ratio" type="float" xpos="-57.956520" ypos="-44.120689">
+      <input name="in2" type="float" nodename="wood3d_ratio" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <ifequal name="wood_color_0" type="color3" xpos="-44.072464" ypos="-48.103447">
+      <input name="value1" type="boolean" interfacename="use_diffuse_perlin" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in2" type="color3" nodename="overall_albedo" />
+      <input name="in1" type="color3" nodename="wood3d_perlin_color" />
+    </ifequal>
+    <switch name="pore_ratio" type="float" xpos="-45.398552" ypos="-46.551723">
+      <input name="which" type="integer" interfacename="pore_type" />
+      <input name="in3" type="float" nodename="wood3d_ratio" />
+      <input name="in4" type="float" value="1" />
+      <input name="in5" type="float" value="1" />
+      <input name="in2" type="float" nodename="latecolor_ratio" />
+      <input name="in1" type="float" value="1" />
+    </switch>
+    <multiply name="weighted_wood_color" type="color3" xpos="-25.565218" ypos="-47.603447">
+      <input name="in2" type="float" interfacename="diffuse_lobe_weight" />
+      <input name="in1" type="color3" nodename="wood_color_2" />
+    </multiply>
+    <wood3d_util_pore_impulse name="pore_weight" type="float" xpos="-43.391304" ypos="-45.879311">
+      <input name="position" type="vector3" nodename="wood_position" />
+      <input name="wood_weight" type="float" nodename="pore_ratio" />
+      <input name="seed" type="float" nodename="adjusted_seed" />
+      <input name="pore_cell_dim" type="float" interfacename="pore_cell_dim" />
+      <input name="pore_radius" type="float" interfacename="pore_radius" />
+    </wood3d_util_pore_impulse>
+    <wood3d_util_pore_impulse name="pore_bump_weight" type="float" xpos="-43.768116" ypos="-41.534481">
+      <input name="position" type="vector3" nodename="wood_position" />
+      <input name="wood_weight" type="float" nodename="pore_ratio" />
+      <input name="seed" type="float" nodename="adjusted_seed" />
+      <input name="pore_cell_dim" type="float" interfacename="pore_cell_dim" />
+      <input name="pore_radius" type="float" interfacename="pore_radius" />
+    </wood3d_util_pore_impulse>
+    <ifequal name="wood_color_1" type="color3" xpos="-38.086956" ypos="-48.551723">
+      <input name="value1" type="boolean" interfacename="use_pore_color" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in2" type="color3" nodename="wood_color_0" />
+      <input name="in1" type="color3" nodename="wood3d_pore_color" />
+    </ifequal>
+    <ifequal name="wood_color_2" type="color3" xpos="-29.231884" ypos="-48.534481">
+      <input name="value1" type="boolean" interfacename="use_ray_color" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in2" type="color3" nodename="wood_color_1" />
+      <input name="in1" type="color3" output="ray_color" nodename="wood3d_ray" />
+    </ifequal>
+    <ifequal name="distorted_radius" type="float" xpos="-75.971016" ypos="-50.051723">
+      <input name="value2" type="boolean" value="true" />
+      <input name="in2" type="float" nodename="radius" />
+      <input name="value1" type="boolean" interfacename="use_growth_perlin" />
+      <input name="in1" type="float" nodename="wood3d_growth_perlin" />
+    </ifequal>
+    <max name="final_radius" type="float" xpos="-74.072464" ypos="-49.258621">
+      <input name="in1" type="float" nodename="distorted_radius" />
+    </max>
+    <ifequal name="final_earlycolor" type="color3" xpos="-58.144928" ypos="-50.534481">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="use_early_wood_color_perlin" />
+      <input name="in1" type="color3" nodename="earlycolor_perlin" />
+      <input name="in2" type="color3" interfacename="early_color" />
+    </ifequal>
+    <ifequal name="final_latecolor" type="color3" xpos="-57.956520" ypos="-46.310345">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="use_late_wood_color_perlin" />
+      <input name="in1" type="color3" nodename="latecolor_prelin" />
+      <input name="in2" type="color3" nodename="latecolor" />
+    </ifequal>
+    <ifequal name="ray_roughness_weight" type="float" xpos="-29.362318" ypos="-43.051723">
+      <input name="value1" type="boolean" interfacename="use_ray_color" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in1" type="float" output="ray_weight" nodename="wood3d_ray" />
+    </ifequal>
+    <separate3 name="separated_xyz" type="multioutput" xpos="-115.775360" ypos="-52.241379">
+      <input name="in" type="vector3" nodename="input_xyz" />
+      <output name="outy" type="float" />
+      <output name="outz" type="float" />
+      <output name="outx" type="float" />
+    </separate3>
+    <switch name="original_wood_position" type="vector3" xpos="-111.123192" ypos="-50.827587">
+      <input name="which" type="float" interfacename="axis" />
+      <input name="in3" type="vector3" nodename="input_xyz" />
+      <input name="in4" type="vector3" nodename="input_xyz" />
+      <input name="in5" type="vector3" nodename="input_xyz" />
+      <input name="in1" type="vector3" nodename="yzx" />
+      <input name="in2" type="vector3" nodename="zxy" />
+    </switch>
+    <combine3 name="yzx" type="vector3" xpos="-113.652176" ypos="-53.344826">
+      <input name="in1" type="float" output="outy" nodename="separated_xyz" />
+      <input name="in2" type="float" output="outz" nodename="separated_xyz" />
+      <input name="in3" type="float" output="outx" nodename="separated_xyz" />
+    </combine3>
+    <combine3 name="zxy" type="vector3" xpos="-113.652176" ypos="-51.827587">
+      <input name="in1" type="float" output="outz" nodename="separated_xyz" />
+      <input name="in2" type="float" output="outx" nodename="separated_xyz" />
+      <input name="in3" type="float" output="outy" nodename="separated_xyz" />
+    </combine3>
+    <min name="adjusted_seed" type="float" xpos="-106.615944" ypos="-45.810345">
+      <input name="in2" type="float" value="4095" />
+      <input name="in1" type="float" interfacename="seed" />
+    </min>
+    <ifequal name="wood_position_1" type="vector3" xpos="-95.449272" ypos="-50.172413">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="use_fiber_cosine" />
+      <input name="in2" type="vector3" nodename="wood_position_0" />
+      <input name="in1" type="vector3" nodename="wood3d_fiber_cosine_distortion" />
+    </ifequal>
+    <ifequal name="wood_position" type="vector3" xpos="-88.065216" ypos="-50.172413">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="use_fiber_perlin" />
+      <input name="in2" type="vector3" nodename="wood_position_1" />
+      <input name="in1" type="vector3" nodename="wood3d_fiber_perlin_distortion" />
+    </ifequal>
+    <output name="diffuse_color" type="color3" nodename="weighted_wood_color" xpos="-22.978260" ypos="-47.568966" />
+    <output name="wood_roughness" type="float" nodename="wood3d_roughness" xpos="-23.282608" ypos="-42.810345" />
+    <output name="normal" type="vector3" nodename="wood3d_bump" xpos="-36.550724" ypos="-41.379311" />
+  </nodegraph>
+
+</materialx>

--- a/contrib/adsk/libraries/adsklib/genglsl/adsklib_genglsl_impl.mtlx
+++ b/contrib/adsk/libraries/adsklib/genglsl/adsklib_genglsl_impl.mtlx
@@ -11,4 +11,11 @@
   <implementation name="IM_turbulence2d_float_genglsl" nodedef="ND_turbulence2d_float" file="mx_turbulence2d_float.glsl" function="mx_turbulence2d_float" target="genglsl" />
   <implementation name="IM_turbulence3d_float_genglsl" nodedef="ND_turbulence3d_float" file="mx_turbulence3d_float.glsl" function="mx_turbulence3d_float" target="genglsl" />
 
+  <!-- 2d hashnoise -->
+  <implementation name="IM_hashnoise2d_vector3_genglsl" nodedef="ND_wood3d_util_hashnoise2d_vector3" file="mx_hashnoise2d_vector3.glsl" function="mx_hashnoise2d_vector3" target="genglsl" />
+  <!-- 1d perlin noise -->
+  <implementation name="IM_noise1d_float_genglsl" nodedef="ND_wood3d_util_noise1d_float" file="mx_noise1d_float.glsl" function="mx_noise1d_float" target="genglsl" />
+  <!-- 3D wood pore function -->
+  <implementation name="IM_wood3d_pore_impulse_genglsl" nodedef="ND_wood3d_util_pore_impulse" file="mx_wood_pore_impulse.glsl" function="mx_wood_pore_impulse" target="genglsl" />
+  
 </materialx>

--- a/contrib/adsk/libraries/adsklib/genglsl/mx_hashnoise2d_vector3.glsl
+++ b/contrib/adsk/libraries/adsklib/genglsl/mx_hashnoise2d_vector3.glsl
@@ -1,0 +1,12 @@
+#include "../../stdlib/genglsl/lib/mx_noise.glsl"
+// hash noise is similar to cell noise without floor operation on input.  
+void mx_hashnoise2d_vector3(vec2 texcoord, out vec3 result)
+{
+    int ix = floatBitsToInt(texcoord.x);
+    int iy = floatBitsToInt(texcoord.y);
+    result = vec3(
+            mx_bits_to_01(mx_hash_int(ix, iy, 0)),
+            mx_bits_to_01(mx_hash_int(ix, iy, 1)),
+            mx_bits_to_01(mx_hash_int(ix, iy, 2))
+    );
+}

--- a/contrib/adsk/libraries/adsklib/genglsl/mx_noise1d_float.glsl
+++ b/contrib/adsk/libraries/adsklib/genglsl/mx_noise1d_float.glsl
@@ -1,0 +1,34 @@
+#include "../../stdlib/genglsl/lib/mx_noise.glsl"
+// 1 dimensional gradient function for 1D perlin noise
+float mx_gradient_float(uint hash, float x)
+{
+    uint  h = hash & 15u;
+    float g = 1 + (h & 7u);
+    return mx_negate_if(g, bool(h&8u)) * x; 
+}
+
+// Scaling factors to normalize the result of gradients above.
+// These factors were experimentally calculated to be:
+//    1D:   0.2500
+//    2D:   0.6616
+//    3D:   0.9820
+float mx_gradient_scale1d(float v) { return 0.2500 * v; }
+
+// 1D perlin noise
+float mx_perlin_noise_float(float p)
+{
+    int X;
+    float fx = mx_floorfrac(p, X);
+    float u = mx_fade(fx);
+    // mix in glsl is equivalent to lerp
+    float result = mix(
+        mx_gradient_float(mx_hash_int(X  ), fx ),
+        mx_gradient_float(mx_hash_int(X+1), fx-1.0),
+        u);
+    return mx_gradient_scale1d(result);
+}
+void mx_noise1d_float(float amplitude, float pivot, float p, out float result)
+{
+    float value = mx_perlin_noise_float(p);
+    result = value * amplitude + pivot;
+}

--- a/contrib/adsk/libraries/adsklib/genglsl/mx_wood_pore_impulse.glsl
+++ b/contrib/adsk/libraries/adsklib/genglsl/mx_wood_pore_impulse.glsl
@@ -1,0 +1,44 @@
+#include "../../stdlib/genglsl/lib/mx_noise.glsl"
+
+// Wyvill kernel with pre-squared input.
+float wyvillsq(float rsq)
+{
+	float tmp = 1.0 - rsq;
+	return rsq >= 1.0 ? 0.0 : tmp * tmp * tmp;
+}
+// Compute impulse for wood pore effects which can't be done by node graph. This is essentially a re-implementation of the 
+// weight2DNeighborImpulses function in the 3ds max advance wood source code.
+void mx_wood_pore_impulse(vec3 position, float wood_weight, float seed, float pore_cell_dim, float pore_radius, out float weight)
+{
+  weight = 0.0;
+  if (wood_weight <= 0.0) 
+  {
+    return;
+  }
+  float weighted_pore_radius = pore_radius * wood_weight;
+  
+  // Determine the boundaries of the pore cells that may affect us, given the pore radius and
+  // cell dimensions.
+  float x_left  = floor((position.x - weighted_pore_radius) / pore_cell_dim);
+  float x_right = floor((position.x + weighted_pore_radius) / pore_cell_dim);
+  float y_left  = floor((position.y - weighted_pore_radius) / pore_cell_dim);
+  float y_right = floor((position.y + weighted_pore_radius) / pore_cell_dim);
+
+  // Sum the wyvill impulse from all potentially contributing cells.
+  float inverse_radius_sq = 1.0 / (weighted_pore_radius * weighted_pore_radius);
+  for (int j = int(y_left); j <= int(y_right); j++) 
+  {
+    for (int i = int(x_left); i <= int(x_right); i++) 
+    {
+      // Determine where the pore is in the cell
+      vec2 offset = mx_cell_noise_vec3(vec2(i + seed * 37, j)).xy;
+      vec2 pore_position = (offset + vec2(float(i), float(j))) * pore_cell_dim;
+  
+      // Compute the distance to the pore and use it for the wyvill impulse.
+      vec2 diff = pore_position - vec2(position.x,position.y);
+      float diff_sq = dot(diff, diff);
+      weight += wyvillsq(diff_sq * inverse_radius_sq);
+    }
+  }       
+}
+

--- a/contrib/adsk/libraries/adsklib/genmdl/adsklib_genmdl_impl.mtlx
+++ b/contrib/adsk/libraries/adsklib/genmdl/adsklib_genmdl_impl.mtlx
@@ -11,5 +11,11 @@
   
   <implementation name="IM_turbulence2d_float_genmdl" nodedef="ND_turbulence2d_float" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
   <implementation name="IM_turbulence3d_float_genmdl" nodedef="ND_turbulence3d_float" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
-
+    
+  <!-- 2d hashnoise -->
+  <implementation name="IM_wood3d_util_hashnoise2d_vector3_genmdl" nodedef="ND_wood3d_util_hashnoise2d_vector3" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
+  <!-- 1d perlin noise -->
+  <implementation name="IM_wood3d_util_noise1d_float_genmdl" nodedef="ND_wood3d_util_noise1d_float" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
+  <!-- 3D wood pore function -->
+  <implementation name="IM_wood3d_util_pore_impulse_genmdl" nodedef="ND_wood3d_util_pore_impulse" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
 </materialx>

--- a/contrib/adsk/libraries/adsklib/genosl/adsklib_genosl_impl.mtlx
+++ b/contrib/adsk/libraries/adsklib/genosl/adsklib_genosl_impl.mtlx
@@ -11,5 +11,12 @@
   
   <implementation name="IM_turbulence2d_float_genosl" nodedef="ND_turbulence2d_float" file="mx_turbulence2d_float.osl" function="mx_turbulence2d_float" target="genosl" />
   <implementation name="IM_turbulence3d_float_genosl" nodedef="ND_turbulence3d_float" file="mx_turbulence3d_float.osl" function="mx_turbulence3d_float" target="genosl" />
+  
+  <!-- 2d hashnoise -->
+  <implementation name="IM_wood3d_util_hashnoise2d_vector3_genosl" nodedef="ND_wood3d_util_hashnoise2d_vector3" file="mx_hashnoise2d_vector3.osl" function="mx_hashnoise2d_vector3" target="genosl" />
+  <!-- 1d perlin noise -->
+  <implementation name="IM_wood3d_util_noise1d_float_genosl" nodedef="ND_wood3d_util_noise1d_float" file="mx_noise1d_float.osl" function="mx_noise1d_float" target="genosl" />
+  <!-- 3D wood pore function -->
+  <implementation name="IM_wood3d_util_pore_impulse_genosl" nodedef="ND_wood3d_util_pore_impulse" file="mx_wood_pore_impulse.osl" function="mx_wood_pore_impulse" target="genosl" />
 
 </materialx>

--- a/contrib/adsk/libraries/adsklib/genosl/mx_hashnoise2d_vector3.osl
+++ b/contrib/adsk/libraries/adsklib/genosl/mx_hashnoise2d_vector3.osl
@@ -1,0 +1,4 @@
+void mx_hashnoise2d_vector3(vector2 texcoord, output vector3 result)
+{
+    result = noise("hash", texcoord.x, texcoord.y);
+}

--- a/contrib/adsk/libraries/adsklib/genosl/mx_noise1d_float.osl
+++ b/contrib/adsk/libraries/adsklib/genosl/mx_noise1d_float.osl
@@ -1,0 +1,5 @@
+void mx_noise2d_float(float amplitude, float pivot, float p, output float result)
+{
+    float value = noise("perlin", p);
+    result = value * amplitude + pivot;
+}

--- a/contrib/adsk/libraries/adsklib/genosl/mx_wood_pore_impulse.osl
+++ b/contrib/adsk/libraries/adsklib/genosl/mx_wood_pore_impulse.osl
@@ -1,0 +1,42 @@
+// Wyvill kernel with pre-squared input.
+float wyvillsq(float rsq)
+{
+	float tmp = 1.0 - rsq;
+	return rsq >= 1.0 ? 0.0 : tmp * tmp * tmp;
+}
+// Compute impulse for wood pore effects which can't be done by node graph. This is essentially a re-implementation of the 
+// weight2DNeighborImpulses function in the 3ds max advance wood source code.
+void mx_wood_pore_impulse(vector3 position, float wood_weight, float seed, float pore_cell_dim, float pore_radius, out float weight)
+{
+  weight = 0.0;
+  if (wood_weight <= 0.0) 
+  {
+    return;
+  }
+  float weighted_pore_radius = pore_radius * wood_weight;
+  
+  // Determine the boundaries of the pore cells that may affect us, given the pore radius and
+  // cell dimensions.
+  float x_left  = floor((position.x - weighted_pore_radius) / pore_cell_dim);
+  float x_right = floor((position.x + weighted_pore_radius) / pore_cell_dim);
+  float y_left  = floor((position.y - weighted_pore_radius) / pore_cell_dim);
+  float y_right = floor((position.y + weighted_pore_radius) / pore_cell_dim);
+
+  // Sum the wyvill impulse from all potentially contributing cells.
+  float inverse_radius_sq = 1.0 / (weighted_pore_radius * weighted_pore_radius);
+  for (int j = int(y_left); j <= int(y_right); j++) 
+  {
+    for (int i = int(x_left); i <= int(x_right); i++) 
+    {
+      // Determine where the pore is in the cell
+      vector2 offset = vcellnoise(vector2(i + seed * 37, j)).xy;
+      vector2 pore_position = (offset + vector2(float(i), float(j))) * pore_cell_dim;
+  
+      // Compute the distance to the pore and use it for the wyvill impulse.
+      vector2 diff = pore_position - vector2(position.x,position.y);
+      float diff_sq = dot(diff, diff);
+      weight += wyvillsq(diff_sq * inverse_radius_sq);
+    }
+  }       
+}
+

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/3Dwood/3dwood_presets.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/3Dwood/3dwood_presets.mtlx
@@ -1,0 +1,3092 @@
+<?xml version='1.0' encoding='us-ascii'?>
+<materialx version="1.38">
+  
+  <surfacematerial name="surfacematerial_ash_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_glossy" />
+  </standard_surface>
+  <wood3d name="wood_ash_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.4" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.25" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.22" />
+      <input name="late_wood_ratio" type="float" value="0.098" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.668" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.715465, 0.517401, 0.297653" />
+      <input name="late_wood_color_power" type="float" value="1.0" />
+      <input name="manual_late_wood_color" type="color3" value="0.579547, 0.415148, 0.215764" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+  <surfacematerial name="surfacematerial_ash_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_painted" />
+  </standard_surface>
+  <wood3d name="wood_ash_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.7" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.74" />
+      <input name="late_wood_ratio" type="float" value="0.36" />
+      <input name="early_wood_sharpness" type="float" value="0.3" />
+      <input name="late_wood_sharpness" type="float" value="0.64" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.0915184, 0.0399472, 0.554227" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0.625345, 0.517401, 0.348865" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_ash_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_ash_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.47" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.4" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.25" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.52" />
+      <input name="late_wood_ratio" type="float" value="0.098" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.668" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.715465, 0.517401, 0.297653" />
+      <input name="late_wood_color_power" type="float" value="1.0" />
+      <input name="manual_late_wood_color" type="color3" value="0.579547, 0.415148, 0.215764" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_ash_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_ash_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance" type="float" value="1" />
+      <input name="roughness" type="float" value="0.47" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.4" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.25" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.52" />
+      <input name="late_wood_ratio" type="float" value="0.098" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.668" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.183549, 0.0915184, 0.00455975" />
+      <input name="late_wood_color_power" type="float" value="1.0" />
+      <input name="manual_late_wood_color" type="color3" value="0.476177, 0.108711, 0.0511221" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_ash_stained_light_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_stained_light_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_stained_light_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_stained_light_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_stained_light_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_stained_light_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_ash_stained_light_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.47" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.4" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.25" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.52" />
+      <input name="late_wood_ratio" type="float" value="0.098" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.668" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.399293, 0.2468, 0.0802193" />
+      <input name="late_wood_color_power" type="float" value="1.0" />
+      <input name="manual_late_wood_color" type="color3" value="0.476177, 0.201096, 0.0802193" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_ash_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_ash_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_ash_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_ash_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_ash_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_ash_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_ash_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.7" />
+      <input name="ring_thickness" type="float" value="0.5" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.5" />
+      <input name="pore_color_power" type="float" value="1.4" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.25" />
+      <input name="ray_num_slices" type="float" value="30.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.74" />
+      <input name="late_wood_ratio" type="float" value="0.098" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.668" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.851252, 0.687031, 0.487765" />
+      <input name="late_wood_color_power" type="float" value="1.0" />
+      <input name="manual_late_wood_color" type="color3" value="0.625345, 0.517401, 0.348865" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="50, 25, 10, 3" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 3, 1, 0.2" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="25, 10, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="1.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="6, 0.75, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.35, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="5.0, 1.0, 0.02, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.1, 1.0, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.05" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.4, 0.6, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_glossy" />
+  </standard_surface>
+  <wood3d name="wood_cherry_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.17" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.2" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.85" />
+      <input name="early_color" type="color3" value="0.420508, 0.147998, 0.0563741" />
+      <input name="late_wood_color_power" type="float" value="1.36" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_painted" />
+  </standard_surface>
+  <wood3d name="wood_cherry_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.29" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.34" />
+      <input name="late_wood_ratio" type="float" value="0.26" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.23" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.358654, 0.0289912, 0.275833" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_cherry_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.44" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.5" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.85" />
+      <input name="early_color" type="color3" value="0.43134, 0.162754, 0.0638373" />
+      <input name="late_wood_color_power" type="float" value="1.34" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_cherry_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.44" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.5" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.0802193, 0.00969633, 0.00411618" />
+      <input name="late_wood_color_power" type="float" value="1.34" />
+      <input name="manual_late_wood_color" type="color3" value="0.113921, 0.00775103, 0.00455975" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_stained_light_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_stained_light_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_stained_light_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_stained_light_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_stained_light_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_stained_light_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_cherry_stained_light_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.44" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.5" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.173439, 0.0302565, 0.0111261" />
+      <input name="late_wood_color_power" type="float" value="1.34" />
+      <input name="manual_late_wood_color" type="color3" value="0.180144, 0.0302565, 0.00902149" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_cherry_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+      <input name="roughness" type="float" value="0.81" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.89" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.487765, 0.20836, 0.116576" />
+      <input name="late_wood_color_power" type="float" value="1.24" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_mahogany_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_mahogany_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_mahogany_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_mahogany_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_mahogany_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_mahogany_glossy" />
+  </standard_surface>
+  <wood3d name="wood_mahogany_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.75" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.13" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.19" />
+      <input name="late_wood_ratio" type="float" value="0.238" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.109" />
+      <input name="diffuse_lobe_weight" type="float" value="0.85" />
+      <input name="early_color" type="color3" value="0.20836, 0.0802193, 0.0242229" />
+      <input name="late_wood_color_power" type="float" value="1.07" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="40, 20, 3.5, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="3, 1, 0.2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="2.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 13, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="1, 2, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.02, 0.1, 3, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.25, 0.2, 0.05, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.15" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.3, 0.5, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_mahogany_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_mahogany_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_mahogany_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_mahogany_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_mahogany_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_mahogany_painted" />
+  </standard_surface>
+  <wood3d name="wood_mahogany_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.38" />
+      <input name="ring_thickness" type="float" value="0.75" />
+      <input name="pore_cell_dim" type="float" value="0.14" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.36" />
+      <input name="late_wood_ratio" type="float" value="0.238" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.109" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.00969633, 0.242796, 0.242796" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="40, 20, 3.5, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="3, 1, 0.2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="2.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 13, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="1, 2, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.02, 0.1, 3, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.25, 0.2, 0.05, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.15" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.3, 0.5, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_mahogany_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_mahogany_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_mahogany_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_mahogany_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_mahogany_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_mahogany_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_mahogany_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.51" />
+      <input name="ring_thickness" type="float" value="0.75" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.92" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.57" />
+      <input name="late_wood_ratio" type="float" value="0.238" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.109" />
+      <input name="diffuse_lobe_weight" type="float" value="0.85" />
+      <input name="early_color" type="color3" value="0.20836, 0.0802193, 0.0242229" />
+      <input name="late_wood_color_power" type="float" value="1.07" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="40, 20, 3.5, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="3, 1, 0.2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="2.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 13, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="1, 2, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.02, 0.1, 3, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.25, 0.2, 0.05, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.15" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.3, 0.5, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_mahogany_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_mahogany_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_mahogany_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_mahogany_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_mahogany_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_mahogany_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_mahogany_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.51" />
+      <input name="ring_thickness" type="float" value="0.75" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.92" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.57" />
+      <input name="late_wood_ratio" type="float" value="0.238" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.109" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.0759261, 0.0103978, 0.0050282" />
+      <input name="late_wood_color_power" type="float" value="1.07" />
+      <input name="manual_late_wood_color" type="color3" value="0.0962661, 0.0160677, 0.00902149" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="40, 20, 3.5, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="3, 1, 0.2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="2.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 13, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="1, 2, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.02, 0.1, 3, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.25, 0.2, 0.05, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.15" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.3, 0.5, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_mahogany_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_mahogany_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_mahogany_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_mahogany_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_mahogany_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_mahogany_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_mahogany_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.8" />
+      <input name="ring_thickness" type="float" value="0.75" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.54" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.85" />
+      <input name="late_wood_ratio" type="float" value="0.238" />
+      <input name="early_wood_sharpness" type="float" value="0.395" />
+      <input name="late_wood_sharpness" type="float" value="0.109" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.284452, 0.139022, 0.0802193" />
+      <input name="late_wood_color_power" type="float" value="1.07" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="40, 20, 3.5, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="3, 1, 0.2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="2.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 13, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="1, 2, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.02, 0.1, 3, 0" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.25, 0.2, 0.05, 0" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.15" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.3, 0.5, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.75, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_glossy" />
+  </standard_surface>
+  <wood3d name="wood_maple_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.2" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.420508, 0.267358, 0.144972" />
+      <input name="late_wood_color_power" type="float" value="1.38" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_painted" />
+  </standard_surface>
+  <wood3d name="wood_maple_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.35" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.35" />
+      <input name="late_wood_ratio" type="float" value="0.54" />
+      <input name="early_wood_sharpness" type="float" value="0.6" />
+      <input name="late_wood_sharpness" type="float" value="0.15" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.511398, 0.38891, 0.0050282" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_maple_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.49" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.499505, 0.334458, 0.193972" />
+      <input name="late_wood_color_power" type="float" value="1.38" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_maple_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.49" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.173439, 0.0657539, 0.0111261" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0.373615, 0.144972, 0.0179364" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_stained_light_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_stained_light_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_stained_light_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_stained_light_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_stained_light_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_stained_light_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_maple_stained_light_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.49" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.511398, 0.275833, 0.0545923" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0.409826, 0.14198, 0.0169881" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_maple_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.74" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.025" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.95" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.605484, 0.45908, 0.320382" />
+      <input name="late_wood_color_power" type="float" value="1.3" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_glossy" />
+  </standard_surface>
+  <wood3d name="wood_oak_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.28" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.5" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.18" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.708298, 0.517401, 0.315763" />
+      <input name="late_wood_color_power" type="float" value="0.85" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.45, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.85, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_painted" />
+  </standard_surface>
+  <wood3d name="wood_oak_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.37" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.32" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.766744, 0.284452, 0.0199178" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.45, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.85, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_oak_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.5" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.5" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.44" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.708298, 0.517401, 0.325037" />
+      <input name="late_wood_color_power" type="float" value="0.8" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.45, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.85, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_oak_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.5" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.8" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.44" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.320382, 0.151058, 0.0477758" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0.415148, 0.215764, 0.0869013" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.35, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.25, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.35, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_stained_light_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_stained_light_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_stained_light_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_stained_light_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_stained_light_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_stained_light_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_oak_stained_light_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.5" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.5" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.44" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.523443, 0.339223, 0.180144" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0.708298, 0.517401, 0.325037" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.35, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.25, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.35, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_oak_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_oak_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_oak_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_oak_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_oak_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_oak_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_oak_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.74" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.63" />
+      <input name="late_wood_ratio" type="float" value="0.33" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.68" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.774227, 0.612066, 0.436813" />
+      <input name="late_wood_color_power" type="float" value="0.8" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="12, 3, 0.08, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.15, 0.15, 0.45, 0.6" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.03" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.5, 0.85, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_glossy" />
+  </standard_surface>
+  <wood3d name="wood_pine_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.14" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.2" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.26" />
+      <input name="late_wood_ratio" type="float" value="0.105" />
+      <input name="early_wood_sharpness" type="float" value="0.777" />
+      <input name="late_wood_sharpness" type="float" value="0.051" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.715465, 0.56681, 0.373615" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_painted" />
+  </standard_surface>
+  <wood3d name="wood_pine_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.36" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.36" />
+      <input name="late_wood_ratio" type="float" value="0.54" />
+      <input name="early_wood_sharpness" type="float" value="0.28" />
+      <input name="late_wood_sharpness" type="float" value="0.83" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.348865, 0.00143313, 0.00143313" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_pine_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.39" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.2" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.52" />
+      <input name="late_wood_ratio" type="float" value="0.105" />
+      <input name="early_wood_sharpness" type="float" value="0.777" />
+      <input name="late_wood_sharpness" type="float" value="0.051" />
+      <input name="diffuse_lobe_weight" type="float" value="0.8" />
+      <input name="early_color" type="color3" value="0.715465, 0.56681, 0.373615" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_pine_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.39" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.2" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.45" />
+      <input name="late_wood_ratio" type="float" value="0.105" />
+      <input name="early_wood_sharpness" type="float" value="0.777" />
+      <input name="late_wood_sharpness" type="float" value="0.051" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.215764, 0.0824142, 0.0143105" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0.523443, 0.267358, 0.0780566" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_stained_light_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_stained_light_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_stained_light_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_stained_light_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_stained_light_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_stained_light_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_pine_stained_light_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.39" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.2" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.45" />
+      <input name="late_wood_ratio" type="float" value="0.105" />
+      <input name="early_wood_sharpness" type="float" value="0.777" />
+      <input name="late_wood_sharpness" type="float" value="0.051" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.47044, 0.20836, 0.0563741" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0.523443, 0.267358, 0.0780566" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_pine_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_pine_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_pine_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_pine_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_pine_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_pine_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_pine_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.47" />
+      <input name="ring_thickness" type="float" value="1.0" />
+      <input name="pore_cell_dim" type="float" value="0.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.05" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.2" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.92" />
+      <input name="late_wood_ratio" type="float" value="0.105" />
+      <input name="early_wood_sharpness" type="float" value="0.777" />
+      <input name="late_wood_sharpness" type="float" value="0.051" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.899385, 0.7593, 0.56681" />
+      <input name="late_wood_color_power" type="float" value="1.99" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="2, 17, 30, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="0.1, 0.8, 2, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 4, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.2, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="1, 5, 50, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.75, 0.5, 1, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.01, 0.1, 3.0, 18" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.5, 0.45, 0.15, 0.5" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="10, 0.5, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.5, 0.75, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="7, 0.05, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0.55, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_glossy" />
+  </standard_surface>
+  <wood3d name="wood_walnut_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.05" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.1" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="0.83" />
+      <input name="early_color" type="color3" value="0.0938759, 0.042987, 0.0103978" />
+      <input name="late_wood_color_power" type="float" value="1.63" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_painted" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_painted" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_painted" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_painted" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_painted" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_painted" />
+  </standard_surface>
+  <wood3d name="wood_walnut_painted" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.37" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.0" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.0" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.37" />
+      <input name="late_wood_ratio" type="float" value="0.25" />
+      <input name="early_wood_sharpness" type="float" value="0.09" />
+      <input name="late_wood_sharpness" type="float" value="0.26" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.0143105, 0.383775, 0.0179364" />
+      <input name="late_wood_color_power" type="float" value="0.95" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="false" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="false" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="false" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_walnut_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.36" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.4" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="0.85" />
+      <input name="early_color" type="color3" value="0.0938759, 0.042987, 0.0103978" />
+      <input name="late_wood_color_power" type="float" value="1.63" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_stained_dark_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_stained_dark_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_stained_dark_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_stained_dark_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_stained_dark_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_stained_dark_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_walnut_stained_dark_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.36" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.4" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="0.9" />
+      <input name="early_color" type="color3" value="0.0151752, 0.00658496, 0.00168692" />
+      <input name="late_wood_color_power" type="float" value="1.63" />
+      <input name="manual_late_wood_color" type="color3" value="0.0209511, 0.00552174, 0.000492504" />
+      <input name="use_manual_late_wood_color" type="boolean" value="true" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_unfinished" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_unfinished" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_unfinished" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_unfinished" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_unfinished" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_unfinished" />
+  </standard_surface>
+  <wood3d name="wood_walnut_unfinished" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.5" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="1.0" />
+      <input name="early_color" type="color3" value="0.160444, 0.0869013, 0.0356144" />
+      <input name="late_wood_color_power" type="float" value="1.15" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_curly_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_curly_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_curly_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_curly_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_curly_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_curly_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_maple_curly_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.015" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.49" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.68" />
+      <input name="early_color" type="color3" value="0.499505, 0.334458, 0.193972" />
+      <input name="late_wood_color_power" type="float" value="1.38" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_curly_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_curly_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_curly_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_curly_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_curly_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_curly_glossy" />
+  </standard_surface>
+  <wood3d name="wood_maple_curly_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.015" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.2" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.58" />
+      <input name="early_color" type="color3" value="0.420508, 0.267358, 0.144972" />
+      <input name="late_wood_color_power" type="float" value="1.38" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_quilted_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_quilted_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_quilted_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_quilted_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_quilted_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_quilted_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_maple_quilted_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.45" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.49" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.72" />
+      <input name="early_color" type="color3" value="0.499505, 0.334458, 0.193972" />
+      <input name="late_wood_color_power" type="float" value="1.08" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_maple_quilted_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_maple_quilted_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_maple_quilted_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_maple_quilted_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_maple_quilted_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_maple_quilted_glossy" />
+  </standard_surface>
+  <wood3d name="wood_maple_quilted_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.9" />
+      <input name="pore_cell_dim" type="float" value="1.5" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.06" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.2" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.793" />
+      <input name="late_wood_sharpness" type="float" value="0.527" />
+      <input name="diffuse_lobe_weight" type="float" value="0.65" />
+      <input name="early_color" type="color3" value="0.420508, 0.267358, 0.144972" />
+      <input name="late_wood_color_power" type="float" value="1.08" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="false" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_figured_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_figured_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_figured_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_figured_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_figured_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_figured_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_walnut_figured_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.36" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.4" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="0.68" />
+      <input name="early_color" type="color3" value="0.0938759, 0.042987, 0.0103978" />
+      <input name="late_wood_color_power" type="float" value="1.63" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_walnut_figured_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_walnut_figured_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_walnut_figured_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_walnut_figured_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_walnut_figured_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_walnut_figured_glossy" />
+  </standard_surface>
+  <wood3d name="wood_walnut_figured_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.05" />
+      <input name="ring_thickness" type="float" value="0.7" />
+      <input name="pore_cell_dim" type="float" value="0.1" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.001" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.1" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.1" />
+      <input name="late_wood_ratio" type="float" value="0.059" />
+      <input name="early_wood_sharpness" type="float" value="0.41" />
+      <input name="late_wood_sharpness" type="float" value="0.27" />
+      <input name="diffuse_lobe_weight" type="float" value="0.62" />
+      <input name="early_color" type="color3" value="0.0938759, 0.042987, 0.0103978" />
+      <input name="late_wood_color_power" type="float" value="1.63" />
+      <input name="manual_late_wood_color" type="color3" value="0.217638, 0.0707403, 3.98107e-005" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="23.5, 8, 2, 0" />
+      <input name="fiber_perlin_weights" type="vector4" value="1.25, 0.75, 0.15, 0" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.3" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="15, 2, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.5, 0.5, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="0.5, 0, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="0.5, 0, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="0.1, 0.4, 5, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.1, 0.15, 0.2, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0.35, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.2, 0.3, 0.15, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 1.5, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.25, 0.15, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_koa_curly_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_koa_curly_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_koa_curly_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_koa_curly_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_koa_curly_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_koa_curly_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_koa_curly_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.16" />
+      <input name="ring_thickness" type="float" value="0.8" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.59" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.51" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.26" />
+      <input name="late_wood_ratio" type="float" value="0.17" />
+      <input name="early_wood_sharpness" type="float" value="0.38" />
+      <input name="late_wood_sharpness" type="float" value="0.29" />
+      <input name="diffuse_lobe_weight" type="float" value="0.55" />
+      <input name="early_color" type="color3" value="0.4793, 0.0865, 0.0030" />
+      <input name="late_wood_color_power" type="float" value="2.8" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="0.75, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.25, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="8, 4, 1, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="4, 2.5, 0.5, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8, 2, 0.1, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.5, 0.6, 0.3" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.26" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 4, 1, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="3, 1.5, 0.3, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="8, 4.5, 1, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="2, 0.35, 0.5, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_koa_curly_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_koa_curly_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_koa_curly_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_koa_curly_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_koa_curly_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_koa_curly_glossy" />
+  </standard_surface>
+  <wood3d name="wood_koa_curly_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.08" />
+      <input name="ring_thickness" type="float" value="0.8" />
+      <input name="pore_cell_dim" type="float" value="0.12" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.03" />
+      <input name="pore_depth" type="float" value="0.01" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="2.59" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.51" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.11" />
+      <input name="late_wood_ratio" type="float" value="0.17" />
+      <input name="early_wood_sharpness" type="float" value="0.38" />
+      <input name="late_wood_sharpness" type="float" value="0.29" />
+      <input name="diffuse_lobe_weight" type="float" value="0.35" />
+      <input name="early_color" type="color3" value="0.6653, 0.1274, 0.0065" />
+      <input name="late_wood_color_power" type="float" value="2.9" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="true" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="0.75, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.25, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="8, 4, 1, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="4, 2.5, 0.5, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8, 2, 0.1, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.5, 0.6, 0.3" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.26" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 4, 1, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="3, 1.5, 0.3, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="8, 4.5, 1, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="2, 0.35, 0.5, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_figured_semigloss" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_figured_semigloss" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_figured_semigloss" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_figured_semigloss" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_figured_semigloss" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_figured_semigloss" />
+  </standard_surface>
+  <wood3d name="wood_cherry_figured_semigloss" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.44" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.5" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.68" />
+      <input name="early_color" type="color3" value="0.43134, 0.162754, 0.0638373" />
+      <input name="late_wood_color_power" type="float" value="1.34" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+<surfacematerial name="surfacematerial_cherry_figured_glossy" type="material" xpos="4.608696" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_surfaceshader_cherry_figured_glossy" />
+  </surfacematerial>
+  <standard_surface name="standard_surface_surfaceshader_cherry_figured_glossy" type="surfaceshader" xpos="1.130435" ypos="0.000000">
+    <input name="base_color" type="color3" output="diffuse_color" nodename="wood_cherry_figured_glossy" />
+    <input name="specular_roughness" type="float" output="wood_roughness" nodename="wood_cherry_figured_glossy" />
+    <input name="normal" type="vector3" output="normal" nodename="wood_cherry_figured_glossy" />
+  </standard_surface>
+  <wood3d name="wood_cherry_figured_glossy" type="multioutput" xpos="-1.521739" ypos="-0.008621">
+      <input name="seed" type="float" value="1" /> 
+      <input name="axis" type="float" value="1" />
+      <input name="scale" uivisible="false" unit="centimeter" unittype="distance"  type="float" value="1" />
+    
+      <input name="roughness" type="float" value="0.17" />
+      <input name="ring_thickness" type="float" value="0.6" />
+      <input name="pore_cell_dim" type="float" value="0.15" />
+      <input name="use_pore_color" type="boolean" value="true" />
+      <input name="pore_radius" type="float" value="0.04" />
+      <input name="pore_depth" type="float" value="0.02" />
+      <input name="use_ray_color" type="boolean" value="true" />
+      <input name="ray_seg_length_z" type="float" value="5.0" />
+      <input name="ray_ellipse_scale_x" type="float" value="0.2" />
+      <input name="pore_color_power" type="float" value="1.45" />
+      <input name="pore_type" type="integer" value="0" />
+      <input name="ray_color_power" type="float" value="1.2" />
+      <input name="ray_num_slices" type="float" value="160.0" />
+      <input name="ray_ellipse_z2x" type="float" value="10.0" />
+      <input name="use_groove_roughness" type="boolean" value="true" />
+      <input name="groove_roughness" type="float" value="0.2" />
+      <input name="late_wood_ratio" type="float" value="0.082" />
+      <input name="early_wood_sharpness" type="float" value="0.25" />
+      <input name="late_wood_sharpness" type="float" value="0.812" />
+      <input name="diffuse_lobe_weight" type="float" value="0.62" />
+      <input name="early_color" type="color3" value="0.420508, 0.147998, 0.0563741" />
+      <input name="late_wood_color_power" type="float" value="1.36" />
+      <input name="manual_late_wood_color" type="color3" value="0, 0, 0" />
+      <input name="use_manual_late_wood_color" type="boolean" value="false" />
+      <input name="fiber_perlin_frequencies"   type="vector4" value="60, 20, 5.5, 1" />
+      <input name="fiber_perlin_weights" type="vector4" value="8, 2, 0.5, 0.05" />
+      <input name="fiber_perlin_scale_z" type="float" value="0.2" />
+      <input name="use_fiber_cosine" type="boolean" value="false" />
+      <input name="fiber_cosine_frequencies"   type="vector4" value="1, 0, 0, 0" />
+      <input name="fiber_cosine_weights" type="vector4" value="0.1, 0, 0, 0" />
+      <input name="use_growth_perlin" type="boolean" value="true" />
+      <input name="growth_perlin_frequencies"   type="vector4" value="5, 1, 0, 0" />
+      <input name="growth_perlin_weights" type="vector4" value="2, 0.5, 0, 0" />
+      <input name="use_diffuse_perlin" type="boolean" value="true" />
+      <input name="diffuse_perlin_frequencies"   type="vector4" value="8.0, 2.0, 0.05, 0.01" />
+      <input name="diffuse_perlin_weights" type="vector4" value="0.05, 0.1, 0.25, 0.4" />
+      <input name="diffuse_perlin_scale_z" type="float" value="0.1" />
+      <input name="use_early_wood_color_perlin" type="boolean" value="true" />
+      <input name="earlycolor_perlin_frequencies"   type="vector4" value="8, 3, 0, 0" />
+      <input name="earlycolor_perlin_weights" type="vector4" value="0.85, 0.3, 0, 0" />
+      <input name="use_late_wood_color_perlin" type="boolean" value="true" />
+      <input name="latecolor_perlin_frequencies"   type="vector4" value="4.5, 0, 0, 0" />
+      <input name="latecolor_perlin_weights" type="vector4" value="0.35, 0, 0, 0" />
+      <input name="ray_ellipse_depth" type="float" value="2" />
+      <input name="ray_roughness" type="float" value="0.1" />
+      <input name="use_late_wood_bump" type="boolean" value="true" />
+      <input name="late_wood_bump_depth" type="float" value="0.102" />
+      <input name="use_pores_bump" type="boolean" value="false" />
+  </wood3d>
+</materialx>


### PR DESCRIPTION
Add a 3d wood material node graph (wood3d) which includes following custom nodes/node graphs as its components:

- two custom noise node (wood3d_util_noise1d and wood3d_util_hashnoise2d),
- a custom node for wood pore calculation (wood3d_util_pore_impulse), and
- many sub-graphs that improve readability / help reduce complexity of the wood3d node graph. 

This commit also contains a 3dwood_prests.mtlx which has many pre-defined parameters that helps to create different types of wood.