### PR TITLE
Fix MDL compilation errors in adsklib placeholder implementations

### DIFF
--- a/contrib/adsk/libraries/adsklib/adsklib_ng.mtlx
+++ b/contrib/adsk/libraries/adsklib/adsklib_ng.mtlx
@@ -408,6 +408,7 @@
     </divide>
     <modulo name="specular_rotation_value" type="float">
       <input name="in1" type="float" nodename="div_rotation0" />
+      <input name="in2" type="float" value="1.0" />
     </modulo>
 
     <!-- map values to standard surface -->
@@ -465,6 +466,7 @@
     </divide>
     <modulo name="specular_rotation_value" type="float" >
       <input name="in1" type="float" nodename="div_rotation0" />
+      <input name="in2" type="float" value="1.0" />
     </modulo>
 
 
@@ -576,6 +578,7 @@
     </divide>
     <modulo name="specular_rotation_value" type="float" >
       <input name="in1" type="float" nodename="div_rotation0" />
+      <input name="in2" type="float" value="1.0" />
     </modulo>
 
     <!-- map values to standard surface -->
@@ -720,6 +723,7 @@
     </divide>
     <modulo name="specular_rotation_value" type="float" >
       <input name="in1" type="float" nodename="div_rotation1" />
+      <input name="in2" type="float" value="1.0" />
     </modulo>
 
     <constant name="layered_fraction_param" type="float">
@@ -853,6 +857,7 @@
     </divide>
     <modulo name="specular_rotation_value" type="float" >
       <input name="in1" type="float" nodename="div_rotation0" />
+      <input name="in2" type="float" value="1.0" />
     </modulo>
 
     <!-- specular_IOR = (1.0 + sqrt(x)) / (1.0 - sqrt(x)), where x = luminance(glazing_f0) -->

--- a/contrib/adsk/libraries/adsklib/genmdl/adsklib_genmdl_impl.mtlx
+++ b/contrib/adsk/libraries/adsklib/genmdl/adsklib_genmdl_impl.mtlx
@@ -10,10 +10,10 @@
   <implementation name="IM_backface_util_genmdl" nodedef="adsk:ND_backface_util" sourcecode="color(1, 1, 1)" target="genmdl"/>
 
   <!-- 2d hashnoise -->
-  <implementation name="IM_wood3d_util_hashnoise2d_vector3_genmdl" nodedef="ND_wood3d_util_hashnoise2d_vector3" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
+  <implementation name="IM_wood3d_util_hashnoise2d_vector3_genmdl" nodedef="ND_wood3d_util_hashnoise2d_vector3" sourcecode="float3(0.5)" target="genmdl" />
   <!-- 1d perlin noise -->
-  <implementation name="IM_wood3d_util_noise1d_float_genmdl" nodedef="ND_wood3d_util_noise1d_float" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
+  <implementation name="IM_wood3d_util_noise1d_float_genmdl" nodedef="ND_wood3d_util_noise1d_float" sourcecode="0.5" target="genmdl" />
   <!-- 3D wood pore function -->
-  <implementation name="IM_wood3d_util_pore_impulse_genmdl" nodedef="ND_wood3d_util_pore_impulse" sourcecode="color(0.5, 0.5, 0.5)" target="genmdl" />
+  <implementation name="IM_wood3d_util_pore_impulse_genmdl" nodedef="ND_wood3d_util_pore_impulse" sourcecode="0.5" target="genmdl" />
 
 </materialx>

--- a/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
@@ -72,10 +72,11 @@ void CustomCodeNodeMdl::initializeForInlineSourceCode(const InterfaceElement& el
 
     NodeDefPtr nodeDef = impl.getNodeDef();
     _inlineFunctionName = nodeDef->getName();
-    _hash = std::hash<string>{}(_inlineFunctionName); // make sure we emit the function definition only once
 
     const ShaderGenerator& shadergen = context.getShaderGenerator();
     const MdlSyntax& syntax = static_cast<const MdlSyntax&>(shadergen.getSyntax());
+    syntax.makeValidName(_inlineFunctionName);
+    _hash = std::hash<string>{}(_inlineFunctionName); // make sure we emit the function definition only once
     // Construct the function call template string
     initializeFunctionCallTemplateString(syntax, *nodeDef);
     // Collect information about output names and defaults

--- a/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
@@ -248,7 +248,14 @@ void CustomCodeNodeMdl::emitFunctionDefinition(const ShaderNode& node, GenContex
 
         // User defined code
         shadergen.emitComment("inlined shader source code:", stage);
-        shadergen.emitLine(_inlineSourceCode, stage, false);
+        if (numOutputs == 1)
+        {
+            shadergen.emitLine(outputs.back().name + " = " + _inlineSourceCode, stage);
+        }
+        else
+        {
+            shadergen.emitLine(_inlineSourceCode, stage, false);
+        }
 
         // Output packing
         shadergen.emitComment("pack (in case of multiple outputs) and return outputs:", stage);

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -242,6 +242,9 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
     // avoid warning "C350: unused let temporary '...'"
     mdlcCommand += " -W \"350=off\"";
 
+    // avoid warning "C181: unused variable '...'"
+    mdlcCommand += " -W \"181=off\"";
+
     // but treat all other warnings as errors
     mdlcCommand += " -W err";
 

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -88,7 +88,9 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
                 mx::NodePtr node = datalib->addNodeInstance(nodedef, nodeName + "_" + nodeOutput->getType() + "_" + nodeInput->getType());
                 REQUIRE(node);
 
-                const std::string filename = nodeName + ".osl";
+                std::string safeNodeName = nodeName;
+                generator->getSyntax().makeValidName(safeNodeName);
+                const std::string filename = safeNodeName + ".osl";
                 try
                 {
                     mx::ShaderPtr shader = generator->generate(node->getName(), node, context);


### PR DESCRIPTION
## Summary

- Fix return type mismatches in MDL placeholder `sourcecode` attributes: `vector3` nodedef now returns `float3(0.5)`, `float` nodedefs return `0.5` (was `color(0.5, 0.5, 0.5)` for all three)
- Add missing `in2` input to all 5 `<modulo>` nodes for specular rotation normalization in `adsklib_ng.mtlx`

Closes #1488

## Context

These errors cause the `Windows_VS2022_x64_Python313` extended (scheduled) build to fail in CMake Unit Tests when `mdlc.exe` validates the generated MDL code. PR CI doesn't catch this because MDL SDK is only installed on extended builds.

Failing run: https://github.com/autodesk-forks/MaterialX/actions/runs/27546798177