### PR TITLE
Update compiler version for macOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         - name: MacOS_Xcode_15_Python312
           os: macos-15
           compiler: xcode
-          compiler_version: "15.4"
+          compiler_version: "16.1"
           python: 3.12
           test_shaders: ON
 


### PR DESCRIPTION
On May 29th, 2025, Xcode 15 was removed from MacOS 15
https://github.com/actions/runner-images/issues/12195

Updating to version 16.1