### PR TITLE
Adding legacy knurl

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
@@ -280,6 +280,7 @@
     <input name="rotation" type="float" value="0" uisoftmin="0.0" uisoftmax="360" />
     <input name="realworld_scale" type="vector2" value="1,1" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
     <input name="realworld_offset" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uiname="Offset X, Y" unittype="distance" />
+    <input name="diagonal" type="boolean" value="false" />
     <output name="out_rgb" type="color3" />
     <output name="out_vec3" type="vector3" />
   </nodedef>

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
@@ -51,7 +51,7 @@
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uivisible="false" uiname="Texture Coordinates" />
     <input name="color1" type="color3" value="1, 1, 1" uivisible="true" uiname="Color 1" />
     <input name="color2" type="color3" value="0, 0, 0" uivisible="true" uiname="Color 2" />
-    <input name="realworld_scale" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
+    <input name="realworld_scale" type="vector2" value="1,1" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
     <input name="soften" type="float" value="0" uivisible="true" uiname="Soften" />
     <input name="adjust_soften_y" type="boolean" value="false" uivisible="true" uiname="Adjust Height Softness" />
     <input name="realworld_offset" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Offset X, Y" unittype="distance"/>
@@ -222,7 +222,7 @@
     <input name="rows_mod_enable" type="boolean" value="false" uivisible="true" uiname="Row Modify" />
     <input name="num_rows" type="float" value="5.0" uisoftmin="0.0" uisoftmax="100.0" uivisible="true" uiname="Every N Rows" />
     <input name="rows_mod_amount" type="float" value="3.0" uisoftmin="0.0" uisoftmax="10" uivisible="true" uiname="Modify Amount" />
-    <input name="realworld_scale" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
+    <input name="realworld_scale" type="vector2" value="1,1" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
     <input name="realworld_offset" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Offset X, Y" unittype="distance" />
     <input name="rotation_angle" type="float" value="0" uisoftmin="0.0" uisoftmax="360" uivisible="true" uiname="Rotation Angle" unittype="angle" unit="degree" />
     <input name="tile_x" type="boolean" value="true" />
@@ -272,6 +272,16 @@
     <input name="tile_x" type="boolean" value="true" uivisible="true" uiname="Repeat X" />
     <input name="tile_y" type="boolean" value="true" uivisible="true" uiname="Repeat Y" />
     <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_legacy_knurl" node="legacy_knurl" version="0.1" isdefaultversion="true" nodegroup="adsk_legacy">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uivisible="false" uiname="Texture Coordinates" />
+    <input name="amount" type="float" value="0.25" uimin="0.0" uimax="1.0" />
+    <input name="rotation" type="float" value="0" uisoftmin="0.0" uisoftmax="360" />
+    <input name="realworld_scale" type="vector2" value="1,1" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
+    <input name="realworld_offset" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uiname="Offset X, Y" unittype="distance" />
+    <output name="out_rgb" type="color3" />
+    <output name="out_vec3" type="vector3" />
   </nodedef>
 
   <!-- 

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
@@ -687,9 +687,6 @@
       <input name="value2" type="boolean" value="true" />
       <input name="value1" type="boolean" interfacename="threshold_smooth" />
     </ifequal>
-    <adsk_converter name="adsk_converter1" type="color3" nodedef="ND_adsk_converter_float_color3" Autodesk-hiddenInternalConverter="true" Autodesk-internalConverter="true">
-      <input name="in" type="float" nodename="turbulence3d_max8" />
-    </adsk_converter>
     <backdrop name="offset_and_rotation" xpos="5.36043" ypos="3.36278" width="3.49555" height="4.42037" />
     <add name="add_noise1" type="float" nodedef="ND_add_float" xpos="14.5288" ypos="10.3503">
       <input name="in2" type="float" nodename="mult_phase" />
@@ -3688,6 +3685,122 @@
       <input name="tile_x" type="boolean" interfacename="tile_x" />
       <input name="tile_y" type="boolean" interfacename="tile_y" />
     </legacy_gradient>
+  </nodegraph>
+
+  <nodegraph name="NG_legacy_knurl" Autodesk-ldx_inputPos="-1747.36 -123.243" Autodesk-ldx_outputPos="2689.42 48.6444" nodedef="ND_legacy_knurl">
+    <separate2 name="separate_uv" type="multioutput" nodedef="ND_separate2_vector2" xpos="0.173733" ypos="-1.37102">
+      <input name="in" type="vector2" nodename="uv_modulo" />
+    </separate2>
+    <output name="out_rgb" type="color3" nodename="convert_vec_col" />
+    <constant name="constant_vecX" type="vector3" nodedef="ND_constant_vector3" xpos="-1.92249" ypos="0.974561">
+      <input name="value" type="vector3" value="1, 0, 0" />
+    </constant>
+    <rotate3d name="rotate_Y1" type="vector3" nodedef="ND_rotate3d_vector3" xpos="0.221146" ypos="0.691367">
+      <input name="in" type="vector3" nodename="constant_vecX" />
+      <input name="amount" type="float" nodename="amount_to_degrees" />
+      <input name="axis" type="vector3" value="0, 1, 0" />
+    </rotate3d>
+    <rotate3d name="rotate_Y2" type="vector3" nodedef="ND_rotate3d_vector3" xpos="0.18353" ypos="1.88111">
+      <input name="in" type="vector3" nodename="constant_vecX" />
+      <input name="amount" type="float" ldx_value="90" nodename="invert_180" />
+      <input name="axis" type="vector3" value="0, 1, 0" />
+    </rotate3d>
+    <ifgreater name="ifgreater_half_x" type="vector3" nodedef="ND_ifgreater_vector3" xpos="3.43067" ypos="-1.19766">
+      <input name="value1" type="float" nodename="separate_uv" output="outx" />
+      <input name="value2" type="float" value="0.5" />
+      <input name="in1" type="vector3" nodename="rotate_Y1" ldx_value="0.2934, 0, 0" />
+      <input name="in2" type="vector3" nodename="rotate_Y2" />
+    </ifgreater>
+    <multiply name="amount_to_degrees" type="float" nodedef="ND_multiply_float" xpos="-3.75268" ypos="-0.68535">
+      <input name="in1" type="float" nodename="invert_amount" />
+      <input name="in2" type="float" value="90" />
+    </multiply>
+    <invert name="invert_x" type="float" nodedef="ND_invert_float" xpos="3.46505" ypos="2.25166">
+      <input name="in" type="float" nodename="separate_uv" output="outx" />
+    </invert>
+    <ifgreater name="ifgreater_xy" type="float" nodedef="ND_ifgreater_float" xpos="5.42496" ypos="-0.352874">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="0" />
+      <input name="value1" type="float" nodename="separate_uv" output="outx" />
+      <input name="value2" type="float" nodename="separate_uv" output="outy" />
+    </ifgreater>
+    <ifgreater name="ifgreater_yx" type="float" nodedef="ND_ifgreater_float" xpos="5.42107" ypos="1.22741">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="0" />
+      <input name="value2" type="float" nodename="invert_x" />
+      <input name="value1" type="float" nodename="separate_uv" output="outy" />
+    </ifgreater>
+    <ifequal name="select_plane" type="vector3" nodedef="ND_ifequal_vector3" xpos="7.20856" ypos="0.289837">
+      <input name="value1" type="float" nodename="ifgreater_xy" />
+      <input name="value2" type="float" nodename="ifgreater_yx" />
+      <input name="in1" type="vector3" nodename="ifgreater_half_x" ldx_value="0.4052, 0.0935, 0.0935" />
+      <input name="in2" type="vector3" nodename="ifgreater_half_y" ldx_value="0, 0, 0" />
+    </ifequal>
+    <output name="out_vec3" type="vector3" nodename="normalmap1" />
+    <invert name="invert_amount" type="float" nodedef="ND_invert_float" xpos="-5.42683" ypos="-1.00327">
+      <input name="in" type="float" interfacename="amount" />
+    </invert>
+    <rotate3d name="rotate_X1" type="vector3" nodedef="ND_rotate3d_vector3" xpos="0.193136" ypos="3.51694">
+      <input name="axis" type="vector3" value="1, 0, 0" />
+      <input name="amount" type="float" nodename="invert_180" />
+      <input name="in" type="vector3" nodename="constant_vecY" />
+    </rotate3d>
+    <rotate3d name="rotate_X2" type="vector3" nodedef="ND_rotate3d_vector3" xpos="0.222224" ypos="4.92501">
+      <input name="in" type="vector3" nodename="constant_vecY" />
+      <input name="axis" type="vector3" value="1, 0, 0" />
+      <input name="amount" type="float" ldx_value="0" nodename="amount_to_degrees" />
+    </rotate3d>
+    <constant name="constant_vecY" type="vector3" nodedef="ND_constant_vector3" xpos="-1.76419" ypos="4.90634">
+      <input name="value" type="vector3" value="0, -1, 0" />
+    </constant>
+    <ifgreater name="ifgreater_half_y" type="vector3" nodedef="ND_ifgreater_vector3" xpos="3.4679" ypos="0.693533">
+      <input name="value1" type="float" nodename="separate_uv" output="outy" />
+      <input name="value2" type="float" value="0.5" />
+      <input name="in1" type="vector3" nodename="rotate_X1" ldx_value="0.2934, 0, 0" />
+      <input name="in2" type="vector3" nodename="rotate_X2" />
+    </ifgreater>
+    <divide name="divide_half" type="vector3" nodedef="ND_divide_vector3FA" xpos="10.4983" ypos="0.342258">
+      <input name="in2" type="float" value="2" />
+      <input name="in1" type="vector3" nodename="rotate_normal" />
+    </divide>
+    <add name="offset_half" type="vector3" nodedef="ND_add_vector3FA" xpos="11.8534" ypos="0.355958">
+      <input name="in2" type="float" value="0.5" />
+      <input name="in1" type="vector3" nodename="divide_half" />
+    </add>
+    <convert name="convert_vec_col" type="color3" nodedef="ND_convert_vector3_color3" xpos="13.3929" ypos="-0.464234">
+      <input name="in" type="vector3" nodename="offset_half" />
+    </convert>
+    <modulo name="uv_modulo" type="vector2" nodedef="ND_modulo_vector2FA" xpos="-1.94274" ypos="-1.53743">
+      <input name="in1" type="vector2" nodename="divide1" />
+    </modulo>
+    <rotate2d name="rotate2d_pattern" type="vector2" nodedef="ND_rotate2d_vector2" xpos="-5.43093" ypos="-3.16315">
+      <input name="amount" type="float" nodename="lagacy_rot_direction" ldx_value="0" />
+      <input name="in" type="vector2" nodename="offset_uv" />
+    </rotate2d>
+    <rotate3d name="rotate_normal" type="vector3" nodedef="ND_rotate3d_vector3" xpos="8.83856" ypos="0.319578">
+      <input name="axis" type="vector3" value="0, 0, 1" />
+      <input name="amount" type="float" interfacename="rotation" ldx_value="0" />
+      <input name="in" type="vector3" nodename="select_plane" />
+    </rotate3d>
+    <invert name="invert_180" type="float" nodedef="ND_invert_float" xpos="-1.86346" ypos="2.77993">
+      <input name="amount" type="float" value="180" />
+      <input name="in" type="float" nodename="amount_to_degrees" />
+    </invert>
+    <invert name="lagacy_rot_direction" type="float" nodedef="ND_invert_float" xpos="-7.20711" ypos="-3.31817">
+      <input name="amount" type="float" value="0" />
+      <input name="in" type="float" interfacename="rotation" />
+    </invert>
+    <divide name="divide1" type="vector2" nodedef="ND_divide_vector2" xpos="-3.76994" ypos="-2.2396">
+      <input name="in2" type="vector2" interfacename="realworld_scale" />
+      <input name="in1" type="vector2" ldx_value="1, 1" nodename="rotate2d_pattern" />
+    </divide>
+    <subtract name="offset_uv" type="vector2" nodedef="ND_subtract_vector2" xpos="-7.20083" ypos="-2.1922">
+      <input name="in1" type="vector2" interfacename="texcoord" />
+      <input name="in2" type="vector2" interfacename="realworld_offset" />
+    </subtract>
+    <normalmap name="normalmap1" type="vector3" nodedef="ND_normalmap" xpos="13.3901" ypos="0.818122">
+      <input name="in" type="vector3" nodename="offset_half" />
+    </normalmap>
   </nodegraph>
 
   <!-- 

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
@@ -3689,7 +3689,7 @@
 
   <nodegraph name="NG_legacy_knurl" Autodesk-ldx_inputPos="-1747.36 -123.243" Autodesk-ldx_outputPos="2689.42 48.6444" nodedef="ND_legacy_knurl">
     <separate2 name="separate_uv" type="multioutput" nodedef="ND_separate2_vector2" xpos="0.173733" ypos="-1.37102">
-      <input name="in" type="vector2" nodename="uv_modulo" />
+      <input name="in" type="vector2" nodename="diag_select1" />
     </separate2>
     <output name="out_rgb" type="color3" nodename="convert_vec_col" />
     <constant name="constant_vecX" type="vector3" nodedef="ND_constant_vector3" xpos="-1.92249" ypos="0.974561">
@@ -3706,10 +3706,10 @@
       <input name="axis" type="vector3" value="0, 1, 0" />
     </rotate3d>
     <ifgreater name="ifgreater_half_x" type="vector3" nodedef="ND_ifgreater_vector3" xpos="3.43067" ypos="-1.19766">
-      <input name="value1" type="float" nodename="separate_uv" output="outx" />
       <input name="value2" type="float" value="0.5" />
       <input name="in1" type="vector3" nodename="rotate_Y1" ldx_value="0.2934, 0, 0" />
       <input name="in2" type="vector3" nodename="rotate_Y2" />
+      <input name="value1" type="float" nodename="separate_uv" output="outx" />
     </ifgreater>
     <multiply name="amount_to_degrees" type="float" nodedef="ND_multiply_float" xpos="-3.75268" ypos="-0.68535">
       <input name="in1" type="float" nodename="invert_amount" />
@@ -3721,8 +3721,8 @@
     <ifgreater name="ifgreater_xy" type="float" nodedef="ND_ifgreater_float" xpos="5.42496" ypos="-0.352874">
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
-      <input name="value1" type="float" nodename="separate_uv" output="outx" />
       <input name="value2" type="float" nodename="separate_uv" output="outy" />
+      <input name="value1" type="float" nodename="separate_uv" output="outx" />
     </ifgreater>
     <ifgreater name="ifgreater_yx" type="float" nodedef="ND_ifgreater_float" xpos="5.42107" ypos="1.22741">
       <input name="in1" type="float" value="1" />
@@ -3779,7 +3779,7 @@
     </rotate2d>
     <rotate3d name="rotate_normal" type="vector3" nodedef="ND_rotate3d_vector3" xpos="8.83856" ypos="0.319578">
       <input name="axis" type="vector3" value="0, 0, 1" />
-      <input name="amount" type="float" interfacename="rotation" ldx_value="0" />
+      <input name="amount" type="float" nodename="diag_select2" ldx_value="0" />
       <input name="in" type="vector3" nodename="select_plane" />
     </rotate3d>
     <invert name="invert_180" type="float" nodedef="ND_invert_float" xpos="-1.86346" ypos="2.77993">
@@ -3801,6 +3801,39 @@
     <normalmap name="normalmap1" type="vector3" nodedef="ND_normalmap" xpos="13.3901" ypos="0.818122">
       <input name="in" type="vector3" nodename="offset_half" />
     </normalmap>
+    <rotate2d name="rotate_knurl" type="vector2" nodedef="ND_rotate2d_vector2" xpos="-5.53632" ypos="-5.17471">
+      <input name="amount" type="float" value="45" />
+      <input name="in" type="vector2" nodename="diag_scale" />
+    </rotate2d>
+    <modulo name="modulo_knurl" type="vector2" nodedef="ND_modulo_vector2FA" xpos="-2.39462" ypos="-5.16703">
+      <input name="in1" type="vector2" nodename="diag_shift" />
+      <input name="in2" type="float" value="1" />
+    </modulo>
+    <ifequal name="diag_select1" type="vector2" nodedef="ND_ifequal_vector2B" xpos="-0.836778" ypos="-5.19393">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="diagonal" />
+      <input name="in2" type="vector2" nodename="uv_modulo" />
+      <input name="in1" type="vector2" nodename="modulo_knurl" />
+    </ifequal>
+    <multiply name="diag_scale" type="vector2" nodedef="ND_multiply_vector2FA" xpos="-7.156" ypos="-5.18757">
+      <input name="in2" type="float" value="1.41421" />
+      <input name="in1" type="vector2" nodename="uv_modulo" />
+    </multiply>
+    <add name="diag_shift" type="vector2" nodedef="ND_add_vector2" xpos="-3.90246" ypos="-5.12966">
+      <input name="in1" type="vector2" nodename="rotate_knurl" />
+      <input name="in2" type="vector2" value="0.5, 0.5" />
+    </add>
+    <ifequal name="diag_select2" type="float" nodedef="ND_ifequal_floatB" xpos="-5.46295" ypos="0.625989">
+      <input name="value2" type="boolean" value="true" />
+      <input name="value1" type="boolean" interfacename="diagonal" />
+      <input name="in2" type="float" interfacename="rotation" />
+      <input name="in1" type="float" nodename="diag_adjustment" />
+    </ifequal>
+    <subtract name="diag_adjustment" type="float" nodedef="ND_subtract_float" xpos="-7.42233" ypos="2.30152">
+      <input name="in1" type="float" interfacename="rotation" />
+      <input name="in2" type="float" value="45" />
+    </subtract>
+    <backdrop name="this_is_an_approximation" xpos="-7.892" ypos="1.63793" width="2.22739" height="2.05194" uicolor="#C85252" Autodesk-ldx_alpha="0.156863" />
   </nodegraph>
 
   <!-- 

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_knurl.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_knurl.mtlx
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <standard_surface name="SR_legacy_knurl" type="surfaceshader" xpos="10.521739" ypos="-0.620690">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
+    <input name="specular_roughness" type="float" value="0.1" />
+    <input name="subsurface" type="float" value="0.4" />
+    <input name="subsurface_color" type="color3" value="1, 1, 1" />
+    <input name="metalness" type="float" value="1" />
+    <input name="normal" type="vector3" output="out_vec3" nodename="legacy_knurl" />
+  </standard_surface>
+  <surfacematerial name="M_legacy_knurl" type="material" xpos="13.043478" ypos="0.000000">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_legacy_knurl" />
+  </surfacematerial>
+  <legacy_knurl name="legacy_knurl" type="multioutput" xpos="5.536232" ypos="-1.086207">
+    <output name="out_rgb" type="color3" />
+    <input name="amount" type="float" value="0.25" />
+    <input name="realworld_scale" type="vector2" value="0.1, 0.2" />
+    <input name="diagonal" type="boolean" value="true" />
+    <input name="rotation" type="float" value="45" />
+  </legacy_knurl>
+</materialx>


### PR DESCRIPTION
Adding nodedef and nodegraph for Legacy Knurl.
This implements a generic knurl that is a superset, usable standalone, of the knurl used as a Metal pattern. The original knurl in RapidRT was not usable standalone. This solution is different and has more features, making it a worthwhile extra procedural to add to the library.

A coupe of extra fixes are included
- defaults for a couple of size parameters were incorrectly set to 0,0 after changing them to vector2.
- A converter node from LookdevX was removed. It was unconnected, and it might be recreated if that graph is re-exported. I'll try to keep an eye on it. No biggie if it's there anyway.