### PR TITLE
Swizzle removal

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsk_colorcorrect.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsk_colorcorrect.mtlx
@@ -87,22 +87,20 @@
       <input name="in2" type="color4" nodename="CombineColorAlpha" />
       <input name="value1" type="boolean" interfacename="unpremultiply_input" />
     </ifequal>
-    <swizzle name="outputColor" type="color3">
+    <convert name="outputColor" type="color3">
       <input name="in" type="color4" nodename="if_unpremultiply_condition" />
-      <input name="channels" type="string" value="rgb" />
-    </swizzle>
-    <swizzle name="outputAlpha" type="float">
+    </convert>
+    <extract name="outputAlpha" type="float">
+      <input name="index" type="integer" value="3" />
       <input name="in" type="color4" nodename="if_unpremultiply_condition" />
-      <input name="channels" type="string" value="a" />
-    </swizzle>
-    <swizzle name="extractColorForHsv" type="color3">
+    </extract>
+    <convert name="extractColorForHsv" type="color3">
       <input name="in" type="color4" nodename="if_premultiply_condition" />
-      <input name="channels" type="string" value="rgb" />
-    </swizzle>
-    <swizzle name="extractAlphaForGain" type="float">
+    </convert>
+    <extract name="extractAlphaForGain" type="float">
+      <input name="index" type="integer" value="3" />
       <input name="in" type="color4" nodename="if_premultiply_condition" />
-      <input name="channels" type="string" value="a" />
-    </swizzle>
+    </extract>
     <combine2 name="combineInput" type="color4">
       <input name="in1" type="color3" interfacename="color" />
       <input name="in2" type="float" interfacename="alpha" />


### PR DESCRIPTION
Removing swizzle nodes by replacing the ones extracting "rgb" with a Convert color4 to color3, and the ones extracting "a" with an Extract using index 3.

The diff is confusing to read, but the changes are very simple. Verified also by opening it back in LookdevX and Graph Editor, the connections are sound and the nodes types, inputs, and outputs are correct.

@JGamache-autodesk 