### PR TITLE
Fix function name mismatch in mx_noise1d_float.osl

### DIFF
--- a/contrib/adsk/libraries/adsklib/genosl/mx_noise1d_float.osl
+++ b/contrib/adsk/libraries/adsklib/genosl/mx_noise1d_float.osl
@@ -1,4 +1,4 @@
-void mx_noise2d_float(float amplitude, float pivot, float p, output float result)
+void mx_noise1d_float(float amplitude, float pivot, float p, output float result)
 {
     float value = noise("perlin", p);
     result = value * amplitude + pivot;


### PR DESCRIPTION
## Summary
Fixes a compilation blocker in `contrib/adsk/libraries/adsklib/genosl/mx_noise1d_float.osl` where the function name was incorrectly defined as `mx_noise2d_float` instead of `mx_noise1d_float` (matching its filename and nodedef declaration).

## Test plan
Verify that OSL shader compilation passes successfully for `mx_noise1d_float` with this fix.