### PR TITLE
Additional input units

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
@@ -116,7 +116,7 @@
     <input name="position" type="vector3" defaultgeomprop="Pobject" uivisible="false" uiname="Position Coordinates" />
     <input name="color1" type="color3" value="0, 0, 0" uisoftmin="0,0,0" uisoftmax="1,1,1" uivisible="true" uiname="Color 1" />
     <input name="color2" type="color3" value="1, 1, 1" uisoftmin="0,0,0" uisoftmax="1,1,1" uivisible="true" uiname="Color 2" />
-    <input name="size" type="float" value="1" uisoftmin="0.0" uisoftmax="10.0" uivisible="true" uiname="Size" />
+    <input name="size" type="float" value="1" uisoftmin="0.0" uisoftmax="10.0" uivisible="true" uiname="Size" unittype="distance" />
     <input name="octaves" type="float" value="4.0" uisoftmin="0.0" uisoftmax="8.0" uivisible="true" uiname="Octaves" />
     <input name="realworld_offset" type="vector3" value="0,0,0" uisoftmin="0,0,0" uisoftmax="1,1,1" uivisible="true" uiname="Offset X, Y, Z" unittype="distance" />
     <input name="rotation_angle" type="vector3" value="0,0,0" uisoftmin="0,0,0" uisoftmax="360,360,360" uivisible="true" uiname="Rotation Angle X, Y, Z" unittype="angle" unit="degree" />
@@ -125,7 +125,7 @@
 
   <nodedef name="ND_legacy_marble_color3" node="legacy_marble" version="0.1" isdefaultversion="true" nodegroup="adsk_legacy">
     <input name="position" type="vector3" defaultgeomprop="Pobject" uivisible="false" uiname="Position Coordinates" />
-    <input name="size" type="float" value="0.7636" uimin="0.0" uisoftmax="10.0" uivisible="true" uiname="Vein Spacingg" />
+    <input name="size" type="float" value="0.7636" uimin="0.0" uisoftmax="10.0" uivisible="true" uiname="Vein Spacing" unittype="distance" />
     <input name="width" type="float" value="0.070283" uimin="0.0" uisoftmax="10.0" uivisible="true" uiname="Vein Width" />
     <input name="stone_color" type="color3" value="0.0303, 0.0321, 0.0122" uisoftmin="0,0,0" uisoftmax="1,1,1" uivisible="true" uiname="Stone Color" />
     <input name="vein_color" type="color3" value="0.7832, 0.7832, 0.5755" uisoftmin="0,0,0" uisoftmax="1,1,1" uivisible="true" uiname="Vein Color" />
@@ -277,7 +277,7 @@
   <nodedef name="ND_legacy_knurl" node="legacy_knurl" version="0.1" isdefaultversion="true" nodegroup="adsk_legacy">
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uivisible="false" uiname="Texture Coordinates" />
     <input name="amount" type="float" value="0.25" uimin="0.0" uimax="1.0" />
-    <input name="rotation" type="float" value="0" uisoftmin="0.0" uisoftmax="360" />
+    <input name="rotation_angle" type="float" value="0" uisoftmin="0.0" uisoftmax="360" uivisible="true" uiname="Rotation Angle" unittype="angle" unit="degree" />
     <input name="realworld_scale" type="vector2" value="1,1" uisoftmin="0,0" uisoftmax="1,1" uivisible="true" uiname="Width, Height" unittype="distance" />
     <input name="realworld_offset" type="vector2" value="0,0" uisoftmin="0,0" uisoftmax="1,1" uiname="Offset X, Y" unittype="distance" />
     <input name="diagonal" type="boolean" value="false" />
@@ -355,8 +355,8 @@
     <input name="normal_custom_relief" type="vector3" uivisible="true" uiname="Custom Relief Pattern" defaultgeomprop="Nworld" />
     <input name="cutout_enable" type="boolean" value="false" uivisible="true" uiname="Cutout" />
     <input name="cutout" type="integer" value="0" uivisible="true" uiname="Cutout Type" enum="Circles,Staggered Circles,Squares,Staggered Squares,Hexagons,Grecian,Cloverleaf,Custom" enumvalues="0,1,2,3,4,5,6,7" uimin="0" uimax="7" />
-    <input name="cutout_size" type="float" value="0.1" uivisible="true" uiname="Cutout Size" />
-    <input name="cutout_spacing" type="float" value="0.5" uivisible="true" uiname="Cutout Spacing" uimin="0" uimax="1" />
+    <input name="cutout_size" type="float" value="0.1" uivisible="true" uiname="Cutout Size" unittype="distance" />
+    <input name="cutout_spacing" type="float" value="0.5" uivisible="true" uiname="Cutout Spacing" uimin="0" uimax="1" unittype="distance" />
     <input name="custom_cutout" type="color3" value="1, 1, 1" uivisible="true" uiname="Custom Cutout" />
     <input name="tint_enable" type="boolean" value="false" uivisible="true" uiname="Tint" />
     <input name="tint_color" type="color3" value="1, 1, 1" uivisible="true" uiname="Tint Color" />

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
@@ -3788,7 +3788,7 @@
     </invert>
     <invert name="lagacy_rot_direction" type="float" nodedef="ND_invert_float" xpos="-7.20711" ypos="-3.31817">
       <input name="amount" type="float" value="0" />
-      <input name="in" type="float" interfacename="rotation" />
+      <input name="in" type="float" interfacename="rotation_angle" />
     </invert>
     <divide name="divide1" type="vector2" nodedef="ND_divide_vector2" xpos="-3.76994" ypos="-2.2396">
       <input name="in2" type="vector2" interfacename="realworld_scale" />
@@ -3826,11 +3826,11 @@
     <ifequal name="diag_select2" type="float" nodedef="ND_ifequal_floatB" xpos="-5.46295" ypos="0.625989">
       <input name="value2" type="boolean" value="true" />
       <input name="value1" type="boolean" interfacename="diagonal" />
-      <input name="in2" type="float" interfacename="rotation" />
+      <input name="in2" type="float" interfacename="rotation_angle" />
       <input name="in1" type="float" nodename="diag_adjustment" />
     </ifequal>
     <subtract name="diag_adjustment" type="float" nodedef="ND_subtract_float" xpos="-7.42233" ypos="2.30152">
-      <input name="in1" type="float" interfacename="rotation" />
+      <input name="in1" type="float" interfacename="rotation_angle" />
       <input name="in2" type="float" value="45" />
     </subtract>
     <backdrop name="this_is_an_approximation" xpos="-7.892" ypos="1.63793" width="2.22739" height="2.05194" uicolor="#C85252" Autodesk-ldx_alpha="0.156863" />

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_mat_legacy_metal.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_mat_legacy_metal.mtlx
@@ -12,8 +12,8 @@
     <!-- <input name="custom_relief" type="vector3"/> -->
     <input name="cutout_enable" type="boolean" value="true" />
     <input name="cutout" type="integer" value="4" />
-    <input name="cutout_size" type="float" value="0.01" />
-    <input name="cutout_spacing" type="float" value="0.015" />
+    <input name="cutout_size" type="float" value="0.01" unittype="distance" unit="inch" />
+    <input name="cutout_spacing" type="float" value="0.015" unittype="distance" unit="inch" />
     <!-- <input name="custom_cutout" type="color3"/> -->
     <input name="tint_enable" type="boolean" value="false" />
     <input name="tint_color" type="color3" value="0.95,0.5,0.5" />

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_knurl.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_knurl.mtlx
@@ -15,8 +15,8 @@
   <legacy_knurl name="legacy_knurl" type="multioutput" xpos="5.536232" ypos="-1.086207">
     <output name="out_rgb" type="color3" />
     <input name="amount" type="float" value="0.25" />
-    <input name="realworld_scale" type="vector2" value="0.1, 0.2" />
+    <input name="realworld_scale" type="vector2" value="0.1, 0.2" unittype="distance" unit="inch" />
     <input name="diagonal" type="boolean" value="true" />
-    <input name="rotation" type="float" value="45" />
+    <input name="rotation_angle" type="float" value="45" />
   </legacy_knurl>
 </materialx>

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_marble.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_marble.mtlx
@@ -12,7 +12,7 @@
   </surfacematerial>
   <legacy_marble name="legacy_marble_color3" type="color3" xpos="6.942029" ypos="-2.620690">
     <input name="realworld_offset" type="vector3" value="1.1, 0.8, 0.4" />
-    <input name="size" type="float" value="4.6" />
+    <input name="size" type="float" value="4.6" unittype="distance" unit="inch" />
     <input name="width" type="float" value="0.1" />
     <input name="rotation_angle" type="vector3" value="0, 0, 0" />
   </legacy_marble>

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_speckle.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_speckle.mtlx
@@ -13,7 +13,7 @@
   <legacy_speckle name="legacy_speckle_color3" type="color3" xpos="7.557971" ypos="-2.370690">
     <input name="color1" type="color3" value="0.996616, 0, 0" />
     <input name="color2" type="color3" value="1, 1, 1" />
-    <input name="size" type="float" value="7.6" />
+    <input name="size" type="float" value="7.6" unittype="distance" unit="inch" />
     <input name="octaves" type="float" value="5.5" />
     <input name="realworld_offset" type="vector3" value="0, 0, 0" />
     <input name="rotation_angle" type="vector3" value="0, 0, 0" />

--- a/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_wood.mtlx
+++ b/contrib/adsk/resources/Materials/TestSuite/adsklib/legacy/test_tex_legacy_wood.mtlx
@@ -13,7 +13,7 @@
   <legacy_wood name="NG_legacy_wood" type="color3" xpos="7.630435" ypos="-3.137931">
     <input name="radial_noise" type="float" value="0.7" />
     <input name="axial_noise" type="float" value="0.6" />
-    <input name="thickness" type="float" value="1" />
+    <input name="thickness" type="float" value="1" unittype="distance" unit="inch" />
     <input name="loop" type="boolean" value="false" />
     <input name="position" type="vector3" nodename="multiply_vector3FA" />
     <input name="realworld_offset" type="vector3" value="0, 2.9, 0" />


### PR DESCRIPTION
These inputs are unitless in OGS, so they were left unitless in the MaterialX graphs too. But they obviously need to have a unit to keep a consistent size if the scene unit is changed. Experiments in Inventor seem to suggest all these values are in Inches, but we will check them again once we can do a side-by-side comparison.

Also renamed an input for Knurl, which was not consistent with the rest of the procedurals.