### PR TITLE
Adding input to hardwood

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_defs.mtlx
@@ -332,6 +332,7 @@
     <input name="tint_color" type="color3" value="0.1075, 0.6597, 0.0136" uivisible="true" uiname="Tint Color" />
     <input name="relief_pattern_enable" type="boolean" value="false" uivisible="true" uiname="Relief Pattern" />
     <input name="relief_pattern_type" type="integer" value="0" uivisible="true" uiname="Relief Pattern Type" enum="Based on Wood Grain,Custom" enumvalues="0,1" uimin="0" uimax="1" />
+    <input name="relief_pattern_auto_amount" type="float" value="0.05" uimin="0.0" uimax="1.0" uivisible="true" uiname="Wood Grain Pattern Amount" />
     <input name="normal_pattern_custom" type="vector3" uivisible="true" uiname="Custom Relief Pattern" defaultgeomprop="Nworld" />
     <input name="normal_floor_bump" type="vector3" uivisible="false" defaultgeomprop="Nworld" />
     <output name="out" type="surfaceshader" />

--- a/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_legacy_ng.mtlx
@@ -4039,6 +4039,7 @@
     </constant>
     <heighttonormal name="heighttonormal_color_bump" type="vector3" xpos="3.3347" ypos="11.6428">
       <input name="in" type="float" nodename="extract_float_bump" />
+      <input name="scale" type="float" interfacename="relief_pattern_auto_amount" />
     </heighttonormal>
     <normalmap name="normalmap_color_bump" type="vector3" xpos="4.941" ypos="11.6119">
       <input name="in" type="vector3" nodename="heighttonormal_color_bump" />
@@ -4081,7 +4082,6 @@
       <input name="in2" type="vector3" interfacename="normal_pattern_custom" />
       <input name="which" type="integer" interfacename="relief_pattern_type" />
     </switch>
-    <backdrop name="is_this_ok_at_least_add_amount_multipler" xpos="0.163695" ypos="12.982" width="3.99845" height="0.871989" uicolor="#C85252" Autodesk-ldx_alpha="0.156863" />
   </nodegraph>
 
   <!-- <Legacy Glazing> -->


### PR DESCRIPTION
Adding an input to Hardwood to control amount of the automatic pattern (based on wood grain).
A backdrop used to comment on this has been removed.

This new input is used by the next round of updates for the materials converter.

Note the default value for this amount is low, and based on visual estimates, but it's still a bit high. This is an issue captured in Jira, where all bump amounts seem to be extremely high.