### PR TITLE
Sanitize OSL reference shader filenames for namespaced nodedefs

### DIFF
--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -88,7 +88,9 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
                 mx::NodePtr node = datalib->addNodeInstance(nodedef, nodeName + "_" + nodeOutput->getType() + "_" + nodeInput->getType());
                 REQUIRE(node);
 
-                const std::string filename = nodeName + ".osl";
+                std::string safeNodeName = nodeName;
+                generator->getSyntax().makeValidName(safeNodeName);
+                const std::string filename = safeNodeName + ".osl";
                 try
                 {
                     mx::ShaderPtr shader = generator->generate(node->getName(), node, context);


### PR DESCRIPTION
## Summary

Nodedef names qualified with a namespace prefix (e.g. `adsk:ND_backface_util`) produce filenames containing colons when the OSL reference shader test (`GenReference.cpp`) writes compile error logs. Colons are invalid in filenames on Windows and are rejected by GitHub Actions artifact upload on macOS, causing the `Upload Test Logs` step to fail:

```
The path for one of the files in artifact is not valid:
/reference/osl/adsk:backface_util.oso_compile_errors.txt.
Contains the following character: Colon :
```

This applies `makeValidName()` to sanitize the node name before constructing the filename, consistent with how `LibsToOso.cpp` already handles this.

## Context

- Observed in workflow_dispatch run [#2919](https://github.com/autodesk-forks/MaterialX/actions/runs/27639139831) on the `MacOS_Xcode_16_Python313` job
- The underlying OSL compilation error for the namespaced adsklib node likely still exists — this fix only unblocks the artifact upload so the rest of the test suite can complete and report results
- Related MDL namespace fix: PR #2988 (upstream draft)

## Status

Parked as a draft — low priority until the MDL codegen fixes land and the remaining OSL compilation issues for adsklib are investigated.