### PR TITLE
Revert automerge parametrization (#1472)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,11 +2,6 @@ name: Create Branch and PR
 
 on:
   workflow_dispatch:  # This allows for manual triggering.
-    inputs:
-      sync_ref:
-        description: 'Branch or tag to sync into adsk_contrib/dev (e.g. main or v1.39.5)'
-        required: false
-        default: 'main'
   schedule:
     - cron: '0 0 * * 6'  # This sets the workflow to run every Saturday at midnight.
 
@@ -15,58 +10,45 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MERGE_BRANCH: adsk-merge-branch
-      # On scheduled runs github.event.inputs is empty, so default to 'main'.
-      SYNC_REF: ${{ github.event.inputs.sync_ref || 'main' }}
 
     steps:
-    - name: Checkout adsk_contrib/dev branch
+    - name: Checkout main branch
       uses: actions/checkout@v2
       with:
-        ref: adsk_contrib/dev
+        ref: main
         fetch-depth: 0
 
     - name: Create merge branch and PR
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # Ensure we have the latest information (including tags) from the remote before proceeding
-        if git fetch origin --tags; then
+      run: | 
+        # Ensure we have the latest information from the remote repository before proceeding
+        if git fetch origin; then
             echo "git fetch origin succeeded"
         else
             echo "git fetch origin failed"
             exit 1
         fi
 
-        # Resolve SYNC_REF to a concrete commit. It may be a branch (origin/<ref>) or a tag.
-        if git rev-parse --verify --quiet "refs/tags/$SYNC_REF" >/dev/null; then
-            SYNC_COMMIT="refs/tags/$SYNC_REF"
-        elif git rev-parse --verify --quiet "origin/$SYNC_REF" >/dev/null; then
-            SYNC_COMMIT="origin/$SYNC_REF"
-        else
-            echo "Could not resolve '$SYNC_REF' as a tag or remote branch. Exiting."
-            exit 1
-        fi
-        echo "Syncing from $SYNC_REF ($SYNC_COMMIT)"
-
-        # Check if adsk_contrib/dev already contains SYNC_REF; if so, automerge is not needed
-        if git merge-base --is-ancestor "$SYNC_COMMIT" origin/adsk_contrib/dev; then
-            echo "adsk_contrib/dev already contains $SYNC_REF, automerge not required"
+        # Check if adsk_contrib/dev is already up to date with main; if so, automerge is not needed
+        if git diff --quiet origin/main adsk_contrib/dev; then
+            echo "adsk_contrib/dev is updated with main, automerge not required"
             exit 0
         fi
 
-        # Always (re)create the merge branch from the PR target so the resulting PR
-        # contains only the diff between adsk_contrib/dev and SYNC_REF, regardless of
-        # any divergent state left on a previous run's merge branch.
-        echo "Reset $MERGE_BRANCH to origin/adsk_contrib/dev"
-        git checkout -B "$MERGE_BRANCH" origin/adsk_contrib/dev
-
-        echo "Merge $SYNC_REF into $MERGE_BRANCH"
-        # Attempt to merge SYNC_REF into the merge branch and exit if the merge fails
-        if git merge --no-edit "$SYNC_COMMIT"; then
-            echo "Merge completed successfully."
+        # Try to checkout the merge branch; if it doesn't exist, create it. If it exists, merge main into it and handle merge errors
+        if ! git checkout "$MERGE_BRANCH"; then
+            echo "Create new branch $MERGE_BRANCH"
+            git checkout -b "$MERGE_BRANCH"
         else
-            echo "Merge failed. Exiting workflow."
-            exit 1
+            echo "Merge main into the existing $MERGE_BRANCH"
+            # Attempt to merge main into the merge branch and exit if the merge fails
+            if git merge main; then
+                echo "Merge completed successfully."
+            else
+                echo "Merge failed. Exiting workflow."
+                exit 1
+            fi
         fi
 
         # Check if there are any changes to push to the remote merge branch; if not, skip push and PR creation
@@ -75,11 +57,8 @@ jobs:
             exit 0
         fi
 
-        # Force push: the branch is rebuilt from adsk_contrib/dev each run, so it is not
-        # a fast-forward of the previous run's branch. --force-with-lease is safe because
-        # the change-detection step above just fetched origin/$MERGE_BRANCH.
         echo "push to $MERGE_BRANCH"
-        git push --force-with-lease origin "$MERGE_BRANCH"
+        git push origin "$MERGE_BRANCH"
 
         # Check if a PR from the merge branch to adsk_contrib/dev already exists; if so, do not create a new one
         EXISTING_PR=$(gh pr list --base adsk_contrib/dev --head "$MERGE_BRANCH" --state open --json number --jq '.[0].number')
@@ -91,8 +70,8 @@ jobs:
         # Attempt to create the PR and exit if the creation fails
         echo "Create merge PR"
         if gh pr create \
-            --title "Merge $MERGE_BRANCH ($SYNC_REF) into adsk_contrib/dev" \
-            --body "Auto-created PR to merge $MERGE_BRANCH into adsk_contrib/dev (synced from \`$SYNC_REF\`)" \
+            --title "Merge $MERGE_BRANCH into adsk_contrib/dev" \
+            --body "Auto-created PR to merge $MERGE_BRANCH into adsk_contrib/dev" \
             --head "$MERGE_BRANCH" \
             --base adsk_contrib/dev \
             --reviewer "ashwinbhat,zicher3d,ppenenko"


### PR DESCRIPTION
## Summary

Reverts PR #1472 ("Parametrize automerge workflow with optional `sync_ref` input"), restoring `.github/workflows/automerge.yml` to its pre-#1472 state.

The parametrized version that landed on `adsk_contrib/dev` is not viable as-merged: performing a real (non-fast-forward) merge of a diverged ref requires a committer identity on the runner **and** a token with `workflow` scope to push the resulting `.github/workflows/main.yml` changes (the fork intentionally diverges from upstream there — see #1438, "Disable Deploy Web Viewer job"). The default `GITHUB_TOKEN` cannot push workflow-file changes, and provisioning a GitHub App / PAT with that scope is blocked by org install policy.

Reverting restores the previously working behavior (sync `main` into `adsk_contrib/dev`) until a viable auth approach is decided.

This revert is workflow-only and byte-identical to the file as it existed before #1472.
