### PR TITLE
Refactor pytest image comparison into fixture and remove dead code

### DIFF
--- a/contrib/tests/conftest.py
+++ b/contrib/tests/conftest.py
@@ -578,3 +578,35 @@ def compare_rendered_image(rendered_path: Path, baseline_path: Path, heatmap_pat
 
     return result
 
+
+@pytest.fixture(scope="session")
+def assert_image_matches_baseline(baseline_dir, flip_threshold, output_dir):
+    """
+    Fixture that returns a function to assert a rendered image matches its baseline.
+    """
+    def _assert(rendered_file: Path):
+        if not (baseline_dir and rendered_file):
+            return
+            
+        rel_rendered = rendered_file.relative_to(output_dir)
+        baseline_file = baseline_dir / rel_rendered
+        
+        # Generate heatmap in the same directory as rendered file
+        heatmap_file = rendered_file.parent / f"{rendered_file.stem}_diff.png"
+        
+        res = compare_rendered_image(rendered_file, baseline_file, heatmap_path=heatmap_file)
+        if not res['success']:
+            assert False, f"Image comparison failed: {res['error']}"
+            
+        mean_flip = res['mean_flip']
+        max_flip = res['max_flip']
+        pct_diff = res['pct_diff_pixels']
+        
+        assert mean_flip < flip_threshold, (
+            f"Image comparison failed! Mean FLIP: {mean_flip:.4f} "
+            f"(threshold: {flip_threshold}), Max FLIP: {max_flip:.4f}, "
+            f"{pct_diff:.1f}% pixels differ. Heatmap saved to {heatmap_file.name}"
+        )
+    return _assert
+
+

--- a/contrib/tests/test_render.py
+++ b/contrib/tests/test_render.py
@@ -78,8 +78,7 @@ class TestRenderStdlibMaterials:
         stdlib,
         search_path,
         output_dir,
-        baseline_dir,
-        flip_threshold
+        assert_image_matches_baseline
     ):
         """Test all renderable elements in a stdlib material file."""
         # Load the document, then attach the standard library as referenced data.
@@ -119,27 +118,7 @@ class TestRenderStdlibMaterials:
                 )
                 assert success, f"Render failed: {error}"
                 
-                if baseline_dir and rendered_file:
-                    rel_rendered = rendered_file.relative_to(output_dir)
-                    baseline_file = baseline_dir / rel_rendered
-                    
-                    # Generate heatmap in the same directory as rendered file
-                    heatmap_file = rendered_file.parent / f"{rendered_file.stem}_diff.png"
-                    
-                    from conftest import compare_rendered_image
-                    res = compare_rendered_image(rendered_file, baseline_file, heatmap_path=heatmap_file)
-                    if not res['success']:
-                        assert False, f"Image comparison failed: {res['error']}"
-                    else:
-                        mean_flip = res['mean_flip']
-                        max_flip = res['max_flip']
-                        pct_diff = res['pct_diff_pixels']
-                        
-                        assert mean_flip < flip_threshold, (
-                            f"Image comparison failed! Mean FLIP: {mean_flip:.4f} "
-                            f"(threshold: {flip_threshold}), Max FLIP: {max_flip:.4f}, "
-                            f"{pct_diff:.1f}% pixels differ. Heatmap saved to {heatmap_file.name}"
-                        )
+                assert_image_matches_baseline(rendered_file)
 
 
 class TestRenderAdskMaterials:
@@ -154,8 +133,7 @@ class TestRenderAdskMaterials:
         data_library,
         search_path,
         output_dir,
-        baseline_dir,
-        flip_threshold
+        assert_image_matches_baseline
     ):
         """Test all renderable elements in an Autodesk material file."""
         # Load the document, then attach the combined library as referenced data
@@ -195,24 +173,4 @@ class TestRenderAdskMaterials:
                 )
                 assert success, f"Render failed: {error}"
                 
-                if baseline_dir and rendered_file:
-                    rel_rendered = rendered_file.relative_to(output_dir)
-                    baseline_file = baseline_dir / rel_rendered
-                    
-                    # Generate heatmap in the same directory as rendered file
-                    heatmap_file = rendered_file.parent / f"{rendered_file.stem}_diff.png"
-                    
-                    from conftest import compare_rendered_image
-                    res = compare_rendered_image(rendered_file, baseline_file, heatmap_path=heatmap_file)
-                    if not res['success']:
-                        assert False, f"Image comparison failed: {res['error']}"
-                    else:
-                        mean_flip = res['mean_flip']
-                        max_flip = res['max_flip']
-                        pct_diff = res['pct_diff_pixels']
-                        
-                        assert mean_flip < flip_threshold, (
-                            f"Image comparison failed! Mean FLIP: {mean_flip:.4f} "
-                            f"(threshold: {flip_threshold}), Max FLIP: {max_flip:.4f}, "
-                            f"{pct_diff:.1f}% pixels differ. Heatmap saved to {heatmap_file.name}"
-                        )
+                assert_image_matches_baseline(rendered_file)

--- a/contrib/utilities/scripts/rendertest/mtlxutils/render_material.py
+++ b/contrib/utilities/scripts/rendertest/mtlxutils/render_material.py
@@ -7,7 +7,7 @@ pytest test cases (parametrized tests).
 import MaterialX as mx
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Optional, List, Tuple
+from typing import Optional, List
 
 
 @dataclass
@@ -118,65 +118,3 @@ def render_material(
         result.output_path = output_file
     
     return result
-
-
-def render_file(
-    renderer,
-    mtlx_file: Path,
-    libraries: List,
-    search_path,
-    output_path: Optional[Path] = None
-) -> List[RenderResult]:
-    """
-    Render all materials in a single .mtlx file.
-    
-    Args:
-        renderer: Initialized GlslRenderer instance
-        mtlx_file: Path to the .mtlx file
-        libraries: List of loaded library documents
-        search_path: MaterialX search path
-        output_path: Directory to save output images (optional)
-        
-    Returns:
-        List of RenderResult for each material in the file
-    """
-    results = []
-    
-    # Create working document with libraries
-    doc = mx.createDocument()
-    for lib in libraries:
-        doc.importLibrary(lib)
-    
-    # Load the material file
-    try:
-        mx.readFromXmlFile(doc, str(mtlx_file))
-        valid, msg = doc.validate()
-        if not valid:
-            return [RenderResult(
-                success=False,
-                material_name=str(mtlx_file),
-                error=f"Validation failed: {msg}"
-            )]
-    except mx.Exception as err:
-        return [RenderResult(
-            success=False,
-            material_name=str(mtlx_file),
-            error=str(err)
-        )]
-    
-    # Update search path with file's directory
-    file_dir = mtlx_file.parent.resolve()
-    full_search_path = mx.FileSearchPath(search_path)
-    full_search_path.append(str(file_dir))
-    
-    # Update image handler search path
-    image_handler = renderer.getImageHandler()
-    image_handler.setSearchPath(full_search_path)
-    
-    # Find and render all materials
-    render_nodes = renderer.findRenderableElements(doc)
-    for node in render_nodes:
-        result = render_material(renderer, doc, node, output_path)
-        results.append(result)
-    
-    return results


### PR DESCRIPTION
## Summary

- Extract duplicated FLIP image comparison logic from both test classes into a single `assert_image_matches_baseline` session-scoped fixture in `conftest.py`
- Remove unused `render_file()` function from `render_material.py` — the pytest framework calls `render_material()` directly per-element, making `render_file()` dead code (also closes #1486 by deletion)

## Changes

- **`conftest.py`**: Add `assert_image_matches_baseline` fixture encapsulating baseline lookup, heatmap generation, and FLIP threshold assertion
- **`test_render.py`**: Replace inline comparison blocks in both `TestRenderStdlibMaterials` and `TestRenderAdskMaterials` with a single `assert_image_matches_baseline(rendered_file)` call
- **`render_material.py`**: Delete `render_file()` and unused `Tuple` import

Net: 3 files changed, 37 insertions, 109 deletions.

## Test plan

- [x] Full pytest suite passes locally (216 passed, 63 skipped, 885 subtests passed)