### PR TITLE
Adding procedural to normal utility node

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
@@ -40,7 +40,15 @@
     <input name="weight" type="float" value="1" uimin="0" uimax="1" />
     <output name="out" type="vector3" />
   </nodedef>
-  
+
+  <nodedef name="ND_util_proc_to_norm" node="util_proc_to_norm" version="0.1" isdefaultversion="true" nodegroup="adsk_legacy">
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="color" type="color3" value="0, 0, 0" />
+    <input name="amount_htn" type="float" value="1" uimin="0" uimax="1" />
+    <input name="amount_nm" type="float" value="1" uimin="0" uimax="1" />
+    <output name="out" type="vector3" />
+  </nodedef>
+ 
   <!-- 
       ===============================================
       Nodedefs for Autodesk Legacy Procedural Classes

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
@@ -316,6 +316,22 @@
     <output name="out" type="vector3" xpos="39.420288" ypos="-0.448276" nodename="normalmap" />
   </nodegraph>
 
+  <nodegraph name="NG_util_proc_to_norm" nodedef="ND_util_proc_to_norm">
+    <extract name="extract_r" type="float" xpos="5.920290" ypos="-6.879310">
+      <input name="in" type="color3" interfacename="color" />
+    </extract>
+    <heighttonormal name="heighttonormal1" type="vector3" xpos="7.739130" ypos="-6.862069">
+      <input name="in" type="float" nodename="extract_r" />
+      <input name="scale" type="float" interfacename="amount_htn" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
+    </heighttonormal>
+    <normalmap name="normalmap1" type="vector3" xpos="10.333333" ypos="-6.827586">
+      <input name="in" type="vector3" nodename="heighttonormal1" />
+      <input name="scale" type="float" interfacename="amount_nm" />
+    </normalmap>
+    <output name="out" type="vector3" nodename="normalmap1" xpos="12.615942" ypos="-6.775862" />
+  </nodegraph>
+
   <!-- 
       =================================================
       Nodegraphs for Autodesk Legacy Procedural Classes


### PR DESCRIPTION
Most of our legacy procedurals have a Color3 output. This utility node simply takes the R channel, calls heighttonormal, and then normalmap to generate a Vector3 normal in world space, which is the common input for our custom normals in the Protein graphs.

Since this will happen often in the converter, this node simplifies the code,  avoiding creating the graph nodes by code every time.