### PR TITLE
contrib/tests: load render-test docs via setDataLibrary (fix validation failures)

### DIFF
--- a/contrib/tests/conftest.py
+++ b/contrib/tests/conftest.py
@@ -77,6 +77,21 @@ def libraries(stdlib, adsklib):
     return [stdlib, adsklib]
 
 
+@pytest.fixture(scope="session")
+def data_library(stdlib, adsklib):
+    """Combined data library (stdlib + adsklib) as a single document.
+
+    Mirrors the C++ tests' single ``dependLib`` document. Test documents
+    reference it via ``Document.setDataLibrary`` rather than merging libraries
+    in with ``importLibrary`` -- merging before upgrading old-syntax documents
+    can produce spurious "too many bindings" validation errors.
+    """
+    lib = mx.createDocument()
+    lib.importLibrary(stdlib)
+    lib.importLibrary(adsklib)
+    return lib
+
+
 def _add_stream_if_missing(mesh, name, attr_type, index, stride, fill_func):
     """Helper to create and add a mesh stream if it doesn't exist."""
     if mesh.getStream(name):

--- a/contrib/tests/test_render.py
+++ b/contrib/tests/test_render.py
@@ -80,10 +80,12 @@ class TestRenderStdlibMaterials:
         output_dir
     ):
         """Test all renderable elements in a stdlib material file."""
-        # Load document
+        # Load the document, then attach the standard library as referenced data.
+        # Matches the C++ tests' setDataLibrary; importing/merging the library
+        # before upgrading old-syntax docs can produce spurious validation errors.
         doc = mx.createDocument()
-        doc.importLibrary(stdlib)
         mx.readFromXmlFile(doc, str(mtlx_file))
+        doc.setDataLibrary(stdlib)
         
         valid, msg = doc.validate()
         assert valid, f"Document validation failed: {msg}"
@@ -125,16 +127,16 @@ class TestRenderAdskMaterials:
         mtlx_file: Path,
         subtests,
         renderer,
-        libraries,
+        data_library,
         search_path,
         output_dir
     ):
         """Test all renderable elements in an Autodesk material file."""
-        # Load document
+        # Load the document, then attach the combined library as referenced data
+        # (matches the C++ tests' setDataLibrary).
         doc = mx.createDocument()
-        for lib in libraries:
-            doc.importLibrary(lib)
         mx.readFromXmlFile(doc, str(mtlx_file))
+        doc.setDataLibrary(data_library)
         
         valid, msg = doc.validate()
         assert valid, f"Document validation failed: {msg}"


### PR DESCRIPTION
## Summary

Fixes spurious document-validation failures in the `contrib/tests` pytest render suite by loading test documents the same way the C++ tests do.

- Load test documents with **`Document.setDataLibrary(...)`** instead of `importLibrary(...)`, matching the C++ render/genshader tests (`RenderUtil.cpp` / `GenShaderUtil.cpp`). Merging libraries into the document *before* upgrading old-syntax documents produced `"Node input has too many bindings"` failures on `TestSuite/stdlib/upgrade/syntax_1_22.mtlx` and `syntax_1_25.mtlx`. With `setDataLibrary` these validate cleanly — consistent with the C++ CTest suite, which already passes these files.
- Adds a combined **`data_library`** fixture (`stdlib` + `adsklib` as one document, mirroring the C++ `dependLib`) used by the Autodesk material tests.

## Stacked on #1475

This PR is **stacked on top of #1475** (base = `ppenenko/pytest_image_compare`), so the diff here is only the document-loading fix — the render-image-output feature lives in #1475. Merge order: **#1475 first**, after which this PR auto-retargets to `adsk_contrib/dev`. Combined suite result: **218 passed, 65 skipped, 885 subtests passed, 0 failed** (the two `upgrade/syntax_1_2x` files now pass).

## Test plan

```
cd contrib/tests
python -m pytest -n auto
```
